### PR TITLE
feat(cognitive): edge-load memories & ground responses (lost-in-the-middle + hallucination)

### DIFF
--- a/backend/app/cognitive/action.py
+++ b/backend/app/cognitive/action.py
@@ -187,9 +187,11 @@ class ActionService:
                 set(re.findall(r"\b[a-z]{3,}\b", sentence.lower()))
                 - _GROUNDING_STOPWORDS
             )
-            # Only act when the claim carries real specifics and NONE of them are
-            # grounded; a partial match means the memory is at least partly real.
-            if len(claim_words) >= 2 and not (claim_words & grounding_words):
+            # Only act when the claim has at least two unsupported specifics;
+            # this catches both wholly-ungrounded claims and partially-grounded
+            # claims that mix real context with fabricated details.
+            unsupported_words = claim_words - grounding_words
+            if len(unsupported_words) >= 2:
                 return (
                     False,
                     "You referenced a shared memory that is not in the provided "
@@ -647,6 +649,21 @@ class ActionService:
                                         "data": "I need a moment to gather my thoughts...",
                                     }
                                     break
+                                # Check grounding on the accumulated response so far
+                                is_retry_grounded, retry_ground_reason = (
+                                    self._check_response_grounding(
+                                        candidate, surfaced, msg
+                                    )
+                                )
+                                if not is_retry_grounded:
+                                    logger.warning(
+                                        f"[System 3] Retry fabricated a memory claim: {retry_ground_reason}. Yielding safe fallback."
+                                    )
+                                    yield {
+                                        "type": "content",
+                                        "data": "I need a moment to gather my thoughts...",
+                                    }
+                                    break
                                 yield {"type": "content", "data": clean_chunk}
                                 accumulated_retry_response = candidate
 
@@ -657,7 +674,24 @@ class ActionService:
                                 is_valid_trail, _ = self._validate_partial_response(
                                     candidate, plan.goal
                                 )
-                                if not is_valid_trail:
+                                if is_valid_trail:
+                                    # Check grounding on trailing content too
+                                    is_trail_grounded, trail_ground_reason = (
+                                        self._check_response_grounding(
+                                            candidate, surfaced, msg
+                                        )
+                                    )
+                                    if not is_trail_grounded:
+                                        logger.warning(
+                                            f"[System 3] Retry trailing fabricated a memory claim: {trail_ground_reason}. Yielding safe fallback."
+                                        )
+                                        yield {
+                                            "type": "content",
+                                            "data": "I need a moment to gather my thoughts...",
+                                        }
+                                    else:
+                                        yield {"type": "content", "data": trailing}
+                                else:
                                     logger.warning(
                                         "[System 3] Retry trailing also violated constraints; yielding safe fallback."
                                     )
@@ -665,8 +699,7 @@ class ActionService:
                                         "type": "content",
                                         "data": "I need a moment to gather my thoughts...",
                                     }
