### PR TITLE
memory fidelity Tier 2 + Tier 3: archive-cleanup fixes + ACT-R/insert refactors

### DIFF
--- a/backend/app/state/memory_store.py
+++ b/backend/app/state/memory_store.py
@@ -307,6 +307,122 @@ class MemoryStore:
             - ACTR_STRESS_SUPPRESSION * current_arousal * current_cortisol
         )
 
+    # Columns always written; the Eriksonian columns below may be absent on an
+    # un-migrated schema, so a failed full insert falls back to just these.
+    _MEMORY_BASE_COLUMNS = (
+        "id",
+        "content",
+        "raw_content",
+        "wing",
+        "room",
+        "embedding",
+        "importance_score",
+        "emotional_weight",
+        "valence",
+        "certainty",
+        "source",
+        "metadata",
+    )
+    _MEMORY_ERIKSONIAN_COLUMNS = (
+        "lifespan_stage",
+        "crisis",
+        "virtue",
+        "relations",
+        "relation_circles",
+        "modality",
+    )
+
+    async def _insert_memory_row(
+        self,
+        conn,
+        *,
+        memory_id,
+        content,
+        raw_val,
+        wing,
+        room,
+        vector_str,
+        importance,
+        emotion,
+        valence,
+        certainty,
+        source,
+        metadata_json,
+        lifespan_stage,
+        crisis,
+        virtue,
+        relations,
+        relation_circles,
+        modality,
+        current_time,
+    ):
+        """Insert a memory row from a single column/placeholder builder.
+
+        Collapses what were eight near-identical INSERTs spanning three binary
+        axes -- SQLite vs PostgreSQL placeholders, timed vs untimed
+        (created_at/last_recalled_at), and the full Eriksonian column set vs a
+        legacy fallback for un-migrated schemas. recall_count is always the
+        literal 1; an untimed insert lets last_recalled_at default via
+        CURRENT_TIMESTAMP.
+        """
+        base_vals = [
+            memory_id,
+            content,
+            raw_val,
+            wing,
+            room,
+            vector_str,
+            importance,
+            emotion,
+            valence,
+            certainty,
+            source,
+            metadata_json,
+        ]
+        erik_vals = [lifespan_stage, crisis, virtue, relations, relation_circles, modality]
+
+        async def _insert(include_eriksonian: bool):
+            cols = list(self._MEMORY_BASE_COLUMNS)
+            vals = list(base_vals)
+            if include_eriksonian:
+                cols += list(self._MEMORY_ERIKSONIAN_COLUMNS)
+                vals += erik_vals
+
+            if self.is_sqlite:
+                placeholders = ["?"] * len(vals)
+            else:
+                placeholders = [f"${i}" for i in range(1, len(vals) + 1)]
+
+            # recall_count is a literal, never a bound parameter.
+            cols.append("recall_count")
+            placeholders.append("1")
+
+            params = list(vals)
+            if current_time is not None:
+                cols += ["last_recalled_at", "created_at"]
+                if self.is_sqlite:
+                    placeholders += ["?", "?"]
+                else:
+                    placeholders += [f"${len(vals) + 1}", f"${len(vals) + 2}"]
+                params += [current_time, current_time]
+            else:
+                cols.append("last_recalled_at")
+                placeholders.append("CURRENT_TIMESTAMP")
+
+            sql = (
+                f"INSERT INTO memories ({', '.join(cols)}) "
+                f"VALUES ({', '.join(placeholders)})"
+            )
+            await conn.execute(sql, *params)
+
+        try:
+            await _insert(include_eriksonian=True)
+        except Exception as e:
+            logger.warning(
+                f"Eriksonian insert failed, falling back to legacy schema: {e}"
+            )
+            await _insert(include_eriksonian=False)
+
     async def get_embedding(self, text: str):
         """Generates vector embedding for text using local Ollama."""
         attempts = [
@@ -432,246 +548,28 @@ class MemoryStore:
 
             vector_str = str(vector)
             async with self.pool.acquire() as conn:
-                if self.is_sqlite:
-                    try:
-                        if current_time is not None:
-                            await conn.execute(
-                                """
-                                INSERT INTO memories (
-                                    id, content, raw_content, wing, room,
-                                    embedding, importance_score, emotional_weight,
-                                    valence, certainty, source, metadata,
-                                    lifespan_stage, crisis, virtue, relations, relation_circles, modality,
-                                    recall_count, last_recalled_at, created_at
-                                )
-                                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
-                                """,
-                                memory_id,
-                                content,
-                                raw_val,
-                                wing,
-                                room,
-                                vector_str,
-                                importance,
-                                emotion,
-                                valence,
-                                certainty,
-                                source,
-                                orjson.dumps(metadata or {}).decode(),
-                                lifespan_stage,
-                                crisis,
-                                virtue,
-                                relations,
-                                relation_circles,
-                                modality,
-                                current_time,
-                                current_time,
-                            )
-                        else:
-                            await conn.execute(
-                                """
-                                INSERT INTO memories (
-                                    id, content, raw_content, wing, room,
-                                    embedding, importance_score, emotional_weight,
-                                    valence, certainty, source, metadata,
-                                    lifespan_stage, crisis, virtue, relations, relation_circles, modality,
-                                    recall_count, last_recalled_at
-                                )
-                                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP)
-                                """,
-                                memory_id,
-                                content,
-                                raw_val,
-                                wing,
-                                room,
-                                vector_str,
-                                importance,
-                                emotion,
-                                valence,
-                                certainty,
-                                source,
-                                orjson.dumps(metadata or {}).decode(),
-                                lifespan_stage,
-                                crisis,
-                                virtue,
-                                relations,
-                                relation_circles,
-                                modality,
-                            )
-                    except Exception as e:
-                        logger.warning(
-                            f"Eriksonian insert failed, falling back to legacy schema: {e}"
-                        )
-                        if current_time is not None:
-                            await conn.execute(
-                                """
-                                INSERT INTO memories (
-                                    id, content, raw_content, wing, room,
-                                    embedding, importance_score, emotional_weight,
-                                    valence, certainty, source, metadata,
-                                    recall_count, last_recalled_at, created_at
-                                )
-                                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
-                                """,
-                                memory_id,
-                                content,
-                                raw_val,
-                                wing,
-                                room,
-                                vector_str,
-                                importance,
-                                emotion,
-                                valence,
-                                certainty,
-                                source,
-                                orjson.dumps(metadata or {}).decode(),
-                                current_time,
-                                current_time,
-                            )
-                        else:
-                            await conn.execute(
-                                """
-                                INSERT INTO memories (
-                                    id, content, raw_content, wing, room,
-                                    embedding, importance_score, emotional_weight,
-                                    valence, certainty, source, metadata,
-                                    recall_count, last_recalled_at
-                                )
-                                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, CURRENT_TIMESTAMP)
-                                """,
-                                memory_id,
-                                content,
-                                raw_val,
-                                wing,
-                                room,
-                                vector_str,
-                                importance,
-                                emotion,
-                                valence,
-                                certainty,
-                                source,
-                                orjson.dumps(metadata or {}).decode(),
-                            )
-                else:
-                    try:
-                        if current_time is not None:
-                            await conn.execute(
-                                """
-                                INSERT INTO memories (
-                                    id, content, raw_content, wing, room,
-                                    embedding, importance_score, emotional_weight,
-                                    valence, certainty, source, metadata,
-                                    lifespan_stage, crisis, virtue, relations, relation_circles, modality,
-                                    recall_count, last_recalled_at, created_at
-                                )
-                                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, 1, $19, $20)
-                                """,
-                                memory_id,
-                                content,
-                                raw_val,
-                                wing,
-                                room,
-                                vector_str,
-                                importance,
-                                emotion,
-                                valence,
-                                certainty,
-                                source,
-                                orjson.dumps(metadata or {}).decode(),
-                                lifespan_stage,
-                                crisis,
-                                virtue,
-                                relations,
-                                relation_circles,
-                                modality,
-                                current_time,
-                                current_time,
-                            )
-                        else:
-                            await conn.execute(
-                                """
-                                INSERT INTO memories (
-                                    id, content, raw_content, wing, room,
-                                    embedding, importance_score, emotional_weight,
-                                    valence, certainty, source, metadata,
-                                    lifespan_stage, crisis, virtue, relations, relation_circles, modality,
-                                    recall_count, last_recalled_at
-                                )
-                                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, 1, CURRENT_TIMESTAMP)
-                                """,
-                                memory_id,
-                                content,
-                                raw_val,
-                                wing,
-                                room,
-                                vector_str,
-                                importance,
-                                emotion,
-                                valence,
-                                certainty,
-                                source,
-                                orjson.dumps(metadata or {}).decode(),
-                                lifespan_stage,
-                                crisis,
-                                virtue,
-                                relations,
-                                relation_circles,
-                                modality,
-                            )
-                    except Exception as e:
-                        logger.warning(
-                            f"Eriksonian insert failed, falling back to legacy schema: {e}"
-                        )
-                        if current_time is not None:
-                            await conn.execute(
-                                """
-                                INSERT INTO memories (
-                                    id, content, raw_content, wing, room,
-                                    embedding, importance_score, emotional_weight,
-                                    valence, certainty, source, metadata,
-                                    recall_count, last_recalled_at, created_at
-                                )
-                                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, 1, $13, $14)
-                                """,
-                                memory_id,
-                                content,
-                                raw_val,
-                                wing,
-                                room,
-                                vector_str,
-                                importance,
-                                emotion,
-                                valence,
-                                certainty,
-                                source,
-                                orjson.dumps(metadata or {}).decode(),
-                                current_time,
-                                current_time,
-                            )
-                        else:
-                            await conn.execute(
-                                """
-                                INSERT INTO memories (
-                                    id, content, raw_content, wing, room,
-                                    embedding, importance_score, emotional_weight,
-                                    valence, certainty, source, metadata,
-                                    recall_count, last_recalled_at
-                                )
-                                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, 1, CURRENT_TIMESTAMP)
-                                """,
-                                memory_id,
-                                content,
-                                raw_val,
-                                wing,
-                                room,
-                                vector_str,
-                                importance,
-                                emotion,
-                                valence,
-                                certainty,
-                                source,
-                                orjson.dumps(metadata or {}).decode(),
-                            )
+                await self._insert_memory_row(
+                    conn,
+                    memory_id=memory_id,
+                    content=content,
+                    raw_val=raw_val,
+                    wing=wing,
+                    room=room,
+                    vector_str=vector_str,
+                    importance=importance,
+                    emotion=emotion,
+                    valence=valence,
+                    certainty=certainty,
+                    source=source,
+                    metadata_json=orjson.dumps(metadata or {}).decode(),
+                    lifespan_stage=lifespan_stage,
+                    crisis=crisis,
+                    virtue=virtue,
+                    relations=relations,
+                    relation_circles=relation_circles,
+                    modality=modality,
+                    current_time=current_time,
+                )
             # Upsert into Qdrant if online using the same memory_id
             if self.qdrant_store.client:
                 qdrant_ts = (

--- a/backend/app/state/memory_store.py
+++ b/backend/app/state/memory_store.py
@@ -86,6 +86,19 @@ SYNONYM_MAP = {
 DIRECT_CUE_BOOST = 5.0  # additive score bump per query cue found in a memory
 PPR_DAMPING = 0.85  # canonical PageRank teleport/damping factor
 
+# ACT-R retrieval-scoring weights. These were duplicated inline across three
+# scoring paths (Qdrant/SQLite/PG); naming them here keeps the paths in sync and
+# makes the affective tuning explicit. base_activation adds an importance term
+# and an emotional-proximity bonus to the classic ln(freq) - d·ln(recency) core;
+# the similarity gain rewards congruent valence×arousal and suppresses recall
+# under stress (arousal×cortisol); the final score subtracts an emotional-
+# distance penalty.
+ACTR_IMPORTANCE_WEIGHT = 1.5  # weight on importance_score in base activation
+ACTR_EMO_PROXIMITY_WEIGHT = 0.15  # bonus for small emotional distance
+ACTR_VALENCE_GAIN = 0.1  # similarity gain from congruent valence×arousal
+ACTR_STRESS_SUPPRESSION = 0.2  # similarity suppression under arousal×cortisol
+ACTR_EMO_DISTANCE_PENALTY = 0.5  # score penalty per unit emotional distance
+
 
 class GoalBuffer:
     def __init__(self, capacity=5):
@@ -269,6 +282,30 @@ class MemoryStore:
                     importance,
                     memory_id,
                 )
+
+    def _base_activation(self, recall_count, hours_since, importance_score, dist_emo):
+        """ACT-R base-level activation: ln(freq) - d·ln(recency) plus importance
+        and emotional-proximity terms. Shared by every retrieval-scoring path so
+        the formula stays identical across the Qdrant, SQLite and PG branches.
+        """
+        return (
+            _cached_ln(recall_count)
+            - self.decay_rate * _cached_ln(hours_since + 1.0)
+            + ACTR_IMPORTANCE_WEIGHT * importance_score
+            + ACTR_EMO_PROXIMITY_WEIGHT * (1.0 - dist_emo)
+        )
+
+    def _effective_similarity(
+        self, similarity, memory_valence, emotion_weight, current_arousal, current_cortisol
+    ):
+        """Neuromodulatory gain on cosine similarity: boosted by congruent
+        valence×arousal, suppressed under stress (arousal×cortisol).
+        """
+        return similarity * (
+            1.0
+            + ACTR_VALENCE_GAIN * memory_valence * emotion_weight
+            - ACTR_STRESS_SUPPRESSION * current_arousal * current_cortisol
+        )
 
     async def get_embedding(self, text: str):
         """Generates vector embedding for text using local Ollama."""
@@ -972,22 +1009,25 @@ class MemoryStore:
                             + (emotion_weight_row - current_arousal) ** 2
                         )
 
-                        base_activation = (
-                            _cached_ln(recall_count)
-                            - self.decay_rate * _cached_ln(hours_since + 1.0)
-                            + 1.5 * importance_score
-                            + 0.15 * (1.0 - dist_emo)
+                        base_activation = self._base_activation(
+                            recall_count, hours_since, importance_score, dist_emo
                         )
 
                         similarity = cand["score"]
-                        effective_similarity = similarity * (
-                            1.0
-                            + 0.1 * memory_valence * emotion_weight_row
-                            - 0.2 * current_arousal * current_cortisol
+                        effective_similarity = self._effective_similarity(
+                            similarity,
+                            memory_valence,
+                            emotion_weight_row,
+                            current_arousal,
+                            current_cortisol,
                         )
 
                         spread_activation = self.spread_weight * effective_similarity
-                        score = base_activation + spread_activation - 0.5 * dist_emo
+                        score = (
+                            base_activation
+                            + spread_activation
+                            - ACTR_EMO_DISTANCE_PENALTY * dist_emo
+                        )
 
                         if score <= (threshold - 2.5) and importance_score < 0.7:
                             continue
@@ -1277,24 +1317,30 @@ class MemoryStore:
                                 + (emotion_weight_row - current_arousal) ** 2
                             )
 
-                            base_activation = (
-                                _cached_ln(recall_count)
-                                - self.decay_rate * _cached_ln(hours_since + 1.0)
-                                + 1.5 * (row.get("importance_score") or 0.5)
-                                + 0.15 * (1.0 - dist_emo)
+                            base_activation = self._base_activation(
+                                recall_count,
+                                hours_since,
+                                row.get("importance_score") or 0.5,
+                                dist_emo,
                             )
 
                             # Neuromodulatory distance mapping
-                            effective_similarity = similarity * (
-                                1.0
-                                + 0.1 * memory_valence * emotion_weight_row
-                                - 0.2 * current_arousal * current_cortisol
+                            effective_similarity = self._effective_similarity(
+                                similarity,
+                                memory_valence,
+                                emotion_weight_row,
+                                current_arousal,
+                                current_cortisol,
                             )
 
                             spread_activation = (
                                 self.spread_weight * effective_similarity
                             )
-                            score = base_activation + spread_activation - 0.5 * dist_emo
+                            score = (
+                                base_activation
+                                + spread_activation
+                                - ACTR_EMO_DISTANCE_PENALTY * dist_emo
+                            )
 
                             if (
                                 score <= (threshold - 2.5)
@@ -2034,21 +2080,27 @@ class MemoryStore:
                             + (emotion_weight_row - current_arousal) ** 2
                         )
 
-                        base_activation = (
-                            _cached_ln(recall_count)
-                            - self.decay_rate * _cached_ln(hours_since + 1.0)
-                            + 1.5 * (row.get("importance_score") or 0.5)
-                            + 0.15 * (1.0 - dist_emo)
+                        base_activation = self._base_activation(
+                            recall_count,
+                            hours_since,
+                            row.get("importance_score") or 0.5,
+                            dist_emo,
                         )
 
-                        effective_similarity = similarity * (
-                            1.0
-                            + 0.1 * memory_valence * emotion_weight_row
-                            - 0.2 * current_arousal * current_cortisol
+                        effective_similarity = self._effective_similarity(
+                            similarity,
+                            memory_valence,
+                            emotion_weight_row,
+                            current_arousal,
+                            current_cortisol,
                         )
 
                         spread_activation = self.spread_weight * effective_similarity
-                        score = base_activation + spread_activation - 0.5 * dist_emo
+                        score = (
+                            base_activation
+                            + spread_activation
+                            - ACTR_EMO_DISTANCE_PENALTY * dist_emo
+                        )
 
                         # Lexical match count boost to ensure direct query matches sort higher
                         content_lower = content.lower()
@@ -2284,16 +2336,18 @@ class MemoryStore:
 
                             # Recalculate active score since it is now promoted and last_recalled_at is set to now (hours_since = 0.001)
                             # We use recall_count + 1 since the recall_count has been incremented upon recall/promotion
-                            base_activation_active = (
-                                _cached_ln(recall_count + 1)
-                                - self.decay_rate * _cached_ln(0.001 + 1.0)
-                                + 1.5 * (row.get("importance_score") or 0.5)
-                                + 0.15 * (1.0 - dist_emo)
+                            # recall_count + 1 (already incremented on promotion)
+                            # and a near-zero recency (last_recalled_at is now).
+                            base_activation_active = self._base_activation(
+                                recall_count + 1,
+                                0.001,
+                                row.get("importance_score") or 0.5,
+                                dist_emo,
                             )
                             score_active = (
                                 base_activation_active
                                 + spread_activation
-                                - 0.5 * dist_emo
+                                - ACTR_EMO_DISTANCE_PENALTY * dist_emo
                             )
                             # Apply direct cue boost since it was promoted due to keyword matches
                             match_count = sum(

--- a/backend/app/state/memory_store.py
+++ b/backend/app/state/memory_store.py
@@ -2760,25 +2760,35 @@ class MemoryStore:
                 cutoff_milestones = now_cleanup - timedelta(days=720)
 
                 try:
+                    # COALESCE(last_recalled_at, created_at): a memory that was
+                    # archived but never recalled has NULL last_recalled_at, and
+                    # `NULL < cutoff` is NULL (never true) -- such rows would be
+                    # immortal in the archive. Age them out by creation time
+                    # instead, matching how the activation SQL already coalesces
+                    # this column (db/schema.sql).
                     if self.is_sqlite:
+                        # Normalise both operands through datetime(): the SQLite
+                        # fallback stores timestamps as text, so a raw string
+                        # comparison of differing ISO formats/precision/offsets
+                        # is unreliable. datetime() canonicalises to UTC.
                         await conn.execute(
                             """
                             DELETE FROM archived_memories
-                            WHERE (importance_score < 0.5 AND last_recalled_at < ?)
-                               OR (importance_score >= 0.5 AND importance_score < 0.7 AND last_recalled_at < ?)
-                               OR (importance_score >= 0.7 AND importance_score < 0.9 AND last_recalled_at < ?);
+                            WHERE (importance_score < 0.5 AND datetime(COALESCE(last_recalled_at, created_at)) < datetime(?))
+                               OR (importance_score >= 0.5 AND importance_score < 0.7 AND datetime(COALESCE(last_recalled_at, created_at)) < datetime(?))
+                               OR (importance_score >= 0.7 AND importance_score < 0.9 AND datetime(COALESCE(last_recalled_at, created_at)) < datetime(?));
                             """,
-                            cutoff_distractors,
-                            cutoff_anecdotes,
-                            cutoff_milestones,
+                            cutoff_distractors.isoformat(),
+                            cutoff_anecdotes.isoformat(),
+                            cutoff_milestones.isoformat(),
                         )
                     else:
                         await conn.execute(
                             """
                             DELETE FROM archived_memories
-                            WHERE (importance_score < 0.5 AND last_recalled_at < $1)
-                               OR (importance_score >= 0.5 AND importance_score < 0.7 AND last_recalled_at < $2)
-                               OR (importance_score >= 0.7 AND importance_score < 0.9 AND last_recalled_at < $3);
+                            WHERE (importance_score < 0.5 AND COALESCE(last_recalled_at, created_at) < $1)
+                               OR (importance_score >= 0.5 AND importance_score < 0.7 AND COALESCE(last_recalled_at, created_at) < $2)
+                               OR (importance_score >= 0.7 AND importance_score < 0.9 AND COALESCE(last_recalled_at, created_at) < $3);
                             """,
                             cutoff_distractors,
                             cutoff_anecdotes,

--- a/backend/tests/test_memory_archive_cleanup.py
+++ b/backend/tests/test_memory_archive_cleanup.py
@@ -1,0 +1,180 @@
+"""
+Permanent archive-cleanup tests for apply_actr_decay.
+
+A pruned memory is copied to archived_memories and later permanently deleted
+once it ages past a biological-timeline cutoff. Two fidelity requirements:
+
+  * A memory that was archived but NEVER recalled has last_recalled_at = NULL.
+    `NULL < cutoff` is NULL (never true) in SQL, so without COALESCE such rows
+    become immortal in the archive. They must instead age out by created_at --
+    a never-recalled memory is the most forgettable, not the least.
+
+  * The SQLite fallback stores timestamps as text; comparisons must be robust
+    to ISO format/precision differences, so the cleanup normalises through
+    datetime().
+"""
+
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+from app.state.conversation_store import ConversationHistoryStore
+from app.state.memory_store import MemoryStore
+
+
+_MEMORIES_SCHEMA = """
+    CREATE TABLE IF NOT EXISTS memories (
+        id TEXT PRIMARY KEY,
+        content TEXT,
+        raw_content TEXT,
+        wing TEXT,
+        room TEXT,
+        embedding TEXT,
+        importance_score REAL,
+        emotional_weight REAL,
+        valence REAL,
+        certainty REAL,
+        source TEXT,
+        metadata TEXT,
+        recall_count INTEGER,
+        last_recalled_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        lifespan_stage TEXT,
+        crisis TEXT,
+        virtue TEXT,
+        relations TEXT,
+        relation_circles TEXT,
+        modality TEXT
+    )
+"""
+
+# Minimal archived_memories: apply_actr_decay's cleanup only reads
+# importance_score, last_recalled_at and created_at. The memory kept in
+# `memories` is fresh, so the archive-INSERT (to_delete) path never fires here.
+_ARCHIVE_SCHEMA = """
+    CREATE TABLE IF NOT EXISTS archived_memories (
+        id TEXT PRIMARY KEY,
+        content TEXT,
+        importance_score REAL,
+        last_recalled_at TIMESTAMP,
+        created_at TIMESTAMP
+    )
+"""
+
+
+@pytest.fixture
+async def store_with_archive():
+    store = ConversationHistoryStore()
+    await store.initialize()
+    async with store.pool.acquire() as conn:
+        await conn.execute(_MEMORIES_SCHEMA)
+        await conn.execute(_ARCHIVE_SCHEMA)
+        await conn.execute("DELETE FROM memories;")
+        await conn.execute("DELETE FROM archived_memories;")
+        # A live, fresh memory so apply_actr_decay has a row to process and
+        # proceeds to the cleanup stage (it returns early on no matches).
+        await conn.execute(
+            "INSERT INTO memories (id, content, recall_count, importance_score, "
+            "created_at, last_recalled_at) VALUES "
+            "('live', 'anchor memory', 1, 0.6, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+        )
+
+    mock_graph = MagicMock()
+    mock_graph.execute_query = AsyncMock(return_value=[])
+    mem = MemoryStore(pool=store.pool, graph_db=mock_graph)
+    mem.qdrant_store.client = None
+    mem.get_embedding = AsyncMock(return_value=[0.1] * 768)
+    yield store, mem
+    await store.close()
+    await mem.close()
+
+
+# SQLite (and CURRENT_TIMESTAMP) store naive, space-separated timestamps. Match
+# that format so the stored values read back cleanly and reflect reality.
+def _ts(dt):
+    return dt.strftime("%Y-%m-%d %H:%M:%S") if dt is not None else None
+
+
+async def _insert_archived(store, id_, importance, created_at, last_recalled_at):
+    async with store.pool.acquire() as conn:
+        await conn.execute(
+            "INSERT INTO archived_memories (id, content, importance_score, "
+            "last_recalled_at, created_at) VALUES (?, ?, ?, ?, ?)",
+            id_,
+            id_,
+            importance,
+            _ts(last_recalled_at),
+            _ts(created_at),
+        )
+
+
+async def _surviving_ids(store):
+    async with store.pool.acquire() as conn:
+        rows = await conn.fetch("SELECT id FROM archived_memories")
+    return {r["id"] for r in rows}
+
+
+class TestArchiveNullCleanup:
+    @pytest.mark.asyncio
+    async def test_old_never_recalled_row_is_purged(self, store_with_archive):
+        store, mem = store_with_archive
+        now = datetime(2026, 7, 18)
+        # Distractor (importance < 0.5), never recalled, created 400 days ago:
+        # well past the 30-day distractor cutoff -> must be purged via created_at.
+        await _insert_archived(
+            store,
+            "old_null",
+            0.3,
+            now - timedelta(days=400),
+            None,
+        )
+
+        await mem.apply_actr_decay(["anchor memory"], current_time=now)
+
+        assert "old_null" not in await _surviving_ids(store)
+
+    @pytest.mark.asyncio
+    async def test_recent_never_recalled_row_survives(self, store_with_archive):
+        store, mem = store_with_archive
+        now = datetime(2026, 7, 18)
+        # Never recalled but created only 5 days ago: inside the 30-day cutoff,
+        # so COALESCE(created_at) keeps it -- recency, not NULL, decides.
+        await _insert_archived(
+            store,
+            "recent_null",
+            0.3,
+            now - timedelta(days=5),
+            None,
+        )
+
+        await mem.apply_actr_decay(["anchor memory"], current_time=now)
+
+        assert "recent_null" in await _surviving_ids(store)
+
+    @pytest.mark.asyncio
+    async def test_recalled_row_respects_last_recalled_at(self, store_with_archive):
+        store, mem = store_with_archive
+        now = datetime(2026, 7, 18)
+        # Created long ago but recalled recently: last_recalled_at (5 days ago)
+        # takes precedence over created_at, so it must survive.
+        await _insert_archived(
+            store,
+            "old_but_recalled",
+            0.3,
+            now - timedelta(days=400),
+            now - timedelta(days=5),
+        )
+        # And an old, long-unrecalled distractor that should be purged.
+        await _insert_archived(
+            store,
+            "old_and_stale",
+            0.3,
+            now - timedelta(days=400),
+            now - timedelta(days=90),
+        )
+
+        await mem.apply_actr_decay(["anchor memory"], current_time=now)
+
+        survivors = await _surviving_ids(store)
+        assert "old_but_recalled" in survivors
+        assert "old_and_stale" not in survivors

--- a/backend/tests/test_memory_insert.py
+++ b/backend/tests/test_memory_insert.py
@@ -1,0 +1,183 @@
+"""
+Tests for the unified memory-insert writer (_insert_memory_row).
+
+The writer collapses eight near-identical INSERTs across three axes: SQLite vs
+PostgreSQL placeholders, timed vs untimed (created_at/last_recalled_at), and the
+full Eriksonian column set vs a legacy fallback for un-migrated schemas. These
+tests exercise each axis directly.
+"""
+
+import re
+import pytest
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+from app.state.conversation_store import ConversationHistoryStore
+from app.state.memory_store import MemoryStore
+
+
+_FULL_SCHEMA = """
+    CREATE TABLE IF NOT EXISTS memories (
+        id TEXT PRIMARY KEY, content TEXT, raw_content TEXT, wing TEXT, room TEXT,
+        embedding TEXT, importance_score REAL, emotional_weight REAL, valence REAL,
+        certainty REAL, source TEXT, metadata TEXT, recall_count INTEGER,
+        last_recalled_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        lifespan_stage TEXT, crisis TEXT, virtue TEXT, relations TEXT,
+        relation_circles TEXT, modality TEXT
+    )
+"""
+
+# Legacy schema: no Eriksonian columns -> the full insert must fail and the
+# writer must fall back to the base column set.
+_LEGACY_SCHEMA = """
+    CREATE TABLE IF NOT EXISTS memories (
+        id TEXT PRIMARY KEY, content TEXT, raw_content TEXT, wing TEXT, room TEXT,
+        embedding TEXT, importance_score REAL, emotional_weight REAL, valence REAL,
+        certainty REAL, source TEXT, metadata TEXT, recall_count INTEGER,
+        last_recalled_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )
+"""
+
+
+async def _make_store(schema):
+    store = ConversationHistoryStore()
+    await store.initialize()
+    async with store.pool.acquire() as conn:
+        await conn.execute(schema)
+        await conn.execute("DELETE FROM memories;")
+    mock_graph = MagicMock()
+    mock_graph.execute_query = AsyncMock(return_value=[])
+    mem = MemoryStore(pool=store.pool, graph_db=mock_graph)
+    mem.qdrant_store.client = None
+    mem.get_embedding = AsyncMock(return_value=[0.1] * 768)
+    return store, mem
+
+
+class TestSqliteInsert:
+    @pytest.mark.asyncio
+    async def test_timed_full_insert_sets_created_at_and_eriksonian(self):
+        store, mem = await _make_store(_FULL_SCHEMA)
+        try:
+            ts = datetime(2026, 3, 1, 9, 30, 0)
+            ok = await mem.add_memory(
+                "timed memory",
+                wing="personal",
+                importance=0.7,
+                lifespan_stage="adulthood",
+                modality="text",
+                current_time=ts,
+            )
+            assert ok is True
+            async with store.pool.acquire() as conn:
+                row = await conn.fetchrow(
+                    "SELECT recall_count, created_at, last_recalled_at, "
+                    "lifespan_stage, modality FROM memories WHERE content = 'timed memory'"
+                )
+            assert row["recall_count"] == 1
+            assert str(row["created_at"]).startswith("2026-03-01 09:30:00")
+            assert str(row["last_recalled_at"]).startswith("2026-03-01 09:30:00")
+            assert row["lifespan_stage"] == "adulthood"
+            assert row["modality"] == "text"
+        finally:
+            await store.close()
+            await mem.close()
+
+    @pytest.mark.asyncio
+    async def test_untimed_insert_defaults_last_recalled_at(self):
+        store, mem = await _make_store(_FULL_SCHEMA)
+        try:
+            ok = await mem.add_memory("untimed memory", wing="personal")
+            assert ok is True
+            async with store.pool.acquire() as conn:
+                row = await conn.fetchrow(
+                    "SELECT recall_count, last_recalled_at FROM memories "
+                    "WHERE content = 'untimed memory'"
+                )
+            assert row["recall_count"] == 1
+            # CURRENT_TIMESTAMP default fired -> not NULL.
+            assert row["last_recalled_at"] is not None
+        finally:
+            await store.close()
+            await mem.close()
+
+    @pytest.mark.asyncio
+    async def test_legacy_schema_falls_back_and_still_inserts(self):
+        store, mem = await _make_store(_LEGACY_SCHEMA)
+        try:
+            # Full insert references lifespan_stage etc. which do not exist here;
+            # the writer must catch that and retry with the base columns.
+            ok = await mem.add_memory(
+                "legacy memory", wing="personal", lifespan_stage="childhood"
+            )
+            assert ok is True
+            async with store.pool.acquire() as conn:
+                row = await conn.fetchrow(
+                    "SELECT content, recall_count FROM memories "
+                    "WHERE content = 'legacy memory'"
+                )
+            assert row is not None
+            assert row["recall_count"] == 1
+        finally:
+            await store.close()
+            await mem.close()
+
+
+class TestPgPlaceholderGeneration:
+    """The PG branch builds $n placeholders; assert they are well-formed and
+    aligned with the parameter count on the AsyncMock (no real Postgres)."""
+
+    def _make_pg_store(self):
+        pool = MagicMock()  # not MockPGPool -> is_sqlite False -> PG branch
+        store = MemoryStore(pool, MagicMock())
+        store.qdrant_store.client = None
+        return store
+
+    async def _capture(self, current_time):
+        store = self._make_pg_store()
+        conn = AsyncMock()
+        await store._insert_memory_row(
+            conn,
+            memory_id="id1",
+            content="c",
+            raw_val="c",
+            wing="personal",
+            room=None,
+            vector_str="[0.1]",
+            importance=0.5,
+            emotion=0.0,
+            valence=0.0,
+            certainty=1.0,
+            source="user",
+            metadata_json="{}",
+            lifespan_stage="s",
+            crisis=None,
+            virtue=None,
+            relations=None,
+            relation_circles=None,
+            modality=None,
+            current_time=current_time,
+        )
+        # include_eriksonian=True succeeds on AsyncMock (no exception), so the
+        # first (and only) call is the full insert.
+        sql, params = conn.execute.await_args_list[0].args[0], conn.execute.await_args_list[0].args[1:]
+        return sql, params
+
+    @pytest.mark.asyncio
+    async def test_timed_placeholders_sequential_and_aligned(self):
+        sql, params = await self._capture(datetime(2026, 1, 1))
+        nums = [int(n) for n in re.findall(r"\$(\d+)", sql)]
+        # 12 base + 6 eriksonian + 2 time = 20 bound params, sequential 1..20.
+        assert nums == list(range(1, 21))
+        assert len(params) == 20
+        assert " 1," in sql or ", 1," in sql  # recall_count literal present
+
+    @pytest.mark.asyncio
+    async def test_untimed_uses_current_timestamp_literal(self):
+        sql, params = await self._capture(None)
+        nums = [int(n) for n in re.findall(r"\$(\d+)", sql)]
+        # 12 base + 6 eriksonian = 18 bound params; time is a literal.
+        assert nums == list(range(1, 19))
+        assert len(params) == 18
+        assert "CURRENT_TIMESTAMP" in sql


### PR DESCRIPTION
Combined Tier 2 (correctness) and Tier 3 (maintainability) of the memory-fidelity work, on top of the Tier 1 changes already on `main`.

## Tier 2 — archive cleanup correctness (`13eac26`)

`apply_actr_decay`'s permanent archive cleanup had two bugs:

- **Never-recalled rows were immortal.** `last_recalled_at` is NULL for a never-recalled memory and `NULL < cutoff` is NULL (never true), so those rows were never purged. Now `COALESCE(last_recalled_at, created_at)` ages them out by creation time — matching how the activation SQL in `db/schema.sql` already coalesces this column.
- **SQLite text-timestamp comparison hardened** by normalizing both operands through `datetime()`; PG compares real `timestamptz` and only needs the COALESCE.

Deliberately *not* changed: gating importance-decay by recency — `apply_actr_decay` is a post-consolidation fade of just-consolidated raw episodes (`subconscious_agent.py`), not a periodic sweep, so decaying a fresh trace there is intentional.

## Tier 3 — maintainability refactors (no behaviour change)

- **`4bc8f8f` — Unify the ACT-R scoring formula.** The base-activation + neuromodulatory-similarity + emotional-distance score was copy-pasted across three retrieval paths plus a promotion variant, with five inline magic weights. Extracted `_base_activation()` / `_effective_similarity()` and named the weights as module constants. Bit-identical arithmetic.
- **`831cbe2` — Collapse the eight `add_memory` INSERTs** (SQLite/PG × timed/untimed × full/legacy-fallback, ~240 lines) into one `_insert_memory_row()` column/placeholder builder that keeps the same full→legacy fallback.

## Tests

- `test_memory_archive_cleanup.py` — old never-recalled purged, recent retained, `last_recalled_at` precedence.
- `test_memory_insert.py` — SQLite timed-full / untimed / legacy-fallback, and PG `$n` placeholder alignment (20 timed / 18 untimed).

Full backend suite passes (exit 0); `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)