### PR TITLE
perf(memory): move Personalized-PageRank hot loop into the Rust crate

### DIFF
--- a/backend/app/state/memory_store.py
+++ b/backend/app/state/memory_store.py
@@ -325,6 +325,73 @@ class MemoryStore:
             - ACTR_STRESS_SUPPRESSION * current_arousal * current_cortisol
         )
 
+    @staticmethod
+    def _personalized_pagerank(entity_names, adj, seeds, damping, iterations):
+        """HippoRAG-inspired Personalized PageRank over the entity graph.
+
+        The numeric power-method loop is delegated to the ``cognitive_rust``
+        extension (the same crate that already owns the ACT-R scoring hot loop),
+        with an exact pure-Python fallback if the extension is unavailable. Both
+        paths preserve the legacy semantics precisely:
+
+          * ``degrees`` holds each node's ORIGINAL neighbor count. A neighbor
+            whose name is absent from ``entity_names`` has no resolvable index
+            and is dropped from the push, but the mass is still divided by the
+            full degree -- so that share leaks out of the graph, unchanged.
+          * A degree-0 node is dangling and redistributes uniformly across the
+            seeds rather than the whole graph.
+
+        ``seeds`` is a set of node indices; returns the rank vector (list) of
+        length ``len(entity_names)``.
+        """
+        n = len(entity_names)
+        if not seeds or n == 0:
+            return [0.0] * n
+
+        node_to_idx = {name: idx for idx, name in enumerate(entity_names)}
+        seed_list = sorted(seeds)
+
+        # Resolve name-based adjacency to index lists once; keep the original
+        # degree so the divisor (and the leaked mass) matches the legacy loop.
+        adjacency_idx = []
+        degrees = []
+        for name in entity_names:
+            neighbors = adj.get(name, ())
+            degrees.append(len(neighbors))
+            adjacency_idx.append([node_to_idx[nb] for nb in neighbors if nb in node_to_idx])
+
+        try:
+            import cognitive_rust
+
+            return list(
+                cognitive_rust.personalized_pagerank(
+                    adjacency_idx, degrees, seed_list, damping, iterations
+                )
+            )
+        except Exception:
+            # Pure-Python fallback with identical arithmetic and ordering.
+            p_0 = [0.0] * n
+            seed_share = 1.0 / len(seed_list)
+            for s_idx in seed_list:
+                p_0[s_idx] = seed_share
+            p = list(p_0)
+            for _ in range(iterations):
+                p_next = [0.0] * n
+                for i in range(n):
+                    degree = degrees[i]
+                    if degree:
+                        val = p[i] / degree
+                        for n_idx in adjacency_idx[i]:
+                            p_next[n_idx] += val
+                    else:
+                        dangling_share = p[i] / len(seed_list)
+                        for s_idx in seed_list:
+                            p_next[s_idx] += dangling_share
+                for i in range(n):
+                    p_next[i] = damping * p_next[i] + (1.0 - damping) * p_0[i]
+                p = p_next
+            return p
+
     # Columns always written; the Eriksonian columns below may be absent on an
     # un-migrated schema, so a failed full insert falls back to just these.
     _MEMORY_BASE_COLUMNS = (
@@ -1711,45 +1778,16 @@ class MemoryStore:
                                         if name.lower() == ent.lower():
                                             seeds.add(e_idx)
 
-                    # Compute Personalized PageRank Vector
+                    # Compute Personalized PageRank Vector (3-iteration power
+                    # method, delegated to the Rust hot loop with a Python
+                    # fallback). PPR_DAMPING is the canonical teleport factor.
                     N = len(entity_names)
                     if not seeds:
                         ppr = {}
                     else:
-                        p_0 = [0.0] * N
-                        val = 1.0 / len(seeds)
-                        for s_idx in seeds:
-                            p_0[s_idx] = val
-
-                        p = list(p_0)
-                        node_to_idx = {
-                            name: idx for idx, name in enumerate(entity_names)
-                        }
-
-                        # Standard PageRank damping (teleport) factor.
-                        d = PPR_DAMPING
-
-                        # 3-iteration power method PPR propagation
-                        for _ in range(3):
-                            p_next = [0.0] * N
-                            for i in range(N):
-                                node_name = entity_names[i]
-                                neighbors = adj.get(node_name, set())
-                                if neighbors:
-                                    val = p[i] / len(neighbors)
-                                    for n in neighbors:
-                                        n_idx = node_to_idx.get(n)
-                                        if n_idx is not None:
-                                            p_next[n_idx] += val
-                                else:
-                                    # Dangling node distributes to seeds
-                                    for idx in seeds:
-                                        p_next[idx] += p[i] / len(seeds)
-
-                            for i in range(N):
-                                p_next[i] = d * p_next[i] + (1 - d) * p_0[i]
-                            p = p_next
-
+                        p = self._personalized_pagerank(
+                            entity_names, adj, seeds, PPR_DAMPING, 3
+                        )
                         ppr = {entity_names[i]: p[i] for i in range(N)}
 
                     # Helper to find which entities are present in a memory content (fallback scanning)

--- a/backend/crates/cognitive-rust/src/lib.rs
+++ b/backend/crates/cognitive-rust/src/lib.rs
@@ -317,6 +317,72 @@ pub fn evaluate_acoustic_reflex(rms: f64, _zcr: f64, threshold: f64) -> bool {
     rms > threshold
 }
 
+/// HippoRAG-inspired Personalized PageRank power method for graph spreading
+/// activation. This is a faithful port of the former in-Python hot loop and
+/// preserves its exact semantics, including two deliberate behaviors:
+///
+///   * `degrees[i]` carries the ORIGINAL neighbor count of node `i`. When an
+///     edge points at an entity outside the candidate set its resolved index is
+///     omitted from `adjacency[i]`, yet the mass is still divided by the full
+///     degree -- so that share leaks out of the graph, exactly as before.
+///   * A node with degree 0 is dangling and redistributes its mass uniformly
+///     across the seed set rather than the whole graph.
+///
+/// `adjacency[i]` holds the resolved (in-range) neighbor indices of node `i`;
+/// `seeds` are the personalization/teleport nodes. Returns the rank vector of
+/// length `adjacency.len()`.
+#[pyfunction]
+#[pyo3(signature = (adjacency, degrees, seeds, damping, iterations))]
+pub fn personalized_pagerank(
+    adjacency: Vec<Vec<usize>>,
+    degrees: Vec<usize>,
+    seeds: Vec<usize>,
+    damping: f64,
+    iterations: usize,
+) -> Vec<f64> {
+    let n = adjacency.len();
+    if n == 0 || seeds.is_empty() {
+        return vec![0.0; n];
+    }
+
+    let seed_share = 1.0 / seeds.len() as f64;
+    let mut p0 = vec![0.0_f64; n];
+    for &s in &seeds {
+        if s < n {
+            p0[s] = seed_share;
+        }
+    }
+
+    let mut p = p0.clone();
+    for _ in 0..iterations {
+        let mut p_next = vec![0.0_f64; n];
+        for i in 0..n {
+            let degree = degrees.get(i).copied().unwrap_or(0);
+            if degree > 0 {
+                let share = p[i] / degree as f64;
+                for &nb in &adjacency[i] {
+                    if nb < n {
+                        p_next[nb] += share;
+                    }
+                }
+            } else {
+                // Dangling node: redistribute uniformly across the seeds.
+                let share = p[i] / seeds.len() as f64;
+                for &s in &seeds {
+                    if s < n {
+                        p_next[s] += share;
+                    }
+                }
+            }
+        }
+        for i in 0..n {
+            p_next[i] = damping * p_next[i] + (1.0 - damping) * p0[i];
+        }
+        p = p_next;
+    }
+    p
+}
+
 #[pyfunction]
 pub fn score_memories_actr_sqlite(
     query_vector: Vec<f64>,
@@ -543,6 +609,7 @@ fn cognitive_rust(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(update_fatigue, module)?)?;
     module.add_function(wrap_pyfunction!(compute_vector_delta, module)?)?;
     module.add_function(wrap_pyfunction!(evaluate_acoustic_reflex, module)?)?;
+    module.add_function(wrap_pyfunction!(personalized_pagerank, module)?)?;
     Ok(())
 }
 
@@ -645,5 +712,41 @@ mod tests {
         let delta = compute_vector_delta(v1, v2);
         // (1^2 + 2^2 + 2^2) / 3 = (1 + 4 + 4) / 3 = 9 / 3 = 3.0
         assert!((delta - 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn ppr_single_iteration_two_node_ring() {
+        // seed=node0, both connected. One power iteration, d=0.85.
+        // node0 (deg1) pushes 1.0 -> node1; node1 (deg1) pushes 0.0 -> node0.
+        // teleport: p0[0]=1.0 so node0 = 0.85*0 + 0.15*1 = 0.15; node1 = 0.85*1 = 0.85.
+        let p = personalized_pagerank(vec![vec![1], vec![0]], vec![1, 1], vec![0], 0.85, 1);
+        assert!((p[0] - 0.15).abs() < 1e-12);
+        assert!((p[1] - 0.85).abs() < 1e-12);
+    }
+
+    #[test]
+    fn ppr_dangling_node_redistributes_to_seeds() {
+        // node0 has degree 0 (dangling), node1 -> node0. seed=node0.
+        // node0 dangling pushes its full mass back to the seed set {0}.
+        let p = personalized_pagerank(vec![vec![], vec![0]], vec![0, 1], vec![0], 0.85, 1);
+        assert!((p[0] - 1.0).abs() < 1e-12);
+        assert!((p[1] - 0.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn ppr_degree_greater_than_resolved_neighbors_leaks_mass() {
+        // node0 reports degree 2 but only one neighbor resolved in-set: half its
+        // mass leaks out of the graph, exactly as the legacy Python loop did.
+        // share = 1.0/2 = 0.5 -> node1; node0 = 0.15 (teleport), node1 = 0.85*0.5.
+        let p = personalized_pagerank(vec![vec![1], vec![]], vec![2, 0], vec![0], 0.85, 1);
+        assert!((p[0] - 0.15).abs() < 1e-12);
+        assert!((p[1] - 0.425).abs() < 1e-12);
+        assert!(p[0] + p[1] < 1.0); // mass genuinely leaked
+    }
+
+    #[test]
+    fn ppr_empty_seeds_returns_zero_vector() {
+        let p = personalized_pagerank(vec![vec![1], vec![0]], vec![1, 1], vec![], 0.85, 3);
+        assert_eq!(p, vec![0.0, 0.0]);
     }
 }

--- a/backend/tests/test_ppr_rust.py
+++ b/backend/tests/test_ppr_rust.py
@@ -1,0 +1,126 @@
+"""Parity tests for the Personalized PageRank hot loop port to Rust.
+
+The PPR power method that drives HippoRAG-style graph spreading activation was
+moved from an in-Python loop into the cognitive_rust extension (the crate that
+already owns the ACT-R scoring loop). This is a behavior-preserving move: the
+Rust path, the pure-Python fallback, and a faithful copy of the *original*
+set-based loop must all agree bit-for-bit -- including the two subtle legacy
+behaviors: probability-mass leakage through neighbors absent from entity_names,
+and dangling-node redistribution to the seed set.
+"""
+
+import random
+
+import pytest
+from unittest.mock import patch
+
+from app.state.memory_store import MemoryStore, PPR_DAMPING
+
+
+def _py_reference(entity_names, adj, seeds, damping, iterations):
+    """Verbatim reproduction of the pre-port in-Python PPR loop, used as the
+    independent ground truth for both the Rust and fallback code paths."""
+    n = len(entity_names)
+    if not seeds:
+        return [0.0] * n
+    p_0 = [0.0] * n
+    val = 1.0 / len(seeds)
+    for s_idx in seeds:
+        p_0[s_idx] = val
+    p = list(p_0)
+    node_to_idx = {name: idx for idx, name in enumerate(entity_names)}
+    d = damping
+    for _ in range(iterations):
+        p_next = [0.0] * n
+        for i in range(n):
+            node_name = entity_names[i]
+            neighbors = adj.get(node_name, set())
+            if neighbors:
+                v = p[i] / len(neighbors)
+                for nb in neighbors:
+                    n_idx = node_to_idx.get(nb)
+                    if n_idx is not None:
+                        p_next[n_idx] += v
+            else:
+                for idx in seeds:
+                    p_next[idx] += p[i] / len(seeds)
+        for i in range(n):
+            p_next[i] = d * p_next[i] + (1 - d) * p_0[i]
+        p = p_next
+    return p
+
+
+def _assert_matches(entity_names, adj, seeds, iterations=3):
+    expected = _py_reference(entity_names, adj, seeds, PPR_DAMPING, iterations)
+
+    rust = MemoryStore._personalized_pagerank(
+        entity_names, adj, seeds, PPR_DAMPING, iterations
+    )
+    assert rust == pytest.approx(expected, abs=1e-12)
+
+    # Force the pure-Python fallback by making the Rust call raise.
+    with patch(
+        "cognitive_rust.personalized_pagerank", side_effect=RuntimeError("boom")
+    ):
+        fallback = MemoryStore._personalized_pagerank(
+            entity_names, adj, seeds, PPR_DAMPING, iterations
+        )
+    assert fallback == pytest.approx(expected, abs=1e-12)
+    return rust
+
+
+class TestPprParity:
+    def test_single_seed_ring(self):
+        names = ["a", "b", "c"]
+        adj = {"a": {"b", "c"}, "b": {"a"}, "c": {"a"}}
+        _assert_matches(names, adj, {0})
+
+    def test_multiple_seeds(self):
+        names = ["a", "b", "c", "d"]
+        adj = {"a": {"b"}, "b": {"a", "c"}, "c": {"b", "d"}, "d": {"c"}}
+        _assert_matches(names, adj, {0, 3})
+
+    def test_dangling_node_redistributes_to_seeds(self):
+        # "a" has no adjacency entry -> dangling; its mass returns to the seeds.
+        names = ["a", "b"]
+        adj = {"b": {"a"}}
+        _assert_matches(names, adj, {0})
+
+    def test_empty_seeds_is_zero_vector(self):
+        names = ["a", "b"]
+        adj = {"a": {"b"}, "b": {"a"}}
+        result = MemoryStore._personalized_pagerank(names, adj, set(), PPR_DAMPING, 3)
+        assert result == [0.0, 0.0]
+
+    def test_neighbor_outside_entity_set_leaks_mass(self):
+        # "ghost" is a real graph edge but not a candidate entity: node "a" has
+        # degree 2, yet only "b" resolves, so half of a's mass leaks away.
+        names = ["a", "b"]
+        adj = {"a": {"b", "ghost"}, "b": {"a"}}
+        leaked = _assert_matches(names, adj, {0})
+
+        # Same topology without the phantom edge (degree 1) must score "b"
+        # strictly higher -- proving the original degree is honored, not the
+        # count of resolved neighbors.
+        no_ghost = MemoryStore._personalized_pagerank(
+            names, {"a": {"b"}, "b": {"a"}}, {0}, PPR_DAMPING, 3
+        )
+        assert no_ghost[1] > leaked[1]
+
+    def test_matches_across_random_graphs(self):
+        rng = random.Random(1234)
+        for _ in range(25):
+            n = rng.randint(2, 12)
+            names = [f"n{i}" for i in range(n)]
+            adj = {}
+            for i in range(n):
+                degree = rng.randint(0, n - 1)
+                nbrs = set(rng.sample(range(n), degree)) - {i}
+                if nbrs:
+                    adj[names[i]] = {names[j] for j in nbrs}
+                # Occasionally inject an out-of-set neighbor to exercise leakage.
+                if rng.random() < 0.3:
+                    adj.setdefault(names[i], set()).add("phantom")
+            seed_count = rng.randint(1, n)
+            seeds = set(rng.sample(range(n), seed_count))
+            _assert_matches(names, adj, seeds)

--- a/backend/tests/test_ppr_rust.py
+++ b/backend/tests/test_ppr_rust.py
@@ -53,10 +53,24 @@ def _py_reference(entity_names, adj, seeds, damping, iterations):
 def _assert_matches(entity_names, adj, seeds, iterations=3):
     expected = _py_reference(entity_names, adj, seeds, PPR_DAMPING, iterations)
 
-    rust = MemoryStore._personalized_pagerank(
-        entity_names, adj, seeds, PPR_DAMPING, iterations
+    # Prepare the index-based structures needed by the Rust implementation.
+    n = len(entity_names)
+    node_to_idx = {name: idx for idx, name in enumerate(entity_names)}
+    seed_list = sorted(seeds)
+    adjacency_idx = []
+    degrees = []
+    for name in entity_names:
+        neighbors = adj.get(name, ())
+        degrees.append(len(neighbors))
+        adjacency_idx.append([node_to_idx[nb] for nb in neighbors if nb in node_to_idx])
+
+    import cognitive_rust
+    rust = list(
+        cognitive_rust.personalized_pagerank(
+            adjacency_idx, degrees, seed_list, PPR_DAMPING, iterations
+        )
     )
-    assert rust == pytest.approx(expected, abs=1e-12)
+    assert rust == pytest.approx(expected, abs=1e-12, rel=0)
 
     # Force the pure-Python fallback by making the Rust call raise.
     with patch(
@@ -65,7 +79,7 @@ def _assert_matches(entity_names, adj, seeds, iterations=3):
         fallback = MemoryStore._personalized_pagerank(
             entity_names, adj, seeds, PPR_DAMPING, iterations
         )
-    assert fallback == pytest.approx(expected, abs=1e-12)
+    assert fallback == pytest.approx(expected, abs=1e-12, rel=0)
     return rust
 
 

--- a/backend/tests/test_ppr_rust.py
+++ b/backend/tests/test_ppr_rust.py
@@ -54,7 +54,7 @@ def _assert_matches(entity_names, adj, seeds, iterations=3):
     expected = _py_reference(entity_names, adj, seeds, PPR_DAMPING, iterations)
 
     # Prepare the index-based structures needed by the Rust implementation.
-    n = len(entity_names)
+    len(entity_names)
     node_to_idx = {name: idx for idx, name in enumerate(entity_names)}
     seed_list = sorted(seeds)
     adjacency_idx = []


### PR DESCRIPTION
## What

Ports the HippoRAG-style **Personalized PageRank** spreading-activation power method out of `search_memories` (pure Python) and into the `cognitive_rust` crate — the last per-recall numeric hot loop still in Python. The ACT-R scoring loop (`score_memories_actr_sqlite`) already lives there; this completes plan item 10 (*"move the in-Python PageRank/ACT-R hot loop fully into the existing cognitive-rust crate for real determinism/latency"*).

## How

- **Rust** (`crates/cognitive-rust/src/lib.rs`): new `personalized_pagerank(adjacency, degrees, seeds, damping, iterations)` pyfunction implementing the 3-iteration power method; registered in the module.
- **Python** (`memory_store.py`): a new `_personalized_pagerank` static helper resolves entity names → indices once, calls the Rust function, and falls back to an **exact** pure-Python implementation if the extension is unavailable. The ~40-line inline loop at the call site collapses to a single helper call.

## Behavior preservation (important)

This is strictly behavior-preserving — no retrieval scores change. Two subtle legacy semantics are kept **on purpose**:

1. **Mass leakage** — each node's mass is divided by its *original* degree, so shares that point at graph entities absent from the candidate set leak out of the graph (not silently renormalized). The Rust contract therefore takes both resolved `adjacency` **and** per-node `degrees`.
2. **Dangling nodes** (degree 0) redistribute uniformly to the **seed set**, not the whole graph.

## Tests

- **Rust:** 4 unit tests — ring, dangling redistribution, mass-leakage, empty seeds (hand-computed expected values). `cargo test -p cognitive-rust` → 11 passed.
- **Python** (`tests/test_ppr_rust.py`): parity suite asserting the Rust path, the **forced** Python fallback, and a *verbatim copy of the pre-port loop* all agree to `1e-12` — across fixed cases (including the leakage case) and **25 randomized graphs** with injected out-of-set neighbors.
- Full backend suite green (exit 0); `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved memory retrieval ranking for faster and more efficient results.

* **Reliability**
  * Added a fallback path to preserve ranking behavior when the optimized processing engine is unavailable.
  * Preserved handling for dangling nodes, incomplete graph data, and empty seed sets.

* **Tests**
  * Added comprehensive validation to ensure consistent ranking results across processing paths and graph configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->