-                                else:
-                                    yield {"type": "content", "data": trailing}
+
                         yield {"type": "done", "data": "finished"}
                     except Exception as inner_e:
                         logger.error(

--- a/backend/app/cognitive/action.py
+++ b/backend/app/cognitive/action.py
@@ -300,10 +300,15 @@ class ActionService:
 
             # 1. Prepare Identity-Aware System and User Prompts
             # Static System Prompt (cached by inference engines like Ollama/vLLM)
-            system_instruction = f"{identity_prompt}\n\nGuideline:\n- Maintain your identity rules at all times.\n- Focus on natural conversational phrases.\n- IMPORTANT: If the SHARED HISTORY / RECENT CONTEXT contains relevant biographical facts, partner details, childhood milestones, or personal preferences, you MUST integrate them explicitly and accurately to answer the user's question.\n- GROUNDING: Base any specific claim about the user, your shared past, names, dates, places, or events ONLY on the SHARED HISTORY / RECENT CONTEXT above. Do not invent memories or details that are not there. If the user asks about something you have no memory of, say so naturally (e.g. \"I don't think you've told me that\") instead of making it up.\n- Respond only in English. Do not use Hindi, Hinglish, or any other language for now.\n- The voice layer already carries emotion separately. Do not emit XML wrappers or emotion tags.\n- You may use <pause=300ms> or <hesitate> when it improves natural timing."
+            system_instruction = f"{identity_prompt}\n\nGuideline:\n- Maintain your identity rules at all times.\n- Focus on natural conversational phrases.\n- IMPORTANT: If the SHARED HISTORY / RECENT CONTEXT contains relevant biographical facts, partner details, childhood milestones, or personal preferences, you MUST integrate them explicitly and accurately to answer the user's question.\n- GROUNDING: Base any specific claim about the user, your shared past, names, dates, places, or events ONLY on the SHARED HISTORY / RECENT CONTEXT provided. Do not invent memories or details that are not there. If the user asks about something you have no memory of, say so naturally (e.g. \"I don't think you've told me that\") instead of making it up.\n- Respond only in English. Do not use Hindi, Hinglish, or any other language for now.\n- The voice layer already carries emotion separately. Do not emit XML wrappers or emotion tags.\n- You may use <pause=300ms> or <hesitate> when it improves natural timing."
 
-            # Dynamic User Prompt (appends active context to the query suffix)
-            user_prompt = f"Current Context:\n- Goal: {plan.goal}\n- Current Emotion: {emotion}\n{shared_history}{tom_context}\n\nUser: {msg}\nAssistant:"
+            # Dynamic User Prompt. Ordering fights "lost in the middle": the factual
+            # grounding (SHARED HISTORY) is placed LAST before the user's query so it
+            # sits in the model's high-attention tail, adjacent to what it must
+            # answer. The more abstract, lower-cost-to-lose context (goal, emotion,
+            # Theory-of-Mind) goes earlier. Within the history block itself, memories
+            # are already edge-loaded by reorder_for_long_context().
+            user_prompt = f"Current Context:\n- Goal: {plan.goal}\n- Current Emotion: {emotion}\n{tom_context}{shared_history}\n\nUser: {msg}\nAssistant:"
 
             valence = plan.payload.get("valence", 0.0)
             arousal = plan.payload.get("arousal", 0.5)

--- a/backend/app/cognitive/action.py
+++ b/backend/app/cognitive/action.py
@@ -1,11 +1,57 @@
 import asyncio
 import logging
+import re
 import time
 from typing import Dict, Any, AsyncGenerator
 from .decision import ActionPlan
 from ..config import Config
 
 logger = logging.getLogger(__name__)
+
+# Phrases where the assistant attributes a fact to the shared past or the user's
+# prior statements ("you told me…", "remember when we…"). Such a phrase asserts a
+# memory; if its content is absent from the surfaced memories AND the user's
+# current message, the memory is being fabricated -- the exact hallucination the
+# grounding gate catches.
+_MEMORY_CLAIM_RE = re.compile(
+    r"\b("
+    r"you (?:once |also |already )?(?:told|said|mentioned|shared)"
+    r"|you'?ve (?:told|mentioned|shared)"
+    r"|you used to"
+    r"|remember when (?:you|we)"
+    r"|last time (?:you|we)"
+    r"|i remember you (?:saying|mentioning|telling)"
+    r"|as you (?:said|mentioned|told me)"
+    r"|back when (?:you|we)"
+    r")\b",
+    re.IGNORECASE,
+)
+
+# The trigger words themselves plus generic conversational filler and common
+# function words. Stripped from a claim before checking grounding so only
+# substantive specifics (names, places, activities -- including short ones like
+# "dog" or "Rex") drive the decision, keeping the gate high-precision.
+_GROUNDING_STOPWORDS = frozenset(
+    {
+        # memory-attribution trigger words
+        "told", "said", "mentioned", "shared", "remember", "saying",
+        "mentioning", "telling", "used",
+        # temporal / discourse filler
+        "when", "last", "time", "back", "once", "also", "already",
+        "earlier", "before", "then", "now", "ago",
+        # generic conversational filler
+        "that", "this", "about", "really", "think", "know", "just", "very",
+        "much", "would", "could", "some", "thing", "things", "something",
+        "want", "like", "into", "over", "still", "even", "well", "sure",
+        # pronouns / determiners / common short function words
+        "your", "yours", "you", "the", "and", "are", "for", "not", "but",
+        "his", "her", "was", "has", "had", "our", "out", "who", "how",
+        "all", "any", "can", "did", "get", "got", "let", "may", "off",
+        "old", "one", "own", "put", "say", "see", "she", "too", "two",
+        "use", "way", "yes", "yet", "him", "per", "via", "with", "from",
+        "they", "them", "than", "what", "which", "were", "been", "have",
+    }
+)
 
 
 def _memory_relevance(memory: Dict[str, Any]) -> float:
@@ -110,6 +156,47 @@ class ActionService:
         self.llm = llm_service
         self.memory = memory_store
         self.publish_cb = None
+
+    def _check_response_grounding(
+        self, response: str, surfaced, user_message: str
+    ) -> tuple[bool, str]:
+        """Deterministic anti-hallucination gate for fabricated shared memories.
+
+        Fires only when the response explicitly *attributes* a fact to the shared
+        past ("you told me…", "remember when we…") whose substantive content
+        appears in neither the surfaced memories nor the user's current message.
+        Requiring an attribution phrase plus at least two ungrounded specifics
+        keeps it high-precision: it targets invented recollections, not the
+        model's ordinary conversational contributions.
+
+        Returns (is_grounded, reason). ``reason`` feeds the self-correction prompt.
+        """
+        if not response or not _MEMORY_CLAIM_RE.search(response):
+            return True, ""
+
+        grounding_text = " ".join(
+            (m.get("content") or "") for m in (surfaced or [])
+        )
+        grounding_text = f"{grounding_text} {user_message or ''}".lower()
+        grounding_words = set(re.findall(r"\b[a-z]{3,}\b", grounding_text))
+
+        for sentence in re.split(r"(?<=[.!?])\s+", response):
+            if not _MEMORY_CLAIM_RE.search(sentence):
+                continue
+            claim_words = (
+                set(re.findall(r"\b[a-z]{3,}\b", sentence.lower()))
+                - _GROUNDING_STOPWORDS
+            )
+            # Only act when the claim carries real specifics and NONE of them are
+            # grounded; a partial match means the memory is at least partly real.
+            if len(claim_words) >= 2 and not (claim_words & grounding_words):
+                return (
+                    False,
+                    "You referenced a shared memory that is not in the provided "
+                    "context. Do not invent things the user never told you; only "
+                    "reference facts present in SHARED HISTORY.",
+                )
+        return True, ""
 
     def _validate_partial_response(self, text: str, goal: str) -> tuple[bool, str]:
         stripped = text.strip()
@@ -482,6 +569,16 @@ class ActionService:
                                 raise MetacognitiveException(reason)
                             yield {"type": "content", "data": trailing}
                             accumulated_response = candidate
+
+                    # Post-generation grounding gate: the whole utterance is now
+                    # known, so check it for fabricated shared-memory claims and
+                    # route any hit through the same self-correction path.
+                    is_grounded, ground_reason = self._check_response_grounding(
+                        accumulated_response, surfaced, msg
+                    )
+                    if not is_grounded:
+                        raise MetacognitiveException(ground_reason)
+
                     yield {"type": "done", "data": "finished"}
 
                 except MetacognitiveException as me:

--- a/backend/app/cognitive/action.py
+++ b/backend/app/cognitive/action.py
@@ -8,6 +8,48 @@ from ..config import Config
 logger = logging.getLogger(__name__)
 
 
+def _memory_relevance(memory: Dict[str, Any]) -> float:
+    """Relevance value used to order a surfaced memory.
+
+    ``search_memories`` emits ``score``; the proactive surfacing path in
+    ``core.py`` emits ``relevance``. Fall back to 0.0 when neither is a usable
+    number so unranked items keep a stable (middle-ish) position rather than
+    crashing the sort.
+    """
+    for key in ("score", "relevance"):
+        val = memory.get(key)
+        if isinstance(val, (int, float)) and not isinstance(val, bool):
+            return float(val)
+    return 0.0
+
+
+def reorder_for_long_context(memories):
+    """Reorder retrieved memories to mitigate the "lost in the middle" effect.
+
+    LLMs attend most strongly to the beginning and end of their context and
+    systematically lose information placed in the middle (Liu et al., 2023).
+    Retrieval hands us memories ranked most- to least-relevant, so a plain
+    concatenation spends the high-attention *final* slot on the least relevant
+    item and buries the mid-ranked ones. Instead, place the most relevant items
+    at both edges and the least relevant in the middle: ranked ``[A, B, C, D, E]``
+    (A most relevant) becomes ``[A, C, E, D, B]``, so A and B bracket the block.
+
+    Input order is not trusted — items are sorted by relevance first — so this is
+    safe for both producer shapes (``score`` and ``relevance``).
+    """
+    ranked = sorted(memories, key=_memory_relevance, reverse=True)
+    reordered = [None] * len(ranked)
+    left, right = 0, len(ranked) - 1
+    for i, item in enumerate(ranked):
+        if i % 2 == 0:
+            reordered[left] = item
+            left += 1
+        else:
+            reordered[right] = item
+            right -= 1
+    return reordered
+
+
 class MetacognitiveException(Exception):
     def __init__(self, reason: str):
         super().__init__(reason)
@@ -133,9 +175,13 @@ class ActionService:
 
             shared_history = ""
             if surfaced:
+                # Edge-load the most relevant memories so they land in the LLM's
+                # high-attention start/end positions instead of being lost in the
+                # middle of the block.
+                ordered = reorder_for_long_context(surfaced)
                 shared_history = (
                     "\nSHARED HISTORY / RECENT CONTEXT (Active Influence):\n"
-                    + "\n".join([f"- {m['content']}" for m in surfaced])
+                    + "\n".join([f"- {m['content']}" for m in ordered])
                 )
 
             # Theory of Mind (ToM) Context Injection
@@ -167,7 +213,7 @@ class ActionService:
 
             # 1. Prepare Identity-Aware System and User Prompts
             # Static System Prompt (cached by inference engines like Ollama/vLLM)
-            system_instruction = f"{identity_prompt}\n\nGuideline:\n- Maintain your identity rules at all times.\n- Focus on natural conversational phrases.\n- IMPORTANT: If the SHARED HISTORY / RECENT CONTEXT contains relevant biographical facts, partner details, childhood milestones, or personal preferences, you MUST integrate them explicitly and accurately to answer the user's question.\n- Respond only in English. Do not use Hindi, Hinglish, or any other language for now.\n- The voice layer already carries emotion separately. Do not emit XML wrappers or emotion tags.\n- You may use <pause=300ms> or <hesitate> when it improves natural timing."
+            system_instruction = f"{identity_prompt}\n\nGuideline:\n- Maintain your identity rules at all times.\n- Focus on natural conversational phrases.\n- IMPORTANT: If the SHARED HISTORY / RECENT CONTEXT contains relevant biographical facts, partner details, childhood milestones, or personal preferences, you MUST integrate them explicitly and accurately to answer the user's question.\n- GROUNDING: Base any specific claim about the user, your shared past, names, dates, places, or events ONLY on the SHARED HISTORY / RECENT CONTEXT above. Do not invent memories or details that are not there. If the user asks about something you have no memory of, say so naturally (e.g. \"I don't think you've told me that\") instead of making it up.\n- Respond only in English. Do not use Hindi, Hinglish, or any other language for now.\n- The voice layer already carries emotion separately. Do not emit XML wrappers or emotion tags.\n- You may use <pause=300ms> or <hesitate> when it improves natural timing."
 
             # Dynamic User Prompt (appends active context to the query suffix)
             user_prompt = f"Current Context:\n- Goal: {plan.goal}\n- Current Emotion: {emotion}\n{shared_history}{tom_context}\n\nUser: {msg}\nAssistant:"

--- a/backend/tests/test_context_assembly.py
+++ b/backend/tests/test_context_assembly.py
@@ -239,6 +239,16 @@ class TestResponseGroundingGate:
         )
         assert ok is True
 
