### PR TITLE
Fix broken markdown links for lychee

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,6 +117,6 @@ AI Friend maintains a persistent persona through a dedicated identity layer:
 ---
 
 **For implementation details, see:**
-- [README.md](./README.md) - Getting started guide
+- [README.md](../README.md) - Getting started guide
 - [API_SPEC.md](./API_SPEC.md) - API documentation
 - [DEPLOYMENT.md](./DEPLOYMENT.md) - Production deployment

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -28,7 +28,7 @@ Before deploying to production, ensure you have completed the following:
 - [ ] Rotate API keys and use environment variables
 - [ ] Enable rate limiting
 - [ ] Configure database backups
-- [ ] Review [SECURITY.md](./SECURITY.md)
+- [ ] Review [SECURITY.md](../SECURITY.md)
 
 ### Performance
 - [ ] Test with production-scale traffic
@@ -613,4 +613,4 @@ sudo certbot certificates
 ---
 
 **For architecture details, see [ARCHITECTURE.md](./ARCHITECTURE.md)**  
-**For security best practices, see [SECURITY.md](./SECURITY.md)**
+**For security best practices, see [SECURITY.md](../SECURITY.md)**

--- a/skills/python-design-patterns/SKILL.md
+++ b/skills/python-design-patterns/SKILL.md
@@ -429,5 +429,5 @@ This is a layering violation. The service layer must not import from handlers. I
 
 ## Related Skills
 
-- [python-testing-patterns](../python-testing-patterns/SKILL.md) — Test each layer in isolation using the dependency injection structure established here
-- [python-project-setup](../python-project-setup/SKILL.md) — Set up project structure and tooling that enforces layer boundaries from the start
+- [python-testing-patterns](../../.agents/skills/python-testing-patterns/SKILL.md) — Test each layer in isolation using the dependency injection structure established here
+- [python-project-setup](../../.agents/skills/python-project-setup/SKILL.md) — Set up project structure and tooling that enforces layer boundaries from the start


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected relative file path references in Architecture and Deployment guides to ensure internal documentation cross-references properly resolve within the documentation structure.
  * Updated skill documentation links in Python design patterns documentation to point to correct documentation locations, improving navigation reliability across all guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->