### PR TITLE
fix: batch of small robustness/maintainability fixes (A5, A7, E2, E3, F3, F4)

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -2224,3 +2224,68 @@ HippoRAG "~92% Recall@5", ACT-R/E "0.280 ToM MAE") against the cited papers
 themselves — still open from the prior audit entry; a full audit of
 `literature_references.md`'s ~30+ citations (out of scope for this pass, by
 explicit choice).
+
+---
+
+## 2026-07-18 A5, A7, E2, E3, F3, F4 resolved — batch of small robustness/maintainability fixes
+
+**A5 (brittle `is_sqlite` sniffing).** `MemoryStore.is_sqlite` matched
+`type(self.pool).__name__` against a hardcoded set of strings (`"MockPGPool"`,
+excluding `"MagicMock"/"AsyncMock"/"Mock"`) - any renamed/subclassed/new pool
+silently misclassified. Now checks a structural fact instead: whether
+`pool.connection.conn` is an actual stdlib `sqlite3.Connection` (the one thing
+the production `SQLitePool` and its test doubles genuinely share, since both
+wrap a real `sqlite3.connect(...)`). New `tests/test_memory_store_is_sqlite.py`
+covers a real pool, a generic `MagicMock`, a pool with no `.connection` at all,
+and a renamed `SQLitePool` subclass.
+
+**A7 (over-strict prosody validator).** `AgentVoiceModulation.validate_trajectory`
+required consecutive frame offsets to differ by *exactly* 50ms, rejecting the
+whole trajectory on any jitter. The only real producer
+(`generate_apra_trajectory` in `cognitive-rust`) does step in exact 50ms
+increments, but the contract only needs frames close enough together for smooth
+playback. Replaced the exact-equality check with strictly-increasing + a
+`MAX_FRAME_GAP_MS = 250` ceiling. `test_invalid_voice_modulation_wrong_cadence`
+(asserting a 40ms gap must fail) replaced with
+`test_voice_modulation_tolerates_jittered_cadence` plus explicit zero-gap and
+gap-too-large rejection tests.
+
+**E2 (brain_agent 512M memory limit).** The only service in
+`docker-compose.prod.yml` with an explicit memory cap was also the heaviest one
+(asyncpg pool, neo4j driver, embedding/LLM HTTP buffers, in-process caches) -
+every sibling service has no limit at all. Raised to a 2048M limit / 512M
+reservation. Verified with `docker compose -f docker-compose.infra.yml -f
+docker-compose.prod.yml config` (resolves to 2147483648 / 536870912 bytes).
+
+**E3 (LiveKit `http://` vs `ws://`).** `Config.LIVEKIT_URL` defaulted to
+`http://127.0.0.1:7880`, but both consumers (`useWebRTCVoice.js`'s
+`room.connect()` and `transport_agent.py`'s `room.connect()`) need `ws(s)://`.
+Fixed the default and both `.env.example` files, and added a
+`field_validator` on `LIVEKIT_URL` that rewrites `http(s)://` to `ws(s)://` so
+an existing deployment's already-saved `.env` self-heals instead of requiring
+a manual edit.
+
+**F3 (inline imports in hot handlers).** `brain_agent.py` re-imported
+`AudioStop`/`AudioResume`/`AudioPlaybackProgress`/`UserVoiceProperties` from
+`..contracts` (and `InterruptionClassifier`/`ConversationalRuntime` from
+`..utils`) inside the per-message handler methods and `__init__`. Hoisted all
+six to module-level imports; no circular-import issue (checked both `utils`
+modules import nothing back from `agents`).
+
+**F4 (`Config` metaclass `__getattr__` surprise).** `ConfigMeta.__getattr__`
+special-cased `ALLOWED_ORIGINS`/`OLLAMA_REQUIRED_MODELS` inline before falling
+back to `getattr(config_instance, name)` for everything else - a surprising
+place to hide derived config, easy to miss when adding a third computed value.
+Moved both to real `@computed_field @property` definitions on `AppSettings`
+itself; `ConfigMeta.__getattr__` is now just the one-line delegation. Behavior
+preserved exactly, including the pre-existing quirk that the explicit-CSV
+branch of `OLLAMA_REQUIRED_MODELS` does *not* dedupe (only the
+derived-from-individual-models branch does) - caught by an initial wrong test
+expectation, fixed after reproducing directly with `python -c`.
+
+Verification: `cd backend && python -m pytest` — all passed; `ruff check .`
+clean; compose config resolves.
+
+**NOT done:** F1 (`search_memories`/`ActionService.execute` god-functions,
+F2 already resolved in an earlier pass) — explicitly left for a separate
+pass, this batch was scoped to the smaller items only.

--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@
 LIVEKIT_API_KEY=your_api_key_here
 LIVEKIT_API_SECRET=your_api_secret_here
 LIVEKIT_KEYS="your_api_key: your_api_secret"
-LIVEKIT_URL=http://local_sfu:7880
+LIVEKIT_URL=ws://local_sfu:7880
 
 # PostgreSQL
 POSTGRES_PASSWORD=your_password_here

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,7 +9,7 @@ ALLOWED_ORIGINS=http://127.0.0.1:3000
 
 # Service Discovery (Internal Docker Mesh)
 NATS_URL=nats://nats_mesh:4222
-LIVEKIT_URL=http://local_sfu:7880
+LIVEKIT_URL=ws://local_sfu:7880
 OLLAMA_URL=http://host.docker.internal:11434
 SOVITS_URL=http://local_voice:9871
 

--- a/backend/app/agents/brain_agent.py
+++ b/backend/app/agents/brain_agent.py
@@ -12,8 +12,19 @@ from ..state import GraphDB, MemoryStore, ConversationHistoryStore
 from ..config import Config
 from ..cognitive import CognitiveService
 from ..runtime_bootstrap import bootstrap_runtime
-from ..contracts import ChatInput, ChatOutput, ChatOutputAffect, Topics
+from ..contracts import (
+    AudioPlaybackProgress,
+    AudioResume,
+    AudioStop,
+    ChatInput,
+    ChatOutput,
+    ChatOutputAffect,
+    Topics,
+    UserVoiceProperties,
+)
 from ..logging_config import setup_logging
+from ..utils.conversational_runtime import ConversationalRuntime
+from ..utils.interruption_classifier import InterruptionClassifier
 from ..utils.segmentation import HybridSegmenter
 from ..utils.speech import SpeechCoordinator
 
@@ -56,9 +67,6 @@ class BrainAgent(BaseAgent):
         self.coordinator = SpeechCoordinator(
             segmenter=HybridSegmenter(target_size=7), formation_buffer_ms=0.030
         )
-        from ..utils.interruption_classifier import InterruptionClassifier
-        from ..utils.conversational_runtime import ConversationalRuntime
-
         self.interruption_classifier = InterruptionClassifier()
         self.conversational_runtime = ConversationalRuntime(publish_cb=self.publish)
         self._active_generation_task = None
@@ -194,8 +202,6 @@ class BrainAgent(BaseAgent):
 
         # If it is not a subconscious pulse, publish a confirmed stop to silence any playing voice agent audio
         if not is_subconscious:
-            from ..contracts import AudioStop
-
             stop_msg = AudioStop(
                 interrupt=True,
                 speculative=False,
@@ -352,8 +358,6 @@ class BrainAgent(BaseAgent):
                 )
 
                 # Instantly publish confirmed audio.stop to silence playback
-                from ..contracts import AudioStop
-
                 stop_msg = AudioStop(
                     interrupt=True,
                     speculative=False,
@@ -375,8 +379,6 @@ class BrainAgent(BaseAgent):
                     self._active_generation_task.cancel()
             else:
                 # Not a valid semantic interruption! Send an audio resume to restore volume.
-                from ..contracts import AudioResume
-
                 resume_msg = AudioResume(
                     reason="not_interruption",
                     perception_text=text,
@@ -387,8 +389,6 @@ class BrainAgent(BaseAgent):
     async def _on_audio_playback_progress(self, data: Dict[str, Any]):
         """Tracks the current word/character progress of the audio playback."""
         try:
-            from ..contracts import AudioPlaybackProgress
-
             progress = AudioPlaybackProgress.model_validate(data)
             self.last_audio_progress = progress
             logger.debug(
@@ -400,8 +400,6 @@ class BrainAgent(BaseAgent):
     async def _on_audio_stop(self, data: Dict[str, Any]):
         """Handles confirmed audio stops to truncate the last played utterance in history."""
         try:
-            from ..contracts import AudioStop
-
             stop_msg = AudioStop.model_validate(data)
 
             # Truncation only happens on confirmed (non-speculative) interrupts
@@ -447,8 +445,6 @@ class BrainAgent(BaseAgent):
     async def _on_user_voice_properties(self, data: Dict[str, Any]):
         """Ingest real-time user voice properties (System 1 feature stream)."""
         try:
-            from ..contracts import UserVoiceProperties
-
             props = UserVoiceProperties.model_validate(data)
             self.last_user_voice_properties = props
             logger.debug(

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from typing import List, Optional
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from pydantic import Field, model_validator
+from pydantic import Field, computed_field, field_validator, model_validator
 
 _env_file = Path(__file__).resolve().parent.parent.parent / ".env"
 
@@ -36,7 +36,7 @@ class AppSettings(BaseSettings):
     QDRANT_PORT: int = 6333
 
     # LiveKit Configuration
-    LIVEKIT_URL: str = "http://127.0.0.1:7880"
+    LIVEKIT_URL: str = "ws://127.0.0.1:7880"
     LIVEKIT_API_KEY: Optional[str] = None
     LIVEKIT_API_SECRET: Optional[str] = None
 
@@ -148,31 +148,57 @@ class AppSettings(BaseSettings):
             self.LLM_REFLECTION_MODEL = self.LLM_CHAT_MODEL
         return self
 
+    @field_validator("LIVEKIT_URL")
+    @classmethod
+    def normalize_livekit_scheme(cls, v: str) -> str:
+        """E3: both the frontend and transport_agent hand this straight to
+        LiveKit's room.connect(), which needs ws(s)://, not http(s)://. Normalize
+        here so an existing .env carrying the old http:// default (from before
+        this fix) self-heals instead of requiring every deployment to be
+        manually edited.
+        """
+        if v.startswith("https://"):
+            return "wss://" + v[len("https://") :]
+        if v.startswith("http://"):
+            return "ws://" + v[len("http://") :]
+        return v
+
+    # F4: these were previously computed in ConfigMeta.__getattr__, which
+    # special-cased these two names and silently delegated every other
+    # attribute straight to config_instance - a surprising place to look for
+    # derived config, and easy to miss when adding a third computed value.
+    # Real computed_field properties are visible on AppSettings itself, so
+    # ConfigMeta's job shrinks to "look up the instance," nothing more.
+    @computed_field
+    @property
+    def ALLOWED_ORIGINS(self) -> List[str]:
+        return self.ALLOWED_ORIGINS_STR.split(",")
+
+    @computed_field
+    @property
+    def OLLAMA_REQUIRED_MODELS(self) -> List[str]:
+        if self.OLLAMA_REQUIRED_MODELS_STR.strip():
+            return [
+                model.strip()
+                for model in self.OLLAMA_REQUIRED_MODELS_STR.split(",")
+                if model.strip()
+            ]
+        models = [
+            self.LLM_CHAT_MODEL,
+            self.LLM_FAST_MODEL,
+            self.LLM_REFLECTION_MODEL,
+            "nomic-embed-text",
+        ]
+        if self.VLM_ENABLED:
+            models.append(self.VLM_MODEL)
+        return list(dict.fromkeys(models))
+
 
 config_instance = AppSettings()
 
 
 class ConfigMeta(type):
     def __getattr__(cls, name):
-        if name == "ALLOWED_ORIGINS":
-            return config_instance.ALLOWED_ORIGINS_STR.split(",")
-        if name == "OLLAMA_REQUIRED_MODELS":
-            if config_instance.OLLAMA_REQUIRED_MODELS_STR.strip():
-                return [
-                    model.strip()
-                    for model in config_instance.OLLAMA_REQUIRED_MODELS_STR.split(",")
-                    if model.strip()
-                ]
-            else:
-                models = [
-                    config_instance.LLM_CHAT_MODEL,
-                    config_instance.LLM_FAST_MODEL,
-                    config_instance.LLM_REFLECTION_MODEL,
-                    "nomic-embed-text",
-                ]
-                if config_instance.VLM_ENABLED:
-                    models.append(config_instance.VLM_MODEL)
-                return list(dict.fromkeys(models))
         return getattr(config_instance, name)
 
 

--- a/backend/app/contracts.py
+++ b/backend/app/contracts.py
@@ -17,7 +17,7 @@ Usage:
 from __future__ import annotations
 
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 from pydantic import BaseModel, Field, field_validator
 
 
@@ -247,6 +247,13 @@ class ProsodyFrame(BaseModel):
 class AgentVoiceModulation(BaseModel):
     model_config = {"extra": "allow"}
 
+    # A7: the reference generator (generate_apra_trajectory, cognitive-rust)
+    # steps in exactly 50ms increments, but the contract only needs frames close
+    # enough together for smooth playback - not that exact grid. A hard "==50"
+    # check made any jitter or resampling (e.g. a future non-Rust producer, or a
+    # frame dropped/merged in transit) reject the *entire* trajectory.
+    MAX_FRAME_GAP_MS: ClassVar[int] = 250
+
     trajectory: List[ProsodyFrame] = Field(..., min_length=1)
     timestamp: float = Field(default_factory=time.time)
 
@@ -258,12 +265,17 @@ class AgentVoiceModulation(BaseModel):
         if v[0].time_offset_ms < 0:
             raise ValueError("First offset must be >= 0.")
         for i in range(1, len(v)):
-            if v[i].time_offset_ms < v[i - 1].time_offset_ms:
+            gap = v[i].time_offset_ms - v[i - 1].time_offset_ms
+            if gap <= 0:
                 raise ValueError(
-                    "Trajectory must be ordered by time_offset_ms ascending."
+                    "Trajectory must be strictly ordered by time_offset_ms ascending."
                 )
-            if v[i].time_offset_ms - v[i - 1].time_offset_ms != 50:
-                raise ValueError("Consecutive frames must differ by exactly 50 ms.")
+            if gap > AgentVoiceModulation.MAX_FRAME_GAP_MS:
+                raise ValueError(
+                    "Consecutive frames must be no more than "
+                    f"{AgentVoiceModulation.MAX_FRAME_GAP_MS} ms apart "
+                    f"(got {gap} ms)."
+                )
         return v
 
 

--- a/backend/app/state/memory_store.py
+++ b/backend/app/state/memory_store.py
@@ -17,6 +17,7 @@ import asyncio
 import httpx
 import orjson
 import math
+import sqlite3
 from collections import OrderedDict
 from datetime import datetime, timezone, timedelta
 from typing import Iterable
@@ -160,11 +161,20 @@ class MemoryStore:
 
     @property
     def is_sqlite(self) -> bool:
-        """Heuristic check to determine if the backing pool uses the Mock SQLite adaptor."""
-        return type(self.pool).__name__ == "MockPGPool" or (
-            hasattr(self.pool, "connection")
-            and type(self.pool).__name__ not in ("MagicMock", "AsyncMock", "Mock")
-        )
+        """Whether the backing pool is actually a stdlib sqlite3 connection under
+        the hood (SQLitePool, or a test double shaped like it), rather than real
+        asyncpg/Postgres.
+
+        A5: previously sniffed type(self.pool).__name__ against a hardcoded set
+        of class names ("MockPGPool", excluding "MagicMock"/"AsyncMock"/"Mock").
+        Any pool class not on that exact list - a rename, a subclass, a new test
+        double - silently misclassified and routed to the wrong SQL dialect.
+        Checking what pool.connection.conn actually *is* (a real sqlite3.Connection,
+        the one thing both the production SQLitePool and its test doubles genuinely
+        share) is a structural fact instead of a name-matching guess.
+        """
+        conn = getattr(self.pool, "connection", None)
+        return isinstance(getattr(conn, "conn", None), sqlite3.Connection)
 
     @staticmethod
     def _as_aware_utc(dt):

--- a/backend/tests/test_memory_store_is_sqlite.py
+++ b/backend/tests/test_memory_store_is_sqlite.py
@@ -1,0 +1,48 @@
+"""
+A5 regression: MemoryStore.is_sqlite must key off what the pool's connection
+actually is (a real sqlite3.Connection), not a hardcoded set of class-name
+strings that silently misclassifies any pool it doesn't recognize.
+"""
+
+from unittest.mock import MagicMock
+
+from app.state.memory_store import MemoryStore
+from app.state.sqlite_fallback import SQLitePool
+
+
+def _make_store(pool):
+    store = MemoryStore(pool, MagicMock())
+    store.qdrant_store.client = None
+    return store
+
+
+def test_is_sqlite_true_for_real_sqlite_pool():
+    store = _make_store(SQLitePool(":memory:"))
+    assert store.is_sqlite is True
+
+
+def test_is_sqlite_false_for_generic_pool_mock():
+    # A bare MagicMock auto-vivifies any attribute access (including
+    # .connection.conn), so the old name-based check needed to special-case
+    # "MagicMock"/"AsyncMock"/"Mock" explicitly. The structural check doesn't.
+    store = _make_store(MagicMock())
+    assert store.is_sqlite is False
+
+
+def test_is_sqlite_false_for_pool_with_no_connection_attribute():
+    class BarePool:
+        async def close(self):
+            pass
+
+    store = _make_store(BarePool())
+    assert store.is_sqlite is False
+
+
+def test_is_sqlite_true_for_renamed_sqlite_pool_subclass():
+    # A5's core complaint: a renamed/subclassed SQLite pool used to be silently
+    # misdetected because the check matched on type(pool).__name__.
+    class CustomSQLitePool(SQLitePool):
+        pass
+
+    store = _make_store(CustomSQLitePool(":memory:"))
+    assert store.is_sqlite is True

--- a/backend/tests/test_regressions.py
+++ b/backend/tests/test_regressions.py
@@ -263,6 +263,71 @@ def test_action_service_strips_emotion_wrappers_but_keeps_pause_tags():
     assert content == "hey there<pause=300ms>"
 
 
+def test_config_normalizes_livekit_url_scheme_to_websocket():
+    # E3: room.connect() (both the JS frontend and transport_agent's Python RTC
+    # client) needs ws(s)://, not http(s)://. An existing .env still carrying the
+    # old http:// default must self-heal rather than silently breaking connects.
+    from app.config import AppSettings
+
+    assert AppSettings(LIVEKIT_URL="http://local_sfu:7880").LIVEKIT_URL == (
+        "ws://local_sfu:7880"
+    )
+    assert AppSettings(LIVEKIT_URL="https://sfu.example.com").LIVEKIT_URL == (
+        "wss://sfu.example.com"
+    )
+    assert AppSettings(LIVEKIT_URL="ws://already-correct:7880").LIVEKIT_URL == (
+        "ws://already-correct:7880"
+    )
+
+
+def test_config_allowed_origins_computed_field_splits_csv():
+    # F4: ALLOWED_ORIGINS used to be materialized only inside
+    # ConfigMeta.__getattr__'s special-casing; it's now a real computed_field
+    # on AppSettings, visible on the model itself.
+    from app.config import AppSettings
+
+    assert AppSettings(ALLOWED_ORIGINS="*").ALLOWED_ORIGINS == ["*"]
+    assert AppSettings(
+        ALLOWED_ORIGINS="http://a.example.com,http://b.example.com"
+    ).ALLOWED_ORIGINS == ["http://a.example.com", "http://b.example.com"]
+
+
+def test_config_ollama_required_models_computed_field():
+    from app.config import AppSettings
+
+    # An explicit CSV is stripped/filtered but not deduped (only the
+    # derived-from-individual-models branch below dedupes) - preserved as-is
+    # from the pre-refactor behavior.
+    explicit = AppSettings(OLLAMA_REQUIRED_MODELS="modelA, modelB ,modelA")
+    assert explicit.OLLAMA_REQUIRED_MODELS == ["modelA", "modelB", "modelA"]
+
+    # OLLAMA_REQUIRED_MODELS="" forces the "derive from individual models"
+    # branch, overriding whatever the real .env on this machine may set.
+    derived = AppSettings(
+        OLLAMA_REQUIRED_MODELS="",
+        LLM_FAST_MODEL="fast-model",
+        LLM_CHAT_MODEL="chat-model",
+        LLM_REFLECTION_MODEL="reflect-model",
+        VLM_ENABLED=True,
+        VLM_MODEL="vision-model",
+    )
+    assert derived.OLLAMA_REQUIRED_MODELS == [
+        "chat-model",
+        "fast-model",
+        "reflect-model",
+        "nomic-embed-text",
+        "vision-model",
+    ]
+
+    derived_vlm_off = AppSettings(
+        OLLAMA_REQUIRED_MODELS="",
+        LLM_FAST_MODEL="fast-model",
+        LLM_CHAT_MODEL="fast-model",
+        VLM_ENABLED=False,
+    )
+    assert derived_vlm_off.OLLAMA_REQUIRED_MODELS == ["fast-model", "nomic-embed-text"]
+
+
 def test_signaling_lan_guard_allows_only_loopback_and_private_clients():
     from app.network import is_lan_client_allowed
 

--- a/backend/tests/test_voice_modulation.py
+++ b/backend/tests/test_voice_modulation.py
@@ -42,11 +42,34 @@ def test_invalid_voice_modulation_unordered():
         )
 
 
-def test_invalid_voice_modulation_wrong_cadence():
+def test_voice_modulation_tolerates_jittered_cadence():
+    # A7: real producers (resampling, a non-Rust generator) won't always land on
+    # an exact 50ms grid. A gap that's merely jittery, not pathological, is fine.
+    modulation = AgentVoiceModulation(
+        trajectory=[
+            ProsodyFrame(time_offset_ms=0, rate=1.0, pitch=1.0, volume=0.5),
+            ProsodyFrame(time_offset_ms=40, rate=1.1, pitch=1.0, volume=0.6),
+            ProsodyFrame(time_offset_ms=95, rate=1.2, pitch=1.0, volume=0.6),
+        ]
+    )
+    assert [f.time_offset_ms for f in modulation.trajectory] == [0, 40, 95]
+
+
+def test_invalid_voice_modulation_zero_gap():
+    with pytest.raises(ValidationError):
+        AgentVoiceModulation(
+            trajectory=[
+                ProsodyFrame(time_offset_ms=50, rate=1.0, pitch=1.0, volume=0.5),
+                ProsodyFrame(time_offset_ms=50, rate=1.1, pitch=1.0, volume=0.6),
+            ]
+        )
+
+
+def test_invalid_voice_modulation_gap_too_large():
     with pytest.raises(ValidationError):
         AgentVoiceModulation(
             trajectory=[
                 ProsodyFrame(time_offset_ms=0, rate=1.0, pitch=1.0, volume=0.5),
-                ProsodyFrame(time_offset_ms=40, rate=1.1, pitch=1.0, volume=0.6),
+                ProsodyFrame(time_offset_ms=5000, rate=1.1, pitch=1.0, volume=0.6),
             ]
         )

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -56,7 +56,15 @@ services:
 
     deploy:
       resources:
+        # E2: brain_agent is the only service in this file with an explicit cap,
+        # yet it's the heaviest one - the full cognitive pipeline (asyncpg pool,
+        # neo4j bolt driver, embedding/LLM HTTP buffers, in-process memory cache)
+        # runs here, while every sibling service below has no limit at all. 512M
+        # was measured tight even in a light benchmark run; give it real headroom
+        # instead of a cap likely to OOM-kill mid-session under sustained load.
         limits:
+          memory: 2048M
+        reservations:
           memory: 512M
     restart: always
     healthcheck:
@@ -206,7 +214,7 @@ services:
     command: [ "python", "-m", "app.agents.transport_agent" ]
     environment:
       - NATS_URL=nats://nats_mesh:4222
-      - LIVEKIT_URL=http://local_sfu:7880
+      - LIVEKIT_URL=ws://local_sfu:7880
       - LIVEKIT_API_KEY=${LIVEKIT_API_KEY}
       - LIVEKIT_API_SECRET=${LIVEKIT_API_SECRET}
       - TRANSPORT_AUDIO_QUEUE_SIZE=${TRANSPORT_AUDIO_QUEUE_SIZE:-1024}


### PR DESCRIPTION
## Summary
- A5: `MemoryStore.is_sqlite` now checks whether `pool.connection.conn` is a real `sqlite3.Connection` instead of sniffing the pool's class name against a hardcoded list.
- A7: `AgentVoiceModulation`'s frame-timing validator tolerates jitter (strictly-increasing + 250ms max gap) instead of requiring exactly 50ms between frames.
- E2: `brain_agent`'s Docker memory limit raised from 512M to a 2048M limit / 512M reservation - it was the only capped service despite being the heaviest.
- E3: `Config.LIVEKIT_URL` now defaults to `ws://` (both `room.connect()` call sites need it), with a validator that normalizes an existing `.env`'s `http(s)://` automatically.
- F3: hoisted repeated inline imports out of `brain_agent.py`'s hot per-message handlers to module scope.
- F4: replaced `ConfigMeta.__getattr__`'s inline special-casing of `ALLOWED_ORIGINS`/`OLLAMA_REQUIRED_MODELS` with real `computed_field` properties on `AppSettings`.

## Test plan
- [x] `cd backend && python -m pytest` - full suite green
- [x] `ruff check .` - clean
- [x] `docker compose -f docker-compose.infra.yml -f docker-compose.prod.yml config` - resolves correctly (2048M/512M confirmed in bytes)
- [x] New regression tests: `test_memory_store_is_sqlite.py`, voice-modulation jitter/gap tests, LiveKit URL scheme normalization, `ALLOWED_ORIGINS`/`OLLAMA_REQUIRED_MODELS` computed-field tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * LiveKit connections now use the appropriate WebSocket protocol, with automatic correction for legacy URL schemes.
  * Voice modulation accepts minor timing jitter while rejecting invalid or excessively large gaps.
  * Configuration handling is more resilient, including clearer origin and model settings behavior.
  * Added a memory limit for the production brain service.
  * Improved SQLite detection reliability across different connection pool implementations.

* **Tests**
  * Added regression coverage for configuration normalization, SQLite detection, and voice-timing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->