+    def test_partial_grounding_with_two_unsupported_specifics_is_rejected(self, svc):
+        # One word grounded, but two fabricated specifics -> should be rejected.
+        ok, reason = svc._check_response_grounding(
+            "You told me about your trip to Japan with Sarah and Emily.",
+            surfaced=[_mem("Planning a trip to Japan next spring", score=2.0)],
+            user_message="hi",
+        )
+        assert ok is False
+        assert "shared memory" in reason
+
     @pytest.mark.asyncio
     async def test_execute_routes_fabrication_to_self_correction(self):
         action_service = ActionService(llm_service=MagicMock())
@@ -277,4 +287,50 @@ class TestResponseGroundingGate:
         # The metacognitive self-correction interstitial proves the grounding gate
         # fired and the retry path ran.
         assert "rephrase" in joined
+        assert calls["n"] == 2
+
+    @pytest.mark.asyncio
+    async def test_execute_retry_fabrication_is_also_caught(self):
+        # When the self-correction retry also fabricates, it must be caught and a
+        # safe fallback emitted instead of forwarding the fabricated claim.
+        action_service = ActionService(llm_service=MagicMock())
+        calls = {"n": 0}
+
+        def stream_factory(prompt, system=None, model=None, options_override=None):
+            calls["n"] += 1
+
+            async def first():
+                yield "You told me your cat is named Whiskers."
+
+            async def retry():
+                # Retry also fabricates a memory claim with 2+ unsupported specifics
+                yield "You told me your favorite band is The Beatles."
+
+            return first() if calls["n"] == 1 else retry()
+
+        action_service.llm.generate_stream = MagicMock(side_effect=stream_factory)
+
+        plan = ActionPlan(
+            action_type="RESPOND_CHAT",
+            goal="ENGAGE",
+            payload={
+                "message": "hi",
+                "identity_prompt": "You are my friend.",
+                "emotion_state": "neutral",
+                "surfaced_memories": [],
+            },
+        )
+
+        chunks = []
+        async for out in action_service.execute(plan):
+            if out.get("type") == "content":
+                chunks.append(out["data"])
+
+        joined = "".join(chunks)
+        # The self-correction interstitial must appear
+        assert "rephrase" in joined
+        # The fabricated retry claim must NOT appear verbatim
+        assert "Beatles" not in joined
+        # Safe fallback must be present
+        assert "gather my thoughts" in joined
         assert calls["n"] == 2

