### PR TITLE
fix(memory): end mixed-timezone crashes in recency arithmetic

### DIFF
--- a/backend/app/state/memory_store.py
+++ b/backend/app/state/memory_store.py
@@ -181,6 +181,24 @@ class MemoryStore:
             and type(self.pool).__name__ not in ("MagicMock", "AsyncMock", "Mock")
         )
 
+    @staticmethod
+    def _as_aware_utc(dt):
+        """Coerce a datetime to timezone-aware UTC so recency arithmetic never
+        mixes naive and aware operands (which raises TypeError).
+
+        Timestamps reach these code paths from two sources: naive values
+        (SQLite CURRENT_TIMESTAMP, strptime of stored strings) and aware values
+        (Postgres timestamptz, datetime.now(timezone.utc), a caller-supplied
+        current_time). Naive inputs are assumed to already be UTC -- which is how
+        the stored timestamps are written -- and aware inputs are converted.
+        None passes through so callers can apply their own fallback.
+        """
+        if dt is None:
+            return None
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc)
+
     def _l1_cache_put(self, cache_key, value):
         """Insert into the L1 cache with LRU eviction.
 
@@ -1192,15 +1210,15 @@ class MemoryStore:
                             # Recalculate score with neuromodulatory gating
                             last_recall = row.get("last_recalled_at")
                             now = (
-                                current_time
+                                self._as_aware_utc(current_time)
                                 if current_time is not None
                                 else datetime.now(timezone.utc)
                             )
-
-                            if last_recall is None:
-                                last_recall = now
-                            elif last_recall.tzinfo is None:
-                                last_recall = last_recall.replace(tzinfo=timezone.utc)
+                            last_recall = (
+                                now
+                                if last_recall is None
+                                else self._as_aware_utc(last_recall)
+                            )
 
                             hours_since = max(
                                 0.001, (now - last_recall).total_seconds() / 3600.0
@@ -1958,14 +1976,13 @@ class MemoryStore:
                         recall_count = max(1, row.get("recall_count") or 1)
                         last_recall = row.get("last_recalled_at")
                         now = (
-                            current_time
+                            self._as_aware_utc(current_time)
                             if current_time is not None
                             else datetime.now(timezone.utc)
                         )
-                        if last_recall is None:
-                            last_recall = now
-                        elif last_recall.tzinfo is None:
-                            last_recall = last_recall.replace(tzinfo=timezone.utc)
+                        last_recall = (
+                            now if last_recall is None else self._as_aware_utc(last_recall)
+                        )
 
                         hours_since = max(
                             0.001, (now - last_recall).total_seconds() / 3600.0
@@ -2060,14 +2077,13 @@ class MemoryStore:
                         recall_count = max(1, row.get("recall_count") or 1)
                         last_recall = row.get("last_recalled_at")
                         now = (
-                            current_time
+                            self._as_aware_utc(current_time)
                             if current_time is not None
                             else datetime.now(timezone.utc)
                         )
-                        if last_recall is None:
-                            last_recall = now
-                        elif last_recall.tzinfo is None:
-                            last_recall = last_recall.replace(tzinfo=timezone.utc)
+                        last_recall = (
+                            now if last_recall is None else self._as_aware_utc(last_recall)
+                        )
 
                         hours_since = max(
                             0.001, (now - last_recall).total_seconds() / 3600.0
@@ -2563,16 +2579,15 @@ class MemoryStore:
                     else:
                         dt = created_at
 
-                    # Calculate hours since creation
-                    if current_time is not None:
-                        now = (
-                            current_time.astimezone(dt.tzinfo)
-                            if dt.tzinfo
-                            else current_time
-                        )
-                    else:
-                        now = datetime.now(dt.tzinfo) if dt.tzinfo else datetime.now()
-                    delta = now - dt
+                    # Calculate hours since creation. Coerce both operands to
+                    # aware-UTC so a naive stored created_at and an aware
+                    # current_time (or vice versa) never raise on subtraction.
+                    now = (
+                        self._as_aware_utc(current_time)
+                        if current_time is not None
+                        else datetime.now(timezone.utc)
+                    )
+                    delta = now - self._as_aware_utc(dt)
                     hours_since = max(0.0, delta.total_seconds() / 3600.0)
 
                     # Extract decay_rate from metadata if possible

--- a/backend/tests/test_memory_tz.py
+++ b/backend/tests/test_memory_tz.py
@@ -1,0 +1,134 @@
+"""
+Mixed timezone-awareness regression tests for MemoryStore recency arithmetic.
+
+Timestamps reach the scoring/decay paths from naive sources (SQLite
+CURRENT_TIMESTAMP, strptime) and aware sources (Postgres timestamptz,
+datetime.now(timezone.utc), a caller-supplied current_time). Subtracting a naive
+and an aware datetime raises TypeError, which previously aborted apply_actr_decay
+and silently emptied search results whenever the two sources were mixed. Every
+recency subtraction now coerces both operands through _as_aware_utc first.
+"""
+
+import asyncio
+import pytest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.state.conversation_store import ConversationHistoryStore
+from app.state.memory_store import MemoryStore
+
+
+class TestAsAwareUtc:
+    def test_naive_is_assumed_utc(self):
+        dt = datetime(2026, 5, 1, 12, 0, 0)
+        out = MemoryStore._as_aware_utc(dt)
+        assert out.tzinfo is timezone.utc
+        assert out.hour == 12  # naive value read as-is, tagged UTC
+
+    def test_aware_is_converted_to_utc(self):
+        tz = timezone(timedelta(hours=5, minutes=30))  # +05:30
+        dt = datetime(2026, 5, 1, 12, 0, 0, tzinfo=tz)
+        out = MemoryStore._as_aware_utc(dt)
+        assert out.tzinfo is timezone.utc
+        assert out.hour == 6 and out.minute == 30  # 12:00+05:30 -> 06:30 UTC
+
+    def test_none_passes_through(self):
+        assert MemoryStore._as_aware_utc(None) is None
+
+    def test_subtraction_never_raises_after_coercion(self):
+        naive = datetime(2026, 5, 1, 12, 0, 0)
+        aware = datetime(2026, 5, 1, 10, 0, 0, tzinfo=timezone.utc)
+        delta = MemoryStore._as_aware_utc(naive) - MemoryStore._as_aware_utc(aware)
+        assert delta.total_seconds() == 2 * 3600
+
+
+_SCHEMA = """
+    CREATE TABLE IF NOT EXISTS memories (
+        id TEXT PRIMARY KEY, content TEXT, raw_content TEXT, wing TEXT, room TEXT,
+        embedding TEXT, importance_score REAL, emotional_weight REAL, valence REAL,
+        certainty REAL, source TEXT, metadata TEXT, recall_count INTEGER,
+        last_recalled_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        lifespan_stage TEXT, crisis TEXT, virtue TEXT, relations TEXT,
+        relation_circles TEXT, modality TEXT
+    )
+"""
+
+
+class TestApplyDecayMixedTz:
+    @pytest.mark.asyncio
+    async def test_aware_current_time_against_naive_storage_decays(self):
+        # SQLite stores naive (UTC) timestamps; passing an aware current_time
+        # used to raise "can't subtract offset-naive and offset-aware
+        # datetimes", abort the decay, and leave importance untouched.
+        store = ConversationHistoryStore()
+        await store.initialize()
+        async with store.pool.acquire() as conn:
+            await conn.execute(_SCHEMA)
+            await conn.execute("DELETE FROM memories;")
+
+        mock_graph = MagicMock()
+        mock_graph.execute_query = AsyncMock(return_value=[])
+        mem = MemoryStore(pool=store.pool, graph_db=mock_graph)
+        mem.qdrant_store.client = None
+        mem.get_embedding = AsyncMock(return_value=[0.1] * 768)
+
+        try:
+            await mem.add_memory("decay me", importance=0.6)
+            # aware current_time ~ now, so the memory is recent (not pruned) and
+            # its importance decays by the 0.8 factor.
+            await mem.apply_actr_decay(
+                ["decay me"], current_time=datetime.now(timezone.utc)
+            )
+            async with store.pool.acquire() as conn:
+                row = await conn.fetchrow(
+                    "SELECT importance_score FROM memories WHERE content = 'decay me'"
+                )
+            assert row["importance_score"] == pytest.approx(0.48, abs=1e-6)
+        finally:
+            await store.close()
+            await mem.close()
+
+
+def _make_row_aware(content, similarity, hours_ago=1, recall_count=1):
+    now = datetime.now(timezone.utc)  # aware last_recalled_at / created_at
+    return {
+        "content": content,
+        "raw_content": content,
+        "wing": "personal",
+        "room": None,
+        "importance_score": 0.5,
+        "emotional_weight": 0.0,
+        "valence": 0.0,
+        "recall_count": recall_count,
+        "last_recalled_at": now - timedelta(hours=hours_ago),
+        "created_at": now - timedelta(hours=hours_ago),
+        "metadata": "{}",
+        "similarity": similarity,
+    }
+
+
+class TestSearchMixedTz:
+    def test_naive_current_time_against_aware_rows_returns_results(self):
+        # Rows carry aware timestamps; a naive current_time previously mixed
+        # naive/aware in (now - last_recall), threw, and the outer handler
+        # swallowed it into an empty result set.
+        pool = MagicMock()
+        pool.acquire = MagicMock()
+        conn = AsyncMock()
+        pool.acquire.return_value.__aenter__.return_value = conn
+        conn.fetch.return_value = [_make_row_aware("aware memory", similarity=1.0)]
+
+        mem = MemoryStore(pool, MagicMock())
+        mem.graph_db.execute_query = AsyncMock(return_value=[])
+        mem.qdrant_store.client = None
+
+        with patch.object(mem, "get_embedding", return_value=[0.1] * 768):
+            results = asyncio.run(
+                mem.search_memories(
+                    "query",
+                    threshold=-5.0,
+                    current_time=datetime(2026, 6, 1, 12, 0, 0),  # naive
+                )
+            )
+        assert any(r["content"] == "aware memory" for r in results)


### PR DESCRIPTION
## Summary

Fixes the latent mixed-timezone fragility surfaced during the Tier 2 review.

Recency timestamps reach the scoring and decay paths from two sources:
- **naive** — SQLite `CURRENT_TIMESTAMP`, `strptime` of stored strings
- **aware** — Postgres `timestamptz`, `datetime.now(timezone.utc)`, a caller-supplied `current_time`

Subtracting a naive from an aware datetime raises `can't subtract offset-naive and offset-aware datetimes`. That bit two ways:

- **`apply_actr_decay`** with an aware `current_time` against naive-stored timestamps raised inside the loop, was swallowed by the outer handler, and left every matched memory **undecayed / unpruned**.
- **`search_memories`** with a naive `current_time` against aware `last_recalled_at` rows raised in `(now - last_recall)` and returned an **empty result set**.

## Fix

One helper — `_as_aware_utc()` (naive assumed UTC, matching how the stored timestamps are written; aware converted; `None` passthrough) — routed through all four recency subtractions: `apply_actr_decay`'s hours-since plus the three retrieval-scoring paths.

The naive/naive and aware/aware cases are unchanged, so existing behaviour is preserved; only the previously-crashing mixed case now works. Float-timestamp paths (which already tag naive as UTC before `.timestamp()`) were left as-is.

## Tests

`backend/tests/test_memory_tz.py`:
- Unit tests for `_as_aware_utc` (naive→UTC, aware converted, None passthrough, subtraction safe).
- `apply_actr_decay` with an aware `current_time` now decays importance (0.6 → 0.48) instead of aborting.
- `search_memories` with a naive `current_time` against aware rows now returns results instead of `[]`.

**All six fail against the pre-fix code and pass after** (verified by stashing the source change).

Full backend suite passes (exit 0); `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)