--- a/backend/tests/test_context_assembly.py
+++ b/backend/tests/test_context_assembly.py
@@ -146,3 +146,104 @@ class TestActionPromptAssembly:
         captured = await self._capture_prompt(action_service, plan)
         assert "GROUNDING" in captured["system"]
         assert "Do not invent" in captured["system"]
+
+
+class TestResponseGroundingGate:
+    @pytest.fixture
+    def svc(self):
+        return ActionService(llm_service=MagicMock())
+
+    def test_fabricated_memory_with_no_context_is_flagged(self, svc):
+        ok, reason = svc._check_response_grounding(
+            "You told me your dog is named Rex.", surfaced=[], user_message="hi"
+        )
+        assert ok is False
+        assert "shared memory" in reason
+
+    def test_short_specifics_are_not_dropped(self, svc):
+        # "dog"/"Rex" are 3 letters; the gate must still see them as specifics.
+        ok, _ = svc._check_response_grounding(
+            "Remember when we adopted Rex?", surfaced=[], user_message=""
+        )
+        assert ok is False
+
+    def test_claim_grounded_by_a_memory_passes(self, svc):
+        ok, _ = svc._check_response_grounding(
+            "You told me your dog is named Rex.",
+            surfaced=[_mem("Their dog Rex loves the park", score=3.0)],
+            user_message="hi",
+        )
+        assert ok is True
+
+    def test_claim_grounded_by_current_user_message_passes(self, svc):
+        # The user just supplied the fact this turn; echoing it is not fabrication.
+        ok, _ = svc._check_response_grounding(
+            "You mentioned you love hiking.",
+            surfaced=[],
+            user_message="I love hiking on weekends",
+        )
+        assert ok is True
+
+    def test_response_without_a_memory_claim_is_never_flagged(self, svc):
+        ok, _ = svc._check_response_grounding(
+            "Have you ever tried rock climbing in Nepal?",
+            surfaced=[],
+            user_message="hi",
+        )
+        assert ok is True
+
+    def test_vague_claim_without_specifics_is_not_flagged(self, svc):
+        # No substantive specifics to fabricate -> stay silent (high precision).
+        ok, _ = svc._check_response_grounding(
+            "You told me that before.", surfaced=[], user_message="hi"
+        )
+        assert ok is True
+
+    def test_partial_grounding_is_treated_as_grounded(self, svc):
+        # One specific matches context; only wholly-unsupported claims are flagged.
+        ok, _ = svc._check_response_grounding(
+            "You told me about your trip to Japan with Sarah.",
+            surfaced=[_mem("Planning a trip to Japan next spring", score=2.0)],
+            user_message="hi",
+        )
+        assert ok is True
+
+    @pytest.mark.asyncio
+    async def test_execute_routes_fabrication_to_self_correction(self):
+        action_service = ActionService(llm_service=MagicMock())
+        calls = {"n": 0}
+
+        def stream_factory(prompt, system=None, model=None, options_override=None):
+            calls["n"] += 1
+
+            async def first():
+                yield "You told me your cat is named Whiskers."
+
+            async def retry():
+                yield "Tell me more about your day."
+
+            return first() if calls["n"] == 1 else retry()
+
+        action_service.llm.generate_stream = MagicMock(side_effect=stream_factory)
+
+        plan = ActionPlan(
+            action_type="RESPOND_CHAT",
+            goal="ENGAGE",
+            payload={
+                "message": "how are you?",
+                "identity_prompt": "You are my friend.",
+                "emotion_state": "neutral",
+                "surfaced_memories": [],
+            },
+        )
+
+        chunks = []
+        async for out in action_service.execute(plan):
+            if out.get("type") == "content":
+                chunks.append(out["data"])
+
+        joined = "".join(chunks)
+        # The metacognitive self-correction interstitial proves the grounding gate
+        # fired and the retry path ran.
+        assert "rephrase" in joined
+        assert calls["n"] == 2

--- a/backend/tests/test_context_assembly.py
+++ b/backend/tests/test_context_assembly.py
@@ -1,0 +1,148 @@
+"""Tests for context assembly in the Action layer.
+
+Covers two anti-degradation goals:
+  * "lost in the middle" — edge-loading the most relevant memories, and
+  * hallucination — a grounding constraint in the system prompt.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from app.cognitive.action import (
+    ActionService,
+    reorder_for_long_context,
+    _memory_relevance,
+)
+from app.cognitive.decision import ActionPlan
+
+
+def _mem(content, score=None, relevance=None):
+    m = {"content": content}
+    if score is not None:
+        m["score"] = score
+    if relevance is not None:
+        m["relevance"] = relevance
+    return m
+
+
+class TestReorderForLongContext:
+    def test_most_relevant_land_on_the_edges(self):
+        mems = [
+            _mem("A", score=5.0),
+            _mem("B", score=4.0),
+            _mem("C", score=3.0),
+            _mem("D", score=2.0),
+            _mem("E", score=1.0),
+        ]
+        ordered = [m["content"] for m in reorder_for_long_context(mems)]
+        # A (best) and B (second) bracket the block; E (worst) sits in the middle.
+        assert ordered == ["A", "C", "E", "D", "B"]
+
+    def test_input_order_is_not_trusted(self):
+        # Shuffled input must produce the same relevance-driven layout.
+        mems = [
+            _mem("C", score=3.0),
+            _mem("E", score=1.0),
+            _mem("A", score=5.0),
+            _mem("D", score=2.0),
+            _mem("B", score=4.0),
+        ]
+        ordered = [m["content"] for m in reorder_for_long_context(mems)]
+        assert ordered[0] == "A"
+        assert ordered[-1] == "B"
+        assert ordered[len(ordered) // 2] == "E"
+
+    def test_relevance_key_is_honoured_like_score(self):
+        # The proactive surfacing path emits `relevance`, not `score`.
+        mems = [
+            _mem("low", relevance=0.1),
+            _mem("high", relevance=0.9),
+            _mem("mid", relevance=0.5),
+        ]
+        ordered = [m["content"] for m in reorder_for_long_context(mems)]
+        assert ordered[0] == "high"
+
+    def test_no_memory_is_dropped_or_duplicated(self):
+        mems = [_mem(str(i), score=float(i)) for i in range(7)]
+        ordered = reorder_for_long_context(mems)
+        assert len(ordered) == 7
+        assert {m["content"] for m in ordered} == {str(i) for i in range(7)}
+
+    def test_unranked_items_do_not_crash(self):
+        mems = [_mem("x"), _mem("y"), _mem("z")]
+        ordered = reorder_for_long_context(mems)
+        assert {m["content"] for m in ordered} == {"x", "y", "z"}
+
+    def test_empty_and_single(self):
+        assert reorder_for_long_context([]) == []
+        one = reorder_for_long_context([_mem("only", score=1.0)])
+        assert [m["content"] for m in one] == ["only"]
+
+    def test_relevance_ignores_bool_scores(self):
+        # bool is an int subclass; it must not be read as a numeric relevance.
+        assert _memory_relevance({"score": True}) == 0.0
+        assert _memory_relevance({"score": 2.5}) == 2.5
+        assert _memory_relevance({"relevance": 0.4}) == 0.4
+        assert _memory_relevance({}) == 0.0
+
+
+class TestActionPromptAssembly:
+    @pytest.fixture
+    def action_service(self):
+        return ActionService(llm_service=MagicMock())
+
+    async def _capture_prompt(self, action_service, plan):
+        captured = {}
+
+        async def capturing_stream(prompt, system=None, model=None, options_override=None):
+            captured["prompt"] = prompt
+            captured["system"] = system
+            yield "ok."
+
+        action_service.llm.generate_stream = MagicMock(side_effect=capturing_stream)
+        async for _ in action_service.execute(plan):
+            pass
+        return captured
+
+    @pytest.mark.asyncio
+    async def test_shared_history_is_edge_loaded(self, action_service):
+        plan = ActionPlan(
+            action_type="RESPOND_CHAT",
+            goal="ENGAGE",
+            payload={
+                "message": "what do you remember?",
+                "identity_prompt": "You are my friend.",
+                "emotion_state": "neutral",
+                "surfaced_memories": [
+                    _mem("MOST relevant fact", score=9.0),
+                    _mem("second fact", score=7.0),
+                    _mem("third fact", score=5.0),
+                    _mem("LEAST relevant fact", score=1.0),
+                ],
+            },
+        )
+        captured = await self._capture_prompt(action_service, plan)
+        prompt = captured["prompt"]
+
+        # The strongest memory opens the block; the least relevant is not last.
+        pos_most = prompt.index("MOST relevant fact")
+        pos_second = prompt.index("second fact")
+        pos_least = prompt.index("LEAST relevant fact")
+        # Most relevant appears before the least; the second-best is edge-loaded
+        # to the tail, so it comes after the least-relevant (middle) item.
+        assert pos_most < pos_least < pos_second
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_carries_grounding_constraint(self, action_service):
+        plan = ActionPlan(
+            action_type="RESPOND_CHAT",
+            goal="ENGAGE",
+            payload={
+                "message": "hi",
+                "identity_prompt": "You are my friend.",
+                "emotion_state": "neutral",
+            },
+        )
+        captured = await self._capture_prompt(action_service, plan)
+        assert "GROUNDING" in captured["system"]
+        assert "Do not invent" in captured["system"]

--- a/backend/tests/test_context_assembly.py
+++ b/backend/tests/test_context_assembly.py
@@ -133,6 +133,37 @@ class TestActionPromptAssembly:
         assert pos_most < pos_least < pos_second
 
     @pytest.mark.asyncio
+    async def test_grounding_block_sits_adjacent_to_the_query(self, action_service):
+        # Lost-in-the-middle at the prompt level: SHARED HISTORY must land in the
+        # high-attention tail (after ToM, immediately before "User:"), not buried
+        # mid-prompt.
+        plan = ActionPlan(
+            action_type="RESPOND_CHAT",
+            goal="ENGAGE",
+            payload={
+                "message": "what should we do?",
+                "identity_prompt": "You are my friend.",
+                "emotion_state": "neutral",
+                "surfaced_memories": [_mem("we love climbing", score=5.0)],
+                "user_mental_model": {
+                    "inferred_valence": 0.2,
+                    "inferred_arousal": 0.5,
+                    "implied_goals": ["plan a weekend"],
+                    "known_concepts": ["climbing"],
+                },
+            },
+        )
+        captured = await self._capture_prompt(action_service, plan)
+        prompt = captured["prompt"]
+
+        pos_tom = prompt.index("Theory of Mind")
+        pos_history = prompt.index("SHARED HISTORY")
+        pos_user = prompt.index("User:")
+        # ToM comes first, then the grounding, then the query — grounding is the
+        # last thing the model reads before the question.
+        assert pos_tom < pos_history < pos_user
+
+    @pytest.mark.asyncio
     async def test_system_prompt_carries_grounding_constraint(self, action_service):
         plan = ActionPlan(
             action_type="RESPOND_CHAT",


### PR DESCRIPTION
## Goal

Addresses the project's #1 quality goal: reduce **lost-in-the-middle** and **hallucination** in the Action layer's response generation.

## Changes (`backend/app/cognitive/action.py`)

### 1a. Lost in the middle — edge-loading within the memory block
`search_memories` returns memories ranked most→least relevant. The old code joined them linearly, so the LLM's high-attention **final** slot went to the *least* relevant memory (Liu et al., 2023, *Lost in the Middle*). New `reorder_for_long_context()` sorts by relevance, then places the strongest at **both edges** and the weakest in the middle: `[A,B,C,D,E] → [A,C,E,D,B]`. Reads either producer key (`score` / `relevance`), doesn't trust input order.

### 1b. Lost in the middle — grounding block placement
The whole grounding block was buried mid-prompt: `Goal / Emotion / SHARED HISTORY / ToM / User query`, so the memories were separated from the question by the Theory-of-Mind block. Reordered to `Goal / Emotion / ToM / SHARED HISTORY / User query`, so the factual grounding is the **last thing the model reads before the question** — in its high-attention tail. Abstract, lower-cost-to-lose context (emotion, ToM) moves earlier.

### 2. Hallucination — grounding constraint (prompt)
Added a `GROUNDING` guideline to the system prompt: base any specific claim about the user / shared past / names / dates / events **only** on SHARED HISTORY, and admit a missing memory naturally rather than inventing one.

### 3. Hallucination — deterministic grounding gate (post-generation)
`_check_response_grounding()` runs once the full utterance is known. Fires **only** on an explicit memory-attribution phrase (`"you told me…"`, `"remember when we…"`) whose substantive content is in **neither** the surfaced memories **nor** the user's current message. On a hit it raises `MetacognitiveException`, routing through the **existing** self-correction path (`control.interrupt` + `audio.stop` + corrective retry). High-precision: requires an attribution phrase **plus ≥2 ungrounded specifics**; partial grounding counts as grounded; specifics matched at a 3-char threshold + expanded stopwords so short-but-real specifics (`Rex`) aren't dropped.

## Tests — `backend/tests/test_context_assembly.py` (18)
- **Reorder (7):** edge-load layout, shuffled-input invariance, both relevance keys, no drops/dupes, bool-score guard, empty/single.
- **Prompt assembly (3):** integration tests driving `execute()` — memory edge-loading, grounding-block adjacency to the query, grounding constraint present.
- **Grounding gate (8):** no-context fabrication flagged, short specifics retained, grounded-by-memory / grounded-by-user-message pass, no-claim never flagged, vague claim ignored, partial grounding passes, and an `execute()` test asserting a fabrication routes to self-correction.

Endocrine / identity / regressions / cognitive-safeguards / scenarios / ToM / multi-user suites green; ruff clean.

## Scope / limits (follow-ups)
- The gate is **deterministic and narrow** by choice: catches fabricated *shared-memory claims*, not every invented fact. An LLM-judge layer is a possible future addition.
- The **retry** path isn't re-grounding-checked (corrective prompt handles it; a second failure only logs).
- Not yet validated against a **live model** (mock-path only); recommended before relying on the numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved conversational memory handling for long-context interactions.
  * Added safeguards to prevent responses from inventing unsupported shared memories.
  * Automatically triggers self-correction when unsupported memory claims are detected.

* **Bug Fixes**
  * Improved placement and ordering of shared history and contextual information in generated responses.
  * Added stronger grounding constraints to reduce inaccurate memory references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->