### PR TITLE
refactor(memory,cognitive): decompose both god-functions (F1)

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -2335,3 +2335,99 @@ clean; compose config resolves.
 **NOT done:** F1 (`search_memories`/`ActionService.execute` god-functions,
 F2 already resolved in an earlier pass) — explicitly left for a separate
 pass, this batch was scoped to the smaller items only.
+
+---
+
+## 2026-07-18 F1 resolved — both god-functions decomposed, behavior proven unchanged
+
+The last open item from the original audit, and the one flagged as "the riskiest
+area to touch." Both functions were split into named stages **with no behavioral
+change**, which was proven rather than assumed (see Verification below).
+
+### `MemoryStore.search_memories`: 1623 → 248 lines (-84%)
+
+It fused L1 caching, Qdrant retrieval, two SQL dialects, cue extraction, graph
+building, pronoun resolution, PageRank spreading activation, archive promotion
+and result formatting into one body. Now an orchestrator over:
+`_compute_mrl_gating`, `_detect_topic_shift`, `_gather_candidate_sources`,
+`_score_qdrant_candidates` (+`_fetch_candidate_db_metadata`,
+`_coerce_last_recall_ts`), `_fetch_sqlite_candidates` (+`_normalize_recall_ts`),
+`_fetch_postgres_candidates` (+`_fetch_surface_actr_rows`),
+`_resolve_dynamic_stop_words`, `_build_entity_graph`, `_resolve_identity_nodes`,
+`_resolve_pronoun_cues`, `_apply_direct_cue_boost`,
+`_apply_ppr_spreading_activation` (+`_collect_ppr_seeds`,
+`_map_candidate_entities`), `_apply_goal_buffer_boost`, `_format_results`, and
+`_recall_from_archive` (+`_expand_archive_cues`, `_fetch_archive_rows`,
+`_rank_archive_rows`, `_promote_archived_rows`, `_write_promoted_memory`,
+`_build_promotion_payload`, `_archive_row_activation`,
+`_parse_stored_embedding`, `_archive_similarity_fallback`).
+
+Hoisted out of the hot path: the 188-word stop-word literal, which was being
+rebuilt on *every single call*, now the module-level `SEARCH_STOP_WORDS`
+frozenset — membership proven identical by `exec`-ing the old literal out of git
+and diffing the sets (188 == 188, empty symmetric difference). Also hoisted: the
+pronoun sets, the four repeated SQL literals, and `re`/`json`/`uuid` (same
+cleanup as F3 in `brain_agent`). `import cognitive_rust` deliberately stays
+lazy — it is an optional compiled extension and a module-level import would
+break importing `MemoryStore` wherever it is not built.
+
+One real duplication removed: the archive-promotion path carried an inline copy
+of the effective-similarity formula. Its constants (`0.1`, `0.2`) are exactly
+`ACTR_VALENCE_GAIN` / `ACTR_STRESS_SUPPRESSION`, so it now calls the shared
+`_effective_similarity` — verified numerically equivalent before the swap.
+
+Subtlety preserved deliberately: the SQLite branch rebinds the enclosing
+`now_ts`, and *that* value is what stamps the L1 cache entry. The extracted
+helper therefore returns `(candidates, now_ts)` rather than letting the caller's
+value stand, so cache timestamps behave exactly as before.
+
+### `ActionService.execute`: 523 → 24 lines (-95%)
+
+Now a dispatcher over `_execute_respond_chat` / `_execute_store_memory`. The
+chat path splits into `_surface_fallback_memories`, `_build_shared_history`,
+`_build_tom_context`, `_compute_endocrine_options`, `_prepended_affect_tag`,
+`_split_thought`, `_emit_validated`, `_stream_primary_response`,
+`_announce_self_correction` and `_stream_self_correction`.
+
+The "maybe inject a hesitation → build candidate → System-3 validate → yield →
+accumulate" block appeared **six times**; it is now `_emit_validated` with an
+`allow_hesitation` flag (the two trailing-flush sites deliberately skip
+hesitation, matching the original). Streaming state moved into a
+`_ChatStreamState` holder. The static half of the system prompt became
+`_CHAT_GUIDELINE` at module scope — extracted via AST from the original f-string
+and proven to reconstruct it byte-for-byte (944 chars).
+
+### Verification — how "no behavior change" was actually established
+
+Not "the tests still pass." Two purpose-built equivalence harnesses:
+
+- **search_memories:** a characterization harness snapshotting exact output over
+  17 scenarios (pronoun resolution both directions, PPR spreading, cue boost,
+  goal-buffer priming across a topic-shift sequence, all three MRL stress tiers,
+  exclusions, thresholds, limits, room filter, no-user_id, stop-word-only query),
+  run before and after → **byte-identical JSON**.
+- **execute:** the pre-refactor module restored from git as a sibling module and
+  driven side-by-side with the new one over 29 scenarios — CoT split across
+  chunks, hesitation budget exhaustion, emotion-tag sanitization, partial tags
+  spanning chunks, all four System-3 violation classes, grounding failure,
+  retry-also-fails fallback, endocrine variants including bad types, ToM edge
+  cases, LLM exceptions, and every non-chat action type — comparing the full
+  emitted chunk sequence, the exact prompts/options handed to the LLM, and the
+  published interrupt events. **All 29 identical.**
+
+New `tests/test_f1_decomposed_stages.py` (42 tests) locks in the extracted
+stages — none of which were reachable in isolation before this refactor, which
+is the whole point of F1. Mutation-checked on both sides (a broken MRL tier and
+a dropped hesitation flag) to confirm the suite detects regressions rather than
+passing vacuously.
+
+Full backend suite: **317 passed** (275 + 42 new). `ruff check .` clean.
+
+**NOT done:** the retrieval pipeline is now decomposed but still runs in-process;
+moving more of the ACT-R/PPR hot loop into the Rust crate (Tier-3 item 10 of the
+original plan) remains open. The archive-promotion path still does per-row SQL
+inside a loop — correct, but a batching opportunity now that it is isolated in
+`_promote_archived_rows`.
+
+With this, every finding from the original audit (A1-A7, B1-B3, C1-C4, D1-D4,
+E1-E3, F1-F4) is either resolved or explicitly accepted.

--- a/backend/app/cognitive/action.py
+++ b/backend/app/cognitive/action.py
@@ -54,6 +54,60 @@ _GROUNDING_STOPWORDS = frozenset(
 )
 
 
+# Static half of the chat system prompt, appended after the identity block.
+# Hoisted out of execute() so the prompt contract is visible at module scope
+# rather than buried mid-function.
+_CHAT_GUIDELINE = (
+    "Guideline:\n"
+    "- Maintain your identity rules at all times.\n"
+    "- Focus on natural conversational phrases.\n"
+    "- IMPORTANT: If the SHARED HISTORY / RECENT CONTEXT contains relevant "
+    "biographical facts, partner details, childhood milestones, or personal "
+    "preferences, you MUST integrate them explicitly and accurately to answer "
+    "the user's question.\n"
+    "- GROUNDING: Base any specific claim about the user, your shared past, "
+    "names, dates, places, or events ONLY on the SHARED HISTORY / RECENT "
+    "CONTEXT provided. Do not invent memories or details that are not there. "
+    "If the user asks about something you have no memory of, say so naturally "
+    '(e.g. "I don\'t think you\'ve told me that") instead of making it up.\n'
+    "- Respond only in English. Do not use Hindi, Hinglish, or any other "
+    "language for now.\n"
+    "- The voice layer already carries emotion separately. Do not emit XML "
+    "wrappers or emotion tags.\n"
+    "- You may use <pause=300ms> or <hesitate> when it improves natural timing."
+)
+
+# Spoken when self-correction cannot produce a compliant reply.
+_SAFE_FALLBACK_LINE = "I need a moment to gather my thoughts..."
+
+
+class _ChatStreamState:
+    """Mutable state threaded through the chat streaming loop.
+
+    Chunk handling needs to carry accumulated text, chain-of-thought parsing
+    position and whether the one allowed hesitation has been spent. Bundling
+    them keeps the per-chunk helpers free of long parameter lists and makes it
+    explicit which state the loop actually mutates.
+    """
+
+    __slots__ = (
+        "accumulated_response",
+        "in_thought",
+        "thought_buffer",
+        "checked_start",
+        "has_hesitated",
+        "dominance",
+    )
+
+    def __init__(self, dominance: float = 0.5):
+        self.accumulated_response = ""
+        self.in_thought = False
+        self.thought_buffer = ""
+        self.checked_start = False
+        self.has_hesitated = False
+        self.dominance = dominance
+
+
 def _memory_relevance(memory: Dict[str, Any]) -> float:
     """Relevance value used to order a surfaced memory.
 
@@ -222,6 +276,523 @@ class ActionService:
 
         return True, ""
 
+    # ------------------------------------------------------------------
+    # RESPOND_CHAT stages (F1)
+    #
+    # execute() was a ~520-line god-function interleaving memory surfacing,
+    # prompt assembly, endocrine sampling math, CoT thought-stripping,
+    # paralinguistic injection, per-chunk validation, grounding checks and a
+    # full self-correction retry loop. The same
+    # hesitate -> validate -> yield -> accumulate block appeared six times.
+    # The stages below are that same behavior, named and de-duplicated.
+    # ------------------------------------------------------------------
+
+    async def _surface_fallback_memories(self, plan: ActionPlan, msg: str) -> list:
+        """Synchronous recall fallback when no memories were pre-surfaced.
+
+        Prevents a race in low-latency/benchmark modes where the async
+        surfacing agent has not answered yet by the time we need context.
+        """
+        try:
+            fallback_memories = await self.memory.search_memories(
+                query_text=msg,
+                wing="personal",
+                limit=3,
+                refresh_on_recall=False,
+                current_valence=plan.payload.get("valence", 0.0),
+                current_arousal=plan.payload.get("arousal", 0.5),
+                current_cortisol=plan.payload.get("cortisol", 0.0),
+            )
+            if fallback_memories:
+                logger.info(
+                    f"⚡ [Action] Synchronous recall fallback surfaced {len(fallback_memories)} memories."
+                )
+                return fallback_memories
+        except Exception as fe:
+            logger.warning(f"Failed to run synchronous memory surfacing fallback: {fe}")
+        return []
+
+    @staticmethod
+    def _build_shared_history(surfaced: list) -> str:
+        """Render surfaced memories, edge-loaded against lost-in-the-middle."""
+        if not surfaced:
+            return ""
+        ordered = reorder_for_long_context(surfaced)
+        return "\nSHARED HISTORY / RECENT CONTEXT (Active Influence):\n" + "\n".join(
+            [f"- {m['content']}" for m in ordered]
+        )
+
+    @staticmethod
+    def _build_tom_context(user_tom) -> str:
+        """Render the Theory-of-Mind block describing the inferred user state."""
+        if not user_tom:
+            return ""
+        inferred_val = user_tom.get("inferred_valence", 0.0)
+        inferred_ar = user_tom.get("inferred_arousal", 0.5)
+        impl_goals = user_tom.get("implied_goals", [])
+        if not isinstance(impl_goals, list):
+            logger.warning(
+                f"[Action] Unexpected type for implied_goals in user_mental_model: {type(impl_goals)}. Falling back to empty list."
+            )
+            impl_goals = []
+        # Take the last 10 known concepts to keep it concise and avoid context bloat
+        known_con = user_tom.get("known_concepts", [])[-10:]
+
+        tom_context = "\n\nYour Inferred Perspective of the User (Theory of Mind):\n"
+        tom_context += (
+            f"- User Inferred Valence: {inferred_val:.2f} (Scale: -1.0 to 1.0)\n"
+        )
+        tom_context += (
+            f"- User Inferred Arousal: {inferred_ar:.2f} (Scale: 0.0 to 1.0)\n"
+        )
+        if impl_goals:
+            tom_context += f"- User Implied Goals: {', '.join(impl_goals)}\n"
+        if known_con:
+            tom_context += f"- User Known Concepts (Respect this knowledge boundary): {', '.join(known_con)}\n"
+        return tom_context
+
+    @staticmethod
+    def _compute_endocrine_options(payload: Dict[str, Any]):
+        """Map the endocrine state onto LLM sampling parameters.
+
+        cortisol -> temperature (stress narrows sampling), dopamine -> top_p
+        (reward widens it), fatigue -> num_predict (tiredness shortens replies).
+        Returns None when no endocrine signal is present at all, leaving the
+        model on its defaults.
+        """
+        cortisol = payload.get("cortisol")
+        dopamine = payload.get("dopamine")
+        fatigue = payload.get("fatigue")
+
+        if cortisol is None and dopamine is None and fatigue is None:
+            return None
+
+        endocrine_options = {}
+        if cortisol is not None:
+            try:
+                endo_temperature = max(
+                    0.0, min(1.0, round(0.9 - (float(cortisol) * 0.6), 3))
+                )
+            except (ValueError, TypeError):
+                endo_temperature = 0.7
+            endocrine_options["temperature"] = endo_temperature
+        else:
+            endocrine_options["temperature"] = 0.7
+
+        if dopamine is not None:
+            try:
+                endo_top_p = max(0.0, min(1.0, round(0.70 + (float(dopamine) * 0.25), 3)))
+            except (ValueError, TypeError):
+                endo_top_p = 0.8
+            endocrine_options["top_p"] = endo_top_p
+        else:
+            endocrine_options["top_p"] = 0.8
+
+        try:
+            fatigue_val = max(
+                0.0, min(1.0, float(fatigue if fatigue is not None else 0.0))
+            )
+        except (ValueError, TypeError):
+            fatigue_val = 0.0
+
+        # Bounded num_predict strictly between 100 (exhausted) and 250 (fresh)
+        endocrine_options["num_predict"] = int(
+            max(100, min(250, int(250 - (fatigue_val * 150))))
+        )
+
+        logger.info(
+            "[Endocrine] Cortisol=%s Dopamine=%s Fatigue=%s → temp=%.3f top_p=%.3f num_predict=%d",
+            cortisol,
+            dopamine,
+            fatigue,
+            endocrine_options["temperature"],
+            endocrine_options["top_p"],
+            endocrine_options["num_predict"],
+        )
+        return endocrine_options
+
+    @staticmethod
+    def _prepended_affect_tag(arousal: float, valence: float) -> str:
+        """Non-verbal breath/sigh opener implied by the current affect."""
+        if arousal > 0.6 and valence < -0.3:
+            return "<breath_fast> "
+        if arousal < 0.4 and valence < 0.0:
+            return "<sigh_soft> "
+        return ""
+
+    @staticmethod
+    def _split_thought(thought_buffer: str):
+        """Split a completed <thought>...</thought> block off the buffer.
+
+        Returns the content that follows the closing tag; the reasoning itself
+        is logged, never spoken.
+        """
+        parts = thought_buffer.split("</thought>", 1)
+        thought_content = parts[0].replace("<thought>", "").strip()
+        logger.info(f"[CoT Thought] {thought_content}")
+        return parts[1]
+
+    async def _emit_validated(
+        self, text: str, state: "_ChatStreamState", goal: str, allow_hesitation: bool = True
+    ):
+        """Validate a piece of pending speech, then emit and accumulate it.
+
+        This single helper replaces six near-identical inline copies of
+        "maybe inject a hesitation, build the candidate utterance, run the
+        System-3 check, yield, accumulate". Raises MetacognitiveException so
+        the caller's self-correction path takes over.
+        """
+        if (
+            allow_hesitation
+            and state.dominance < 0.4
+            and not state.has_hesitated
+            and "," in text
+        ):
+            text = text.replace(",", " <hesitate>,", 1)
+            state.has_hesitated = True
+
+        candidate = state.accumulated_response + text
+        is_valid, reason = self._validate_partial_response(candidate, goal)
+        if not is_valid:
+            raise MetacognitiveException(reason)
+
+        yield {"type": "content", "data": text}
+        state.accumulated_response = candidate
+
+    async def _stream_primary_response(
+        self,
+        *,
+        plan: ActionPlan,
+        user_prompt: str,
+        system_instruction: str,
+        model,
+        endocrine_options,
+        sanitizer: "ControlMarkupSanitizer",
+        stream_budget: int,
+        state: "_ChatStreamState",
+        surfaced: list,
+        msg: str,
+    ):
+        """Stream the first-pass reply, stripping CoT and validating as it goes."""
+        stream_iter = self.llm.generate_stream(
+            prompt=user_prompt,
+            system=system_instruction,
+            model=model,
+            options_override=endocrine_options,
+        ).__aiter__()
+        deadline = time.monotonic() + stream_budget
+
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise asyncio.TimeoutError()
+
+            try:
+                chunk = await asyncio.wait_for(
+                    stream_iter.__anext__(), timeout=remaining
+                )
+            except StopAsyncIteration:
+                break
+
+            clean_chunk = sanitizer.feed(chunk)
+            if not clean_chunk:
+                continue
+
+            # CoT strip check
+            if not state.checked_start:
+                state.thought_buffer += clean_chunk
+                if "<thought" in state.thought_buffer:
+                    state.in_thought = True
+                    state.checked_start = True
+                    if "</thought>" in state.thought_buffer:
+                        remaining_content = self._split_thought(state.thought_buffer)
+                        if remaining_content:
+                            async for out in self._emit_validated(
+                                remaining_content, state, plan.goal
+                            ):
+                                yield out
+                        state.thought_buffer = ""
+                        state.in_thought = False
+                else:
+                    async for out in self._emit_validated(
+                        state.thought_buffer, state, plan.goal
+                    ):
+                        yield out
+                    state.thought_buffer = ""
+                    state.checked_start = True
+                    continue
+
+            elif state.in_thought:
+                state.thought_buffer += clean_chunk
+                if "</thought>" in state.thought_buffer:
+                    remaining_content = self._split_thought(state.thought_buffer)
+                    if remaining_content:
+                        async for out in self._emit_validated(
+                            remaining_content, state, plan.goal
+                        ):
+                            yield out
+                    state.thought_buffer = ""
+                    state.in_thought = False
+                continue
+            else:
+                async for out in self._emit_validated(clean_chunk, state, plan.goal):
+                    yield out
+
+        # Flush whatever the markup sanitizer was still holding back.
+        trailing = sanitizer.flush()
+        if trailing:
+            if state.in_thought:
+                state.thought_buffer += trailing
+                if "</thought>" in state.thought_buffer:
+                    remaining_content = self._split_thought(state.thought_buffer)
+                    if remaining_content:
+                        async for out in self._emit_validated(
+                            remaining_content, state, plan.goal, allow_hesitation=False
+                        ):
+                            yield out
+            else:
+                async for out in self._emit_validated(
+                    trailing, state, plan.goal, allow_hesitation=False
+                ):
+                    yield out
+
+        # Post-generation grounding gate: the whole utterance is now known, so
+        # check it for fabricated shared-memory claims and route any hit
+        # through the same self-correction path.
+        is_grounded, ground_reason = self._check_response_grounding(
+            state.accumulated_response, surfaced, msg
+        )
+        if not is_grounded:
+            raise MetacognitiveException(ground_reason)
+
+        yield {"type": "done", "data": "finished"}
+
+    async def _announce_self_correction(self, reason: str):
+        """Interrupt playback so the retry is not spoken over the bad take."""
+        if self.publish_cb:
+            try:
+                await self.publish_cb(
+                    "control.interrupt", {"reason": reason, "interrupt": True}
+                )
+                await self.publish_cb(
+                    "audio.stop", {"interrupt": True, "reason": reason}
+                )
+            except Exception as pe:
+                logger.error(f"[System 3] Failed to publish interrupt: {pe}")
+
+    async def _stream_self_correction(
+        self,
+        *,
+        plan: ActionPlan,
+        user_prompt: str,
+        system_instruction: str,
+        model,
+        endocrine_options,
+        sanitizer: "ControlMarkupSanitizer",
+        stream_budget: int,
+        surfaced: list,
+        msg: str,
+    ):
+        """Second-pass regeneration after a System-3 violation.
+
+        Any further violation (constraint or grounding, mid-stream or trailing)
+        collapses to a single safe fallback line rather than a third attempt.
+        """
+        stream_iter = self.llm.generate_stream(
+            prompt=user_prompt,
+            system=system_instruction,
+            model=model,
+            options_override=endocrine_options,
+        ).__aiter__()
+        deadline = time.monotonic() + stream_budget
+        accumulated_retry_response = ""
+        is_valid = True
+
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            try:
+                chunk = await asyncio.wait_for(
+                    stream_iter.__anext__(), timeout=remaining
+                )
+            except StopAsyncIteration:
+                break
+            clean_chunk = sanitizer.feed(chunk)
+            if not clean_chunk:
+                continue
+
+            candidate = accumulated_retry_response + clean_chunk
+            is_valid, _ = self._validate_partial_response(candidate, plan.goal)
+            if not is_valid:
+                logger.warning(
+                    "[System 3] Retry also violated constraints; yielding safe fallback."
+                )
+                yield {"type": "content", "data": _SAFE_FALLBACK_LINE}
+                break
+
+            # Check grounding on the accumulated response so far
+            is_retry_grounded, retry_ground_reason = self._check_response_grounding(
+                candidate, surfaced, msg
+            )
+            if not is_retry_grounded:
+                logger.warning(
+                    f"[System 3] Retry fabricated a memory claim: {retry_ground_reason}. Yielding safe fallback."
+                )
+                yield {"type": "content", "data": _SAFE_FALLBACK_LINE}
+                break
+
+            yield {"type": "content", "data": clean_chunk}
+            accumulated_retry_response = candidate
+
+        if is_valid:
+            trailing = sanitizer.flush()
+            if trailing:
+                candidate = accumulated_retry_response + trailing
+                is_valid_trail, _ = self._validate_partial_response(
+                    candidate, plan.goal
+                )
+                if not is_valid_trail:
+                    logger.warning(
+                        "[System 3] Retry trailing also violated constraints; yielding safe fallback."
+                    )
+                    yield {"type": "content", "data": _SAFE_FALLBACK_LINE}
+                else:
+                    # Check grounding on trailing content too
+                    is_trail_grounded, trail_ground_reason = (
+                        self._check_response_grounding(candidate, surfaced, msg)
+                    )
+                    if not is_trail_grounded:
+                        logger.warning(
+                            f"[System 3] Retry trailing fabricated a memory claim: {trail_ground_reason}. Yielding safe fallback."
+                        )
+                        yield {"type": "content", "data": _SAFE_FALLBACK_LINE}
+                    else:
+                        yield {"type": "content", "data": trailing}
+
+        yield {"type": "done", "data": "finished"}
+
+    async def _execute_respond_chat(self, plan: ActionPlan):
+        """Generate a spoken reply: surface context, prompt, stream, self-correct."""
+        msg = plan.payload.get("message", "")
+        identity_prompt = plan.payload.get("identity_prompt", "You are my friend.")
+        emotion = plan.payload.get("emotion_state", "neutral")
+        model = plan.payload.get("model")
+
+        # Contextual Enrichments
+        surfaced = plan.payload.get("surfaced_memories", [])
+        if not surfaced and self.memory:
+            surfaced = await self._surface_fallback_memories(plan, msg)
+
+        shared_history = self._build_shared_history(surfaced)
+        tom_context = self._build_tom_context(plan.payload.get("user_mental_model"))
+
+        # Static System Prompt (cached by inference engines like Ollama/vLLM)
+        system_instruction = f"{identity_prompt}\n\n{_CHAT_GUIDELINE}"
+
+        # Dynamic User Prompt. Ordering fights "lost in the middle": the factual
+        # grounding (SHARED HISTORY) is placed LAST before the user's query so it
+        # sits in the model's high-attention tail, adjacent to what it must
+        # answer. The more abstract, lower-cost-to-lose context (goal, emotion,
+        # Theory-of-Mind) goes earlier. Within the history block itself, memories
+        # are already edge-loaded by reorder_for_long_context().
+        user_prompt = f"Current Context:\n- Goal: {plan.goal}\n- Current Emotion: {emotion}\n{tom_context}{shared_history}\n\nUser: {msg}\nAssistant:"
+
+        valence = plan.payload.get("valence", 0.0)
+        arousal = plan.payload.get("arousal", 0.5)
+        dominance = plan.payload.get("dominance", 0.5)
+
+        try:
+            endocrine_options = self._compute_endocrine_options(plan.payload)
+
+            sanitizer = ControlMarkupSanitizer()
+            stream_budget = max(15, int(getattr(Config, "LLM_STREAM_MAX_SECONDS", 120)))
+            state = _ChatStreamState(dominance=dominance)
+
+            prepended_tag = self._prepended_affect_tag(arousal, valence)
+            if prepended_tag:
+                yield {"type": "content", "data": prepended_tag}
+
+            try:
+                async for out in self._stream_primary_response(
+                    plan=plan,
+                    user_prompt=user_prompt,
+                    system_instruction=system_instruction,
+                    model=model,
+                    endocrine_options=endocrine_options,
+                    sanitizer=sanitizer,
+                    stream_budget=stream_budget,
+                    state=state,
+                    surfaced=surfaced,
+                    msg=msg,
+                ):
+                    yield out
+
+            except MetacognitiveException as me:
+                logger.warning(
+                    f"[System 3] Metacognitive violation: {me.reason}. Triggering self-correction."
+                )
+                await self._announce_self_correction(me.reason)
+
+                yield {"type": "content", "data": " Wait, let me rephrase that... "}
+                if endocrine_options is None:
+                    endocrine_options = {}
+                endocrine_options["temperature"] = min(
+                    1.0, endocrine_options.get("temperature", 0.7) + 0.2
+                )
+                retry_prompt = (
+                    user_prompt
+                    + f"\n\nCRITICAL FIX: Your previous response violated constraints: {me.reason}. Correct it immediately and do not repeat the forbidden phrases."
+                )
+
+                try:
+                    async for out in self._stream_self_correction(
+                        plan=plan,
+                        user_prompt=retry_prompt,
+                        system_instruction=system_instruction,
+                        model=model,
+                        endocrine_options=endocrine_options,
+                        sanitizer=sanitizer,
+                        stream_budget=stream_budget,
+                        surfaced=surfaced,
+                        msg=msg,
+                    ):
+                        yield out
+                except Exception as inner_e:
+                    logger.error(f"[System 3] Self-correction generation failed: {inner_e}")
+                    yield {"type": "done", "data": "finished"}
+
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "[Action] Stream timed out after %ss; emitting graceful fallback.",
+                    stream_budget,
+                )
+                yield {
+                    "type": "content",
+                    "data": "I'm having trouble thinking right now...",
+                }
+                yield {"type": "done", "data": ""}
+
+        except Exception as e:
+            logger.error(f"[Action] LLM Execution failed: {e}")
+            yield {"type": "error", "data": str(e)}
+            yield {"type": "done", "data": ""}
+
+    async def _execute_store_memory(self, plan: ActionPlan):
+        """Commit an explicitly requested memory."""
+        content = plan.payload.get("content", "")
+        # Using the new intelligent MemoryStore
+        if self.memory:
+            await self.memory.add_memory(
+                content=content,
+                importance=0.7,  # High importance for explicit 'remember' commands
+                emotion=0.2,
+                source="user",
+            )
+        yield {"type": "system", "data": "Memory securely consolidated."}
+        yield {"type": "content", "data": "Got it, I've committed that to memory."}
+        yield {"type": "done", "data": ""}
+
     async def execute(self, plan: ActionPlan) -> AsyncGenerator[Dict[str, Any], None]:
         """
         Executes the plan and yields output chunks.
@@ -231,511 +802,12 @@ class ActionService:
         )
 
         if plan.action_type == "RESPOND_CHAT":
-            # 1. Prepare Identity-Aware Prompt
-            msg = plan.payload.get("message", "")
-            identity_prompt = plan.payload.get("identity_prompt", "You are my friend.")
-            emotion = plan.payload.get("emotion_state", "neutral")
-
-            model = plan.payload.get("model")
-
-            # Contextual Enrichments
-            surfaced = plan.payload.get("surfaced_memories", [])
-            if not surfaced and self.memory:
-                try:
-                    # Synchronous fallback to prevent race conditions in low-latency/benchmark modes
-                    fallback_memories = await self.memory.search_memories(
-                        query_text=msg,
-                        wing="personal",
-                        limit=3,
-                        refresh_on_recall=False,
-                        current_valence=plan.payload.get("valence", 0.0),
-                        current_arousal=plan.payload.get("arousal", 0.5),
-                        current_cortisol=plan.payload.get("cortisol", 0.0),
-                    )
-                    if fallback_memories:
-                        surfaced = fallback_memories
-                        logger.info(
-                            f"⚡ [Action] Synchronous recall fallback surfaced {len(surfaced)} memories."
-                        )
-                except Exception as fe:
-                    logger.warning(
-                        f"Failed to run synchronous memory surfacing fallback: {fe}"
-                    )
-
-            shared_history = ""
-            if surfaced:
-                # Edge-load the most relevant memories so they land in the LLM's
-                # high-attention start/end positions instead of being lost in the
-                # middle of the block.
-                ordered = reorder_for_long_context(surfaced)
-                shared_history = (
-                    "\nSHARED HISTORY / RECENT CONTEXT (Active Influence):\n"
-                    + "\n".join([f"- {m['content']}" for m in ordered])
-                )
-
-            # Theory of Mind (ToM) Context Injection
-            tom_context = ""
-            user_tom = plan.payload.get("user_mental_model")
-            if user_tom:
-                inferred_val = user_tom.get("inferred_valence", 0.0)
-                inferred_ar = user_tom.get("inferred_arousal", 0.5)
-                impl_goals = user_tom.get("implied_goals", [])
-                if not isinstance(impl_goals, list):
-                    logger.warning(
-                        f"[Action] Unexpected type for implied_goals in user_mental_model: {type(impl_goals)}. Falling back to empty list."
-                    )
-                    impl_goals = []
-                # Take the last 10 known concepts to keep it concise and avoid context bloat
-                known_con = user_tom.get("known_concepts", [])[-10:]
-
-                tom_context = (
-                    "\n\nYour Inferred Perspective of the User (Theory of Mind):\n"
-                )
-                tom_context += f"- User Inferred Valence: {inferred_val:.2f} (Scale: -1.0 to 1.0)\n"
-                tom_context += (
-                    f"- User Inferred Arousal: {inferred_ar:.2f} (Scale: 0.0 to 1.0)\n"
-                )
-                if impl_goals:
-                    tom_context += f"- User Implied Goals: {', '.join(impl_goals)}\n"
-                if known_con:
-                    tom_context += f"- User Known Concepts (Respect this knowledge boundary): {', '.join(known_con)}\n"
-
-            # 1. Prepare Identity-Aware System and User Prompts
-            # Static System Prompt (cached by inference engines like Ollama/vLLM)
-            system_instruction = f"{identity_prompt}\n\nGuideline:\n- Maintain your identity rules at all times.\n- Focus on natural conversational phrases.\n- IMPORTANT: If the SHARED HISTORY / RECENT CONTEXT contains relevant biographical facts, partner details, childhood milestones, or personal preferences, you MUST integrate them explicitly and accurately to answer the user's question.\n- GROUNDING: Base any specific claim about the user, your shared past, names, dates, places, or events ONLY on the SHARED HISTORY / RECENT CONTEXT provided. Do not invent memories or details that are not there. If the user asks about something you have no memory of, say so naturally (e.g. \"I don't think you've told me that\") instead of making it up.\n- Respond only in English. Do not use Hindi, Hinglish, or any other language for now.\n- The voice layer already carries emotion separately. Do not emit XML wrappers or emotion tags.\n- You may use <pause=300ms> or <hesitate> when it improves natural timing."
-
-            # Dynamic User Prompt. Ordering fights "lost in the middle": the factual
-            # grounding (SHARED HISTORY) is placed LAST before the user's query so it
-            # sits in the model's high-attention tail, adjacent to what it must
-            # answer. The more abstract, lower-cost-to-lose context (goal, emotion,
-            # Theory-of-Mind) goes earlier. Within the history block itself, memories
-            # are already edge-loaded by reorder_for_long_context().
-            user_prompt = f"Current Context:\n- Goal: {plan.goal}\n- Current Emotion: {emotion}\n{tom_context}{shared_history}\n\nUser: {msg}\nAssistant:"
-
-            valence = plan.payload.get("valence", 0.0)
-            arousal = plan.payload.get("arousal", 0.5)
-            dominance = plan.payload.get("dominance", 0.5)
-
-            try:
-                # 2. Endocrine System: Calculate physiological LLM parameters
-                endocrine_options = None
-                cortisol = plan.payload.get("cortisol")
-                dopamine = plan.payload.get("dopamine")
-                fatigue = plan.payload.get("fatigue")
-
-                if cortisol is not None or dopamine is not None or fatigue is not None:
-                    endocrine_options = {}
-                    if cortisol is not None:
-                        try:
-                            val = float(cortisol)
-                            endo_temperature = max(
-                                0.0, min(1.0, round(0.9 - (val * 0.6), 3))
-                            )
-                        except (ValueError, TypeError):
-                            endo_temperature = 0.7
-                        endocrine_options["temperature"] = endo_temperature
-                    else:
-                        endocrine_options["temperature"] = 0.7
-
-                    if dopamine is not None:
-                        try:
-                            val = float(dopamine)
-                            endo_top_p = max(
-                                0.0, min(1.0, round(0.70 + (val * 0.25), 3))
-                            )
-                        except (ValueError, TypeError):
-                            endo_top_p = 0.8
-                        endocrine_options["top_p"] = endo_top_p
-                    else:
-                        endocrine_options["top_p"] = 0.8
-
-                    try:
-                        fatigue_val = max(
-                            0.0,
-                            min(1.0, float(fatigue if fatigue is not None else 0.0)),
-                        )
-                    except (ValueError, TypeError):
-                        fatigue_val = 0.0
-
-                    # Bounded num_predict strictly between 100 (exhausted) and 250 (fresh)
-                    endo_num_predict = int(
-                        max(100, min(250, int(250 - (fatigue_val * 150))))
-                    )
-                    endocrine_options["num_predict"] = endo_num_predict
-
-                    logger.info(
-                        "[Endocrine] Cortisol=%s Dopamine=%s Fatigue=%s → temp=%.3f top_p=%.3f num_predict=%d",
-                        cortisol,
-                        dopamine,
-                        fatigue,
-                        endocrine_options["temperature"],
-                        endocrine_options["top_p"],
-                        endocrine_options["num_predict"],
-                    )
-
-                # 3. Stream Generation
-                sanitizer = ControlMarkupSanitizer()
-                stream_budget = max(
-                    15, int(getattr(Config, "LLM_STREAM_MAX_SECONDS", 120))
-                )
-
-                # Track state for paralinguistic injection, CoT thought stripping, and System 3 checks
-                in_thought = False
-                thought_buffer = ""
-                checked_start = False
-                has_hesitated = False
-                accumulated_response = ""
-
-                # Prepend tags based on emotional states
-                prepended_tag = ""
-                if arousal > 0.6 and valence < -0.3:
-                    prepended_tag = "<breath_fast> "
-                elif arousal < 0.4 and valence < 0.0:
-                    prepended_tag = "<sigh_soft> "
-
-                if prepended_tag:
-                    yield {"type": "content", "data": prepended_tag}
-
-                try:
-                    stream_iter = self.llm.generate_stream(
-                        prompt=user_prompt,
-                        system=system_instruction,
-                        model=model,
-                        options_override=endocrine_options,
-                    ).__aiter__()
-                    deadline = time.monotonic() + stream_budget
-
-                    while True:
-                        remaining = deadline - time.monotonic()
-                        if remaining <= 0:
-                            raise asyncio.TimeoutError()
-
-                        try:
-                            chunk = await asyncio.wait_for(
-                                stream_iter.__anext__(), timeout=remaining
-                            )
-                        except StopAsyncIteration:
-                            break
-
-                        clean_chunk = sanitizer.feed(chunk)
-                        if not clean_chunk:
-                            continue
-
-                        # CoT strip check
-                        if not checked_start:
-                            thought_buffer += clean_chunk
-                            if "<thought" in thought_buffer:
-                                in_thought = True
-                                checked_start = True
-                                if "</thought>" in thought_buffer:
-                                    parts = thought_buffer.split("</thought>", 1)
-                                    thought_block = parts[0]
-                                    remaining_content = parts[1]
-
-                                    thought_content = thought_block.replace(
-                                        "<thought>", ""
-                                    ).strip()
-                                    logger.info(f"[CoT Thought] {thought_content}")
-                                    if remaining_content:
-                                        if (
-                                            dominance < 0.4
-                                            and not has_hesitated
-                                            and "," in remaining_content
-                                        ):
-                                            remaining_content = (
-                                                remaining_content.replace(
-                                                    ",", " <hesitate>,", 1
-                                                )
-                                            )
-                                            has_hesitated = True
-
-                                        candidate = (
-                                            accumulated_response + remaining_content
-                                        )
-                                        is_valid, reason = (
-                                            self._validate_partial_response(
-                                                candidate, plan.goal
-                                            )
-                                        )
-                                        if not is_valid:
-                                            raise MetacognitiveException(reason)
-
-                                        yield {
-                                            "type": "content",
-                                            "data": remaining_content,
-                                        }
-                                        accumulated_response = candidate
-                                    thought_buffer = ""
-                                    in_thought = False
-                            else:
-                                if (
-                                    dominance < 0.4
-                                    and not has_hesitated
-                                    and "," in thought_buffer
-                                ):
-                                    thought_buffer = thought_buffer.replace(
-                                        ",", " <hesitate>,", 1
-                                    )
-                                    has_hesitated = True
-
-                                candidate = accumulated_response + thought_buffer
-                                is_valid, reason = self._validate_partial_response(
-                                    candidate, plan.goal
-                                )
-                                if not is_valid:
-                                    raise MetacognitiveException(reason)
-
-                                yield {"type": "content", "data": thought_buffer}
-                                accumulated_response = candidate
-                                thought_buffer = ""
-                                checked_start = True
-                                continue
-
-                        elif in_thought:
-                            thought_buffer += clean_chunk
-                            if "</thought>" in thought_buffer:
-                                parts = thought_buffer.split("</thought>", 1)
-                                thought_block = parts[0]
-                                remaining_content = parts[1]
-
-                                thought_content = thought_block.replace(
-                                    "<thought>", ""
-                                ).strip()
-                                logger.info(f"[CoT Thought] {thought_content}")
-
-                                if remaining_content:
-                                    if (
-                                        dominance < 0.4
-                                        and not has_hesitated
-                                        and "," in remaining_content
-                                    ):
-                                        remaining_content = remaining_content.replace(
-                                            ",", " <hesitate>,", 1
-                                        )
-                                        has_hesitated = True
-
-                                    candidate = accumulated_response + remaining_content
-                                    is_valid, reason = self._validate_partial_response(
-                                        candidate, plan.goal
-                                    )
-                                    if not is_valid:
-                                        raise MetacognitiveException(reason)
-
-                                    yield {"type": "content", "data": remaining_content}
-                                    accumulated_response = candidate
-                                thought_buffer = ""
-                                in_thought = False
-                            continue
-                        else:
-                            if (
-                                dominance < 0.4
-                                and not has_hesitated
-                                and "," in clean_chunk
-                            ):
-                                clean_chunk = clean_chunk.replace(
-                                    ",", " <hesitate>,", 1
-                                )
-                                has_hesitated = True
-
-                            candidate = accumulated_response + clean_chunk
-                            is_valid, reason = self._validate_partial_response(
-                                candidate, plan.goal
-                            )
-                            if not is_valid:
-                                raise MetacognitiveException(reason)
-
-                            yield {"type": "content", "data": clean_chunk}
-                            accumulated_response = candidate
-
-                    trailing = sanitizer.flush()
-                    if trailing:
-                        if in_thought:
-                            thought_buffer += trailing
-                            if "</thought>" in thought_buffer:
-                                parts = thought_buffer.split("</thought>", 1)
-                                thought_content = (
-                                    parts[0].replace("<thought>", "").strip()
-                                )
-                                logger.info(f"[CoT Thought] {thought_content}")
-                                remaining_content = parts[1]
-                                if remaining_content:
-                                    candidate = accumulated_response + remaining_content
-                                    is_valid, reason = self._validate_partial_response(
-                                        candidate, plan.goal
-                                    )
-                                    if not is_valid:
-                                        raise MetacognitiveException(reason)
-                                    yield {"type": "content", "data": remaining_content}
-                                    accumulated_response = candidate
-                        else:
-                            candidate = accumulated_response + trailing
-                            is_valid, reason = self._validate_partial_response(
-                                candidate, plan.goal
-                            )
-                            if not is_valid:
-                                raise MetacognitiveException(reason)
-                            yield {"type": "content", "data": trailing}
-                            accumulated_response = candidate
-
-                    # Post-generation grounding gate: the whole utterance is now
-                    # known, so check it for fabricated shared-memory claims and
-                    # route any hit through the same self-correction path.
-                    is_grounded, ground_reason = self._check_response_grounding(
-                        accumulated_response, surfaced, msg
-                    )
-                    if not is_grounded:
-                        raise MetacognitiveException(ground_reason)
-
-                    yield {"type": "done", "data": "finished"}
-
-                except MetacognitiveException as me:
-                    logger.warning(
-                        f"[System 3] Metacognitive violation: {me.reason}. Triggering self-correction."
-                    )
-                    if self.publish_cb:
-                        try:
-                            await self.publish_cb(
-                                "control.interrupt",
-                                {"reason": me.reason, "interrupt": True},
-                            )
-                            await self.publish_cb(
-                                "audio.stop", {"interrupt": True, "reason": me.reason}
-                            )
-                        except Exception as pe:
-                            logger.error(
-                                f"[System 3] Failed to publish interrupt: {pe}"
-                            )
-
-                    yield {"type": "content", "data": " Wait, let me rephrase that... "}
-                    if endocrine_options is None:
-                        endocrine_options = {}
-                    endocrine_options["temperature"] = min(
-                        1.0, endocrine_options.get("temperature", 0.7) + 0.2
-                    )
-                    user_prompt += f"\n\nCRITICAL FIX: Your previous response violated constraints: {me.reason}. Correct it immediately and do not repeat the forbidden phrases."
-
-                    try:
-                        stream_iter = self.llm.generate_stream(
-                            prompt=user_prompt,
-                            system=system_instruction,
-                            model=model,
-                            options_override=endocrine_options,
-                        ).__aiter__()
-                        deadline = time.monotonic() + stream_budget
-                        accumulated_retry_response = ""
-                        is_valid = True
-                        while True:
-                            remaining = deadline - time.monotonic()
-                            if remaining <= 0:
-                                break
-                            try:
-                                chunk = await asyncio.wait_for(
-                                    stream_iter.__anext__(), timeout=remaining
-                                )
-                            except StopAsyncIteration:
-                                break
-                            clean_chunk = sanitizer.feed(chunk)
-                            if clean_chunk:
-                                candidate = accumulated_retry_response + clean_chunk
-                                is_valid, _ = self._validate_partial_response(
-                                    candidate, plan.goal
-                                )
-                                if not is_valid:
-                                    logger.warning(
-                                        "[System 3] Retry also violated constraints; yielding safe fallback."
-                                    )
-                                    yield {
-                                        "type": "content",
-                                        "data": "I need a moment to gather my thoughts...",
-                                    }
-                                    break
-                                # Check grounding on the accumulated response so far
-                                is_retry_grounded, retry_ground_reason = (
-                                    self._check_response_grounding(
-                                        candidate, surfaced, msg
-                                    )
-                                )
-                                if not is_retry_grounded:
-                                    logger.warning(
-                                        f"[System 3] Retry fabricated a memory claim: {retry_ground_reason}. Yielding safe fallback."
-                                    )
-                                    yield {
-                                        "type": "content",
-                                        "data": "I need a moment to gather my thoughts...",
-                                    }
-                                    break
-                                yield {"type": "content", "data": clean_chunk}
-                                accumulated_retry_response = candidate
-
-                        if is_valid:
-                            trailing = sanitizer.flush()
-                            if trailing:
-                                candidate = accumulated_retry_response + trailing
-                                is_valid_trail, _ = self._validate_partial_response(
-                                    candidate, plan.goal
-                                )
-                                if is_valid_trail:
-                                    # Check grounding on trailing content too
-                                    is_trail_grounded, trail_ground_reason = (
-                                        self._check_response_grounding(
-                                            candidate, surfaced, msg
-                                        )
-                                    )
-                                    if not is_trail_grounded:
-                                        logger.warning(
-                                            f"[System 3] Retry trailing fabricated a memory claim: {trail_ground_reason}. Yielding safe fallback."
-                                        )
-                                        yield {
-                                            "type": "content",
-                                            "data": "I need a moment to gather my thoughts...",
-                                        }
-                                    else:
-                                        yield {"type": "content", "data": trailing}
-                                else:
-                                    logger.warning(
-                                        "[System 3] Retry trailing also violated constraints; yielding safe fallback."
-                                    )
-                                    yield {
-                                        "type": "content",
-                                        "data": "I need a moment to gather my thoughts...",
-                                    }
-
-                        yield {"type": "done", "data": "finished"}
-                    except Exception as inner_e:
-                        logger.error(
-                            f"[System 3] Self-correction generation failed: {inner_e}"
-                        )
-                        yield {"type": "done", "data": "finished"}
-
-                except asyncio.TimeoutError:
-                    logger.warning(
-                        "[Action] Stream timed out after %ss; emitting graceful fallback.",
-                        stream_budget,
-                    )
-                    yield {
-                        "type": "content",
-                        "data": "I'm having trouble thinking right now...",
-                    }
-                    yield {"type": "done", "data": ""}
-
-            except Exception as e:
-                logger.error(f"[Action] LLM Execution failed: {e}")
-                yield {"type": "error", "data": str(e)}
-                yield {"type": "done", "data": ""}
+            async for out in self._execute_respond_chat(plan):
+                yield out
 
         elif plan.action_type == "STORE_MEMORY":
-            content = plan.payload.get("content", "")
-            # Using the new intelligent MemoryStore
-            if self.memory:
-                await self.memory.add_memory(
-                    content=content,
-                    importance=0.7,  # High importance for explicit 'remember' commands
-                    emotion=0.2,
-                    source="user",
-                )
-            yield {"type": "system", "data": "Memory securely consolidated."}
-            yield {"type": "content", "data": "Got it, I've committed that to memory."}
-            yield {"type": "done", "data": ""}
+            async for out in self._execute_store_memory(plan):
+                yield out
 
         elif plan.action_type == "BACKGROUND_CONSOLIDATION":
             # Already triggered by CognitiveService

--- a/backend/app/state/memory_store.py
+++ b/backend/app/state/memory_store.py
@@ -15,9 +15,12 @@ import logging
 import time
 import asyncio
 import httpx
+import json
 import orjson
 import math
+import re
 import sqlite3
+import uuid
 from collections import OrderedDict
 from datetime import datetime, timezone, timedelta
 from typing import Iterable
@@ -80,6 +83,114 @@ ACTR_EMO_PROXIMITY_WEIGHT = 0.15  # bonus for small emotional distance
 ACTR_VALENCE_GAIN = 0.1  # similarity gain from congruent valence×arousal
 ACTR_STRESS_SUPPRESSION = 0.2  # similarity suppression under arousal×cortisol
 ACTR_EMO_DISTANCE_PENALTY = 0.5  # score penalty per unit emotional distance
+
+# Generic English stop words plus a few domain-generic conversational terms,
+# stripped from a query before it is used for lexical cue matching. Hoisted to
+# module scope: this is a constant, and rebuilding the literal on every
+# search_memories call was pure waste. Membership is unchanged (the original
+# literal contained duplicates, which a set collapses either way).
+SEARCH_STOP_WORDS = frozenset(
+    {
+        "the", "and", "but", "yet", "for", "nor", "with", "this", "that",
+        "these", "those", "you", "your", "yours", "him", "her", "them", "his",
+        "hers", "their", "theirs", "was", "were", "been", "have", "has", "had",
+        "did", "does", "what", "where", "when", "who", "why", "how", "can",
+        "could", "would", "should", "shall", "will", "about", "above", "after",
+        "again", "against", "all", "am", "an", "any", "are", "arent", "as",
+        "at", "be", "because", "before", "being", "below", "between", "both",
+        "by", "cant", "cannot", "didnt", "dont", "down", "during", "each",
+        "few", "from", "further", "hadnt", "hasnt", "havent", "having", "he",
+        "hed", "hell", "hes", "here", "heres", "herself", "himself", "i", "id",
+        "ill", "im", "ive", "if", "in", "into", "isnt", "it", "its", "itself",
+        "lets", "me", "more", "most", "mustnt", "my", "myself", "no", "not",
+        "of", "off", "on", "once", "only", "or", "other", "ought", "our",
+        "ours", "ourselves", "out", "over", "own", "same", "shant", "she",
+        "shed", "shell", "shes", "shouldnt", "so", "some", "such", "than",
+        "thats", "themselves", "then", "there", "theres", "they", "theyd",
+        "theyll", "theyre", "theyve", "through", "to", "too", "under",
+        "until", "up", "very", "wasnt", "we", "wed", "well", "weve", "werent",
+        "whats", "whens", "wheres", "which", "while", "whos", "whom", "whys",
+        "wont", "wouldnt", "youd", "youll", "youre", "youve", "yourself",
+        "yourselves", "describe", "compare", "influence", "influenced",
+        "friend", "companion", "robot", "human", "development", "developer",
+        "developers", "project", "workspace", "shared", "recall", "recalled",
+        "experience", "experiences", "related",
+    }
+)
+
+# Pronoun sets used for speaker/listener cue resolution.
+FIRST_PERSON_PRONOUNS = frozenset({"i", "me", "my", "myself", "we", "our", "us"})
+SECOND_PERSON_PRONOUNS = frozenset(
+    {"you", "your", "yours", "yourself", "yourselves"}
+)
+
+# Postgres retrieval fast path. Two variants of the same query: the current
+# schema also carries the Eriksonian lifespan columns on `memories`, while a
+# not-yet-migrated database has only the base columns. Both take the identical
+# 12-argument tuple; see _fetch_surface_actr_rows.
+_SURFACE_ACTR_SELECT_HEAD = """
+    SELECT
+        m.id AS id,
+        s.content,
+        s.raw_content,
+        s.wing,
+        s.room,
+        s.importance_score,
+        s.emotional_weight,
+        s.valence,
+        s.recall_count,
+        s.last_recalled_at,
+        s.created_at,
+        s.metadata,
+        s.similarity,
+        s.score"""
+
+_SURFACE_ACTR_FROM_JOIN = """
+    FROM surface_actr_memories($1::vector(768), $2::text, $3::text, $4::double precision, $5::double precision, $6::double precision, $7::double precision, $8::double precision, $9::double precision, $10::double precision, $11::integer, $12::timestamptz) s
+    LEFT JOIN memories m ON m.content = s.content AND m.wing = s.wing
+"""
+
+_SURFACE_ACTR_SQL_ERIKSONIAN = (
+    _SURFACE_ACTR_SELECT_HEAD
+    + """,
+        m.lifespan_stage,
+        m.crisis,
+        m.virtue,
+        m.relations,
+        m.relation_circles,
+        m.modality"""
+    + _SURFACE_ACTR_FROM_JOIN
+)
+
+_SURFACE_ACTR_SQL_LEGACY = _SURFACE_ACTR_SELECT_HEAD + _SURFACE_ACTR_FROM_JOIN
+
+# Archive -> active promotion. Same columns in both dialects; only the
+# placeholder style and the EXCLUDED casing differ.
+_PROMOTE_INSERT_COLUMNS = """INSERT INTO memories (
+        id, content, raw_content, wing, room, embedding, importance_score, emotional_weight,
+        valence, certainty, source, recall_count, last_recalled_at, created_at,
+        metadata, lifespan_stage, crisis, virtue, relations, relation_circles, modality
+    ) VALUES """
+
+_PROMOTE_INSERT_SQLITE = (
+    _PROMOTE_INSERT_COLUMNS
+    + """(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET
+        recall_count = excluded.recall_count,
+        last_recalled_at = excluded.last_recalled_at,
+        importance_score = excluded.importance_score
+"""
+)
+
+_PROMOTE_INSERT_PG = (
+    _PROMOTE_INSERT_COLUMNS
+    + """($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
+    ON CONFLICT(id) DO UPDATE SET
+        recall_count = EXCLUDED.recall_count,
+        last_recalled_at = EXCLUDED.last_recalled_at,
+        importance_score = EXCLUDED.importance_score
+"""
+)
 
 
 class GoalBuffer:
@@ -749,6 +860,1371 @@ class MemoryStore:
             logger.debug(f"Failed to load dynamic stop words: {e}")
             self._db_stop_words = set()
 
+    # ------------------------------------------------------------------
+    # search_memories stages (F1)
+    #
+    # search_memories was a ~1600-line god-function fusing L1 caching, Qdrant
+    # retrieval, two SQL dialects, cue extraction, graph building, pronoun
+    # resolution, PageRank spreading activation, archive promotion and result
+    # formatting into one body. The stages below are that same pipeline, split
+    # at its natural seams so each piece can be read and tested on its own.
+    # Behavior is intentionally unchanged - the scoring math, ordering and
+    # error-swallowing semantics are preserved exactly.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _compute_mrl_gating(
+        current_arousal: float,
+        current_cortisol: float,
+        limit,
+        refresh_on_recall: bool,
+    ) -> tuple[int, int]:
+        """Dynamic Matryoshka (MRL) dimension gating.
+
+        Higher stress/arousal restricts the search to a smaller Matryoshka
+        prefix and a smaller candidate pool, bounding retrieval latency when
+        the agent is under load.
+        """
+        stress_index = max(current_arousal, current_cortisol)
+        if stress_index > 0.8:
+            return 256, max(10, limit * 2 if limit is not None else 10)
+        if stress_index > 0.6:
+            return 512, max(30, limit * 3 if limit is not None else 30)
+        if refresh_on_recall:
+            return 768, max(120, limit * 6 if limit is not None else 120)
+        return 768, max(20, limit * 3 if limit is not None else 20)
+
+    def _detect_topic_shift(self, query_vector: list) -> None:
+        """Flush the goal buffer when the query diverges sharply from the last one."""
+        if self._last_query_vector is not None:
+            try:
+                dot = sum(a * b for a, b in zip(query_vector, self._last_query_vector))
+                norm1 = math.sqrt(sum(a * a for a in query_vector))
+                norm2 = math.sqrt(sum(b * b for b in self._last_query_vector))
+                sim = dot / (norm1 * norm2) if norm1 > 1e-9 and norm2 > 1e-9 else 1.0
+                if sim < 0.15:
+                    logger.info(
+                        f"🔄 Topic Shift Detected (similarity {sim:.3f} < 0.15). Flushing Goal Buffer."
+                    )
+                    self.goal_buffer.flush()
+            except Exception as ts_err:
+                logger.debug(f"Topic-shift calculation failed: {ts_err}")
+        self._last_query_vector = query_vector
+
+    async def _gather_candidate_sources(self, mrl_query_vector, candidate_limit):
+        """Fetch vector candidates and the Neo4j entity/relation graph concurrently."""
+
+        async def safe_qdrant_search():
+            try:
+                if self.qdrant_store.client:
+                    return await asyncio.to_thread(
+                        self.qdrant_store.search_vector_memories,
+                        query_vector=mrl_query_vector,
+                        limit=candidate_limit,
+                    )
+            except Exception as qe:
+                logger.error(f"Qdrant retrieval failed: {qe}")
+            return []
+
+        async def _dummy_list():
+            return []
+
+        candidates, entity_records, relation_records = await asyncio.gather(
+            safe_qdrant_search(),
+            self.graph_db.execute_query(
+                "MATCH (e:Entity) RETURN e.name AS name, e.description AS description",
+                use_cache=True,
+            )
+            if self.graph_db
+            else _dummy_list(),
+            self.graph_db.execute_query(
+                "MATCH (s:Entity)-[r]-(t:Entity) RETURN s.name AS source, t.name AS target",
+                use_cache=True,
+            )
+            if self.graph_db
+            else _dummy_list(),
+        )
+
+        # Defensive type checks
+        if not isinstance(entity_records, list):
+            entity_records = []
+        if not isinstance(relation_records, list):
+            relation_records = []
+        return candidates, entity_records, relation_records
+
+    async def _score_qdrant_candidates(
+        self,
+        candidates,
+        *,
+        wing,
+        room,
+        excluded,
+        threshold,
+        current_valence,
+        current_arousal,
+        current_cortisol,
+        current_time,
+        now_ts,
+    ) -> list:
+        """Score Qdrant vector hits with ACT-R activation + neuromodulatory gating."""
+        raw_candidates = []
+        try:
+            db_metadata = await self._fetch_candidate_db_metadata(candidates)
+
+            for cand in candidates:
+                meta = cand["metadata"]
+                c_wing = meta.get("wing")
+                c_room = meta.get("room")
+                if wing is not None and c_wing != wing:
+                    continue
+                if room is not None and c_room != room:
+                    continue
+
+                c_content = cand["content"]
+                if c_content in excluded:
+                    continue
+
+                memory_id = cand["id"]
+                db_meta = db_metadata.get(str(memory_id))
+
+                memory_valence = (
+                    db_meta.get("valence")
+                    if (db_meta and db_meta.get("valence") is not None)
+                    else meta.get("valence", 0.0)
+                )
+                emotion_weight_row = (
+                    db_meta.get("emotional_weight")
+                    if (db_meta and db_meta.get("emotional_weight") is not None)
+                    else meta.get("emotional_weight", 0.0)
+                )
+                importance_score = (
+                    db_meta.get("importance_score")
+                    if (db_meta and db_meta.get("importance_score") is not None)
+                    else meta.get("importance_score", 0.5)
+                )
+                recall_count = max(
+                    1,
+                    db_meta.get("recall_count")
+                    if (db_meta and db_meta.get("recall_count") is not None)
+                    else meta.get("recall_count", 1),
+                )
+
+                last_recall_time = self._coerce_last_recall_ts(db_meta, meta, now_ts)
+                hours_since = max(0.001, (now_ts - last_recall_time) / 3600.0)
+
+                # 2D/3D Emotional Distance matching the research simulator
+                dist_emo = math.sqrt(
+                    (memory_valence - current_valence) ** 2
+                    + (emotion_weight_row - current_arousal) ** 2
+                )
+
+                base_activation = self._base_activation(
+                    recall_count, hours_since, importance_score, dist_emo
+                )
+
+                similarity = cand["score"]
+                effective_similarity = self._effective_similarity(
+                    similarity,
+                    memory_valence,
+                    emotion_weight_row,
+                    current_arousal,
+                    current_cortisol,
+                )
+
+                spread_activation = self.spread_weight * effective_similarity
+                score = (
+                    base_activation
+                    + spread_activation
+                    - ACTR_EMO_DISTANCE_PENALTY * dist_emo
+                )
+
+                if score <= (threshold - 2.5) and importance_score < 0.7:
+                    continue
+
+                created_val = meta.get("created_at")
+                try:
+                    created = (
+                        datetime.fromtimestamp(float(created_val), timezone.utc)
+                        if created_val
+                        else (
+                            current_time
+                            if current_time is not None
+                            else datetime.now(timezone.utc)
+                        )
+                    )
+                except Exception:
+                    created = (
+                        current_time
+                        if current_time is not None
+                        else datetime.now(timezone.utc)
+                    )
+
+                custom_metadata = {}
+                if "custom_metadata" in meta:
+                    try:
+                        custom_metadata = orjson.loads(meta["custom_metadata"])
+                    except Exception:
+                        pass
+
+                raw_candidates.append(
+                    {
+                        "id": memory_id,
+                        "content": c_content,
+                        "raw_content": c_content,
+                        "wing": c_wing or "personal",
+                        "room": c_room,
+                        "score": score,
+                        "valence": memory_valence,
+                        "created_at": created,
+                        "recall_count": recall_count,
+                        "metadata": custom_metadata,
+                        "lifespan_stage": meta.get("lifespan_stage"),
+                        "crisis": meta.get("crisis"),
+                        "virtue": meta.get("virtue"),
+                        "relations": meta.get("relations"),
+                        "relation_circles": meta.get("relation_circles"),
+                        "modality": meta.get("modality"),
+                        "similarity": similarity,
+                        "last_recalled_at": datetime.fromtimestamp(
+                            last_recall_time, timezone.utc
+                        ),
+                    }
+                )
+        except Exception as qe:
+            logger.error(f"Qdrant retrieval failed, falling back to database: {qe}")
+        return raw_candidates
+
+    async def _fetch_candidate_db_metadata(self, candidates) -> dict:
+        """Load the authoritative SQL metadata for a set of Qdrant candidates.
+
+        Qdrant payloads can lag the SQL row (recall_count/last_recalled_at move
+        on every recall), so the DB copy wins where present.
+        """
+        db_metadata = {}
+        try:
+            cand_ids = [c["id"] for c in candidates if c.get("id")]
+            if cand_ids:
+                async with self.pool.acquire() as conn:
+                    if self.is_sqlite:
+                        placeholders = ",".join("?" for _ in cand_ids)
+                        rows = await conn.fetch(
+                            f"SELECT id, importance_score, emotional_weight, valence, recall_count, last_recalled_at FROM memories WHERE id IN ({placeholders})",
+                            *cand_ids,
+                        )
+                    else:
+                        rows = await conn.fetch(
+                            "SELECT id, importance_score, emotional_weight, valence, recall_count, last_recalled_at FROM memories WHERE id = ANY($1)",
+                            cand_ids,
+                        )
+                    for r in rows:
+                        db_metadata[str(r["id"])] = r
+        except Exception as db_err:
+            logger.warning(
+                f"Failed to fetch updated memory metadata from SQL DB for Qdrant candidates: {db_err}"
+            )
+        return db_metadata
+
+    @staticmethod
+    def _coerce_last_recall_ts(db_meta, meta, now_ts) -> float:
+        """Normalize last_recalled_at (datetime | epoch | ISO string) to a float epoch."""
+        try:
+            if db_meta and db_meta.get("last_recalled_at"):
+                last_recall_time = db_meta.get("last_recalled_at")
+                if isinstance(last_recall_time, (int, float)):
+                    return float(last_recall_time)
+                if hasattr(last_recall_time, "timestamp"):
+                    return last_recall_time.timestamp()
+                dt = datetime.fromisoformat(str(last_recall_time).replace(" ", "T"))
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                return dt.timestamp()
+            return float(meta.get("last_recalled_at", now_ts))
+        except (ValueError, TypeError):
+            return now_ts
+
+    async def _fetch_sqlite_candidates(
+        self,
+        conn,
+        *,
+        query_vector,
+        wing,
+        room,
+        excluded,
+        threshold,
+        current_valence,
+        current_arousal,
+        current_cortisol,
+        current_time,
+    ) -> tuple[list, float]:
+        """SQLite fallback: fetch rows and score them via the Rust ACT-R kernel.
+
+        Returns the candidates plus the `now_ts` it computed, because the
+        original inlined body rebound the enclosing now_ts here and that value
+        is what later stamps the L1 cache entry.
+        """
+        if room is not None:
+            rows = await conn.fetch(
+                "SELECT * FROM memories WHERE wing = ? AND room = ?", wing, room
+            )
+        else:
+            rows = await conn.fetch("SELECT * FROM memories WHERE wing = ?", wing)
+
+        # Manual cosine similarity and ACT-R scoring (delegated to Rust PyO3).
+        # Imported lazily: the compiled extension is optional in some envs and
+        # a module-level import would break importing MemoryStore entirely.
+        import cognitive_rust
+
+        now = current_time if current_time is not None else datetime.now(timezone.utc)
+        now_ts = now.timestamp()
+
+        # Preprocess timestamps for Rust
+        for row in rows:
+            row["_last_recall_ts"] = self._normalize_recall_ts(
+                row.get("last_recalled_at"), now_ts
+            )
+
+        scored_indices = cognitive_rust.score_memories_actr_sqlite(
+            query_vector,
+            rows,
+            excluded,
+            current_valence,
+            current_arousal,
+            current_cortisol,
+            self.decay_rate,
+            self.spread_weight,
+            threshold,
+            now_ts,
+        )
+
+        raw_candidates = []
+        for idx, score, similarity in scored_indices:
+            row = rows[idx]
+            last_recall = row.get("last_recalled_at")
+            if last_recall is None:
+                last_recall = now
+            elif isinstance(last_recall, str):
+                try:
+                    last_recall = datetime.fromisoformat(last_recall)
+                except Exception:
+                    last_recall = now
+            if last_recall.tzinfo is None:
+                last_recall = last_recall.replace(tzinfo=timezone.utc)
+
+            created = row.get("created_at")
+            if isinstance(created, str):
+                try:
+                    created = datetime.fromisoformat(created)
+                except Exception:
+                    created = now
+            if created and created.tzinfo is None:
+                created = created.replace(tzinfo=timezone.utc)
+
+            raw_meta = row.get("metadata")
+            if isinstance(raw_meta, str):
+                try:
+                    raw_meta = orjson.loads(raw_meta)
+                except Exception:
+                    raw_meta = {}
+
+            raw_candidates.append(
+                {
+                    "id": row.get("id"),
+                    "content": row["content"],
+                    "raw_content": row.get("raw_content") or row["content"],
+                    "wing": row.get("wing", "personal"),
+                    "room": row.get("room"),
+                    "score": score,
+                    "valence": row.get("valence") or 0.0,
+                    "created_at": created,
+                    "recall_count": max(1, row.get("recall_count") or 1),
+                    "metadata": raw_meta or {},
+                    "lifespan_stage": row.get("lifespan_stage"),
+                    "crisis": row.get("crisis"),
+                    "virtue": row.get("virtue"),
+                    "relations": row.get("relations"),
+                    "relation_circles": row.get("relation_circles"),
+                    "modality": row.get("modality"),
+                    "similarity": similarity,
+                    "last_recalled_at": last_recall,
+                }
+            )
+        return raw_candidates, now_ts
+
+    @staticmethod
+    def _normalize_recall_ts(last_recall, now_ts: float) -> float:
+        """Coerce a row's last_recalled_at into a float epoch for the Rust kernel."""
+        if last_recall is None:
+            return now_ts
+        if isinstance(last_recall, datetime):
+            return last_recall.timestamp()
+        if isinstance(last_recall, (int, float)):
+            return float(last_recall)
+        if isinstance(last_recall, str):
+            try:
+                return float(last_recall)
+            except ValueError:
+                try:
+                    dt = datetime.fromisoformat(last_recall.replace(" ", "T"))
+                    if dt.tzinfo is None:
+                        dt = dt.replace(tzinfo=timezone.utc)
+                    return dt.timestamp()
+                except Exception:
+                    return now_ts
+        return now_ts
+
+    async def _fetch_postgres_candidates(
+        self,
+        conn,
+        *,
+        vector_str,
+        wing,
+        room,
+        excluded,
+        threshold,
+        candidate_limit,
+        current_valence,
+        current_arousal,
+        current_cortisol,
+        current_time,
+    ) -> list:
+        """PostgreSQL fast path via the surface_actr_memories() vector procedure."""
+        rows = await self._fetch_surface_actr_rows(
+            conn,
+            vector_str=vector_str,
+            wing=wing,
+            room=room,
+            threshold=threshold,
+            candidate_limit=candidate_limit,
+            current_valence=current_valence,
+            current_arousal=current_arousal,
+            current_cortisol=current_cortisol,
+            current_time=current_time,
+        )
+
+        raw_candidates = []
+        for row in rows:
+            if row["content"] in excluded:
+                continue
+
+            similarity = row.get("similarity") or 0.0
+            recall_count = max(1, row.get("recall_count") or 1)
+
+            # Recalculate score with neuromodulatory gating
+            last_recall = row.get("last_recalled_at")
+            now = (
+                self._as_aware_utc(current_time)
+                if current_time is not None
+                else datetime.now(timezone.utc)
+            )
+            last_recall = (
+                now if last_recall is None else self._as_aware_utc(last_recall)
+            )
+
+            hours_since = max(0.001, (now - last_recall).total_seconds() / 3600.0)
+
+            memory_valence = row.get("valence") or 0.0
+            emotion_weight_row = row.get("emotional_weight") or 0.0
+
+            # 2D/3D Emotional Distance matching the research simulator
+            dist_emo = math.sqrt(
+                (memory_valence - current_valence) ** 2
+                + (emotion_weight_row - current_arousal) ** 2
+            )
+
+            base_activation = self._base_activation(
+                recall_count,
+                hours_since,
+                row.get("importance_score") or 0.5,
+                dist_emo,
+            )
+
+            # Neuromodulatory distance mapping
+            effective_similarity = self._effective_similarity(
+                similarity,
+                memory_valence,
+                emotion_weight_row,
+                current_arousal,
+                current_cortisol,
+            )
+
+            spread_activation = self.spread_weight * effective_similarity
+            score = (
+                base_activation
+                + spread_activation
+                - ACTR_EMO_DISTANCE_PENALTY * dist_emo
+            )
+
+            if score <= (threshold - 2.5) and (row.get("importance_score") or 0.5) < 0.7:
+                continue
+
+            created = row.get("created_at")
+            if created and created.tzinfo is None:
+                created = created.replace(tzinfo=timezone.utc)
+
+            raw_meta = row.get("metadata")
+            if isinstance(raw_meta, str):
+                try:
+                    raw_meta = orjson.loads(raw_meta)
+                except Exception:
+                    raw_meta = {}
+
+            raw_candidates.append(
+                {
+                    "id": row.get("id"),
+                    "content": row["content"],
+                    "raw_content": row.get("raw_content") or row["content"],
+                    "wing": row.get("wing", "personal"),
+                    "room": row.get("room"),
+                    "score": score,
+                    "valence": row.get("valence") or 0.0,
+                    "created_at": created,
+                    "recall_count": recall_count,
+                    "metadata": raw_meta or {},
+                    "lifespan_stage": row.get("lifespan_stage"),
+                    "crisis": row.get("crisis"),
+                    "virtue": row.get("virtue"),
+                    "relations": row.get("relations"),
+                    "relation_circles": row.get("relation_circles"),
+                    "modality": row.get("modality"),
+                    "similarity": similarity,
+                    "last_recalled_at": last_recall,
+                }
+            )
+        return raw_candidates
+
+    async def _fetch_surface_actr_rows(
+        self,
+        conn,
+        *,
+        vector_str,
+        wing,
+        room,
+        threshold,
+        candidate_limit,
+        current_valence,
+        current_arousal,
+        current_cortisol,
+        current_time,
+    ):
+        """Call surface_actr_memories(), falling back to the pre-Eriksonian schema.
+
+        The two queries take identical arguments and differ only in whether the
+        Eriksonian lifespan columns are selected from the JOINed memories row,
+        so the argument tuple is built once.
+        """
+        args = (
+            vector_str,
+            wing,
+            room,
+            self.decay_rate,
+            self.spread_weight,
+            self.emotion_weight,
+            current_valence,
+            current_arousal,
+            current_cortisol,
+            threshold - 2.5,
+            candidate_limit,
+            current_time,
+        )
+        try:
+            return await conn.fetch(_SURFACE_ACTR_SQL_ERIKSONIAN, *args)
+        except Exception as pg_err:
+            logger.warning(
+                f"Eriksonian JOIN pg query failed, falling back to legacy schema: {pg_err}"
+            )
+            return await conn.fetch(_SURFACE_ACTR_SQL_LEGACY, *args)
+
+    def _resolve_dynamic_stop_words(self, user_id) -> set:
+        """Static stop words plus DB-learned ones and the agent/user proper nouns.
+
+        The agent's own name and the speaker's name are suppressed as cues
+        because they appear in nearly every memory and would otherwise boost
+        everything uniformly.
+        """
+        dynamic_stop_words = set(SEARCH_STOP_WORDS)
+        if getattr(self, "_db_stop_words", None):
+            dynamic_stop_words.update(self._db_stop_words)
+        ai_name_cfg = getattr(Config, "AI_NAME", None)
+        if ai_name_cfg:
+            for w in re.findall(r"\b\w{3,}\b", ai_name_cfg.lower()):
+                dynamic_stop_words.add(w)
+        if user_id:
+            for w in re.findall(r"\b\w{3,}\b", user_id.lower()):
+                dynamic_stop_words.add(w)
+        return dynamic_stop_words
+
+    @staticmethod
+    def _build_entity_graph(entity_records, relation_records, raw_candidates):
+        """Build the entity list and co-occurrence adjacency used by PPR.
+
+        Edges come from Neo4j relations plus entity co-occurrence within each
+        candidate memory.
+        """
+        entity_names = [r["name"] for r in entity_records]
+        adj = {}
+
+        for r in relation_records:
+            src = r["source"]
+            tgt = r["target"]
+            adj.setdefault(src, set()).add(tgt)
+            adj.setdefault(tgt, set()).add(src)
+
+        # Add co-occurrence connections from candidate memories
+        for cand in raw_candidates:
+            payload_meta = cand.get("metadata") or {}
+            cand_ents = payload_meta.get("entities", [])
+            if not cand_ents:
+                content_lower = cand["content"].lower()
+                cand_ents = []
+                for name in entity_names:
+                    pattern = rf"\b{re.escape(name.lower())}\b"
+                    if re.search(pattern, content_lower):
+                        cand_ents.append(name)
+
+            for i in range(len(cand_ents)):
+                for j in range(i + 1, len(cand_ents)):
+                    e1 = cand_ents[i]
+                    e2 = cand_ents[j]
+                    adj.setdefault(e1, set()).add(e2)
+                    adj.setdefault(e2, set()).add(e1)
+
+        return entity_names, adj
+
+    @staticmethod
+    def _resolve_identity_nodes(entity_records, entity_names, adj, user_id):
+        """Discover which graph nodes represent the agent and the user.
+
+        Falls back through description text, configured AI_NAME, and finally
+        the most-connected non-agent entity, so pronoun resolution still works
+        on a graph that was never explicitly annotated.
+        """
+        agent_node_name = None
+        user_node_name = None
+
+        # 1. Discover Agent Node Name dynamically
+        for r in entity_records:
+            desc = r.get("description") or ""
+            if "central cognitive system" in desc.lower():
+                agent_node_name = r["name"]
+                break
+        if not agent_node_name:
+            ai_name = getattr(Config, "AI_NAME", "AI Friend")
+            for name in entity_names:
+                if name.lower() == ai_name.lower():
+                    agent_node_name = name
+                    break
+        if not agent_node_name:
+            agent_node_name = getattr(Config, "AI_NAME", "AI Friend")
+
+        # 2. Discover User Node Name dynamically
+        if user_id:
+            for name in entity_names:
+                if name.lower() == user_id.lower():
+                    user_node_name = name
+                    break
+        if not user_node_name:
+            for r in entity_records:
+                desc = r.get("description") or ""
+                if (
+                    "user" in desc.lower()
+                    or "companion" in desc.lower()
+                    or "friend" in desc.lower()
+                ):
+                    if r["name"] != agent_node_name:
+                        user_node_name = r["name"]
+                        break
+        if not user_node_name and entity_names:
+            ai_names = {"ai friend", "my friend", agent_node_name.lower()}
+            if getattr(Config, "AI_NAME", None):
+                ai_names.add(Config.AI_NAME.lower())
+            candidates_names = [
+                name for name in entity_names if name.lower() not in ai_names
+            ]
+            if candidates_names:
+                candidates_names.sort(
+                    key=lambda name: len(adj.get(name, set())), reverse=True
+                )
+                user_node_name = candidates_names[0]
+        if not user_node_name:
+            user_node_name = user_id or "user"
+
+        return agent_node_name, user_node_name
+
+    @staticmethod
+    def _resolve_pronoun_cues(
+        query_text, agent_node_name, user_node_name, user_id, is_self_reflection
+    ) -> set:
+        """Context-aware speaker/listener pronoun resolution.
+
+        Who "I" and "you" refer to flips depending on whether the agent is
+        reflecting on itself or the user is speaking.
+        """
+        query_words_all = re.findall(r"\b\w+\b", query_text.lower())
+        resolved_cues = set()
+
+        if is_self_reflection:
+            # Agent speaking: "I" -> Agent, "you" -> User
+            speaker, listener = agent_node_name, user_node_name
+        else:
+            # User speaking: "I" -> User, "you" -> Agent
+            speaker, listener = user_node_name, agent_node_name
+
+        if any(p in query_words_all for p in FIRST_PERSON_PRONOUNS) and speaker:
+            resolved_cues.add(speaker.lower())
+        if any(p in query_words_all for p in SECOND_PERSON_PRONOUNS) and listener:
+            resolved_cues.add(listener.lower())
+
+        # Add user/agent names if explicitly mentioned in query
+        user_aliases = {"user"}
+        if user_id:
+            user_aliases.add(user_id.lower())
+        if user_node_name:
+            user_aliases.add(user_node_name.lower())
+
+        agent_aliases = {"ai friend", "my friend"}
+        if getattr(Config, "AI_NAME", None):
+            agent_aliases.add(Config.AI_NAME.lower())
+        if agent_node_name:
+            agent_aliases.add(agent_node_name.lower())
+
+        for word in query_words_all:
+            if word in user_aliases and user_node_name:
+                resolved_cues.add(user_node_name.lower())
+            if word in agent_aliases and agent_node_name:
+                resolved_cues.add(agent_node_name.lower())
+
+        return resolved_cues
+
+    @staticmethod
+    def _apply_direct_cue_boost(raw_candidates, matched_cues) -> set:
+        """Add DIRECT_CUE_BOOST per literal query cue found in a memory.
+
+        Returns the indices that were boosted; PPR treats these as seeds when
+        the query itself names no known entity.
+        """
+        direct_boosted_indices = set()
+        if not matched_cues:
+            return direct_boosted_indices
+        for idx, cand in enumerate(raw_candidates):
+            content_lower = cand["content"].lower()
+            match_count = sum(1 for mc in matched_cues if mc in content_lower)
+            if match_count > 0:
+                cand["score"] += DIRECT_CUE_BOOST * match_count
+                direct_boosted_indices.add(idx)
+        return direct_boosted_indices
+
+    def _apply_ppr_spreading_activation(
+        self,
+        raw_candidates,
+        entity_names,
+        adj,
+        matched_cues,
+        direct_boosted_indices,
+        agent_node_name,
+    ) -> None:
+        """HippoRAG-inspired Personalized PageRank spreading activation.
+
+        Seeds are the query's entity cues (or, failing that, the entities of
+        directly-cued memories), and each candidate gains a degree-scaled boost
+        for the seeded entities it mentions.
+        """
+        if not entity_names:
+            return
+        try:
+            seeds = self._collect_ppr_seeds(
+                entity_names, matched_cues, direct_boosted_indices, raw_candidates
+            )
+
+            # Compute Personalized PageRank Vector (3-iteration power method,
+            # delegated to the Rust hot loop with a Python fallback).
+            # PPR_DAMPING is the canonical teleport factor.
+            if not seeds:
+                ppr = {}
+            else:
+                p = self._personalized_pagerank(
+                    entity_names, adj, seeds, PPR_DAMPING, 3
+                )
+                ppr = {entity_names[i]: p[i] for i in range(len(entity_names))}
+
+            cand_entities = self._map_candidate_entities(
+                raw_candidates, entity_names, agent_node_name
+            )
+
+            # Apply spreading activation boost based on PPR probability
+            for idx, cand in enumerate(raw_candidates):
+                if idx in direct_boosted_indices:
+                    continue
+                boost_sum = 0.0
+                for ent in cand_entities[idx]:
+                    if ent in ppr:
+                        deg = len(adj.get(ent, set()))
+                        # HippoRAG-inspired degree-scaled activation boost
+                        boost = (1.2 * ppr[ent]) / (1.0 + math.log(max(1, deg)))
+                        boost_sum += boost
+                if boost_sum > 0:
+                    cand["score"] += boost_sum
+
+        except Exception as ne_err:
+            logger.error(f"PPR spreading activation failed: {ne_err}")
+
+    @staticmethod
+    def _collect_ppr_seeds(
+        entity_names, matched_cues, direct_boosted_indices, raw_candidates
+    ) -> set:
+        """Pick the PPR seed entities for this query."""
+        seeds = set()
+
+        # 1. Query cues that match entity names
+        for cue in matched_cues:
+            for idx, name in enumerate(entity_names):
+                if name.lower() == cue.lower():
+                    seeds.add(idx)
+
+        # 2. If no direct query seeds, use entities from directly cued memories
+        #    (vector-guided associative recall)
+        if not seeds:
+            for idx in direct_boosted_indices:
+                cand = raw_candidates[idx]
+                payload_meta = cand.get("metadata") or {}
+                cand_ents = payload_meta.get("entities", [])
+                if not cand_ents:
+                    content_lower = cand["content"].lower()
+                    for e_idx, name in enumerate(entity_names):
+                        pattern = rf"\b{re.escape(name.lower())}\b"
+                        if re.search(pattern, content_lower):
+                            seeds.add(e_idx)
+                else:
+                    for ent in cand_ents:
+                        for e_idx, name in enumerate(entity_names):
+                            if name.lower() == ent.lower():
+                                seeds.add(e_idx)
+        return seeds
+
+    @staticmethod
+    def _map_candidate_entities(raw_candidates, entity_names, agent_node_name) -> dict:
+        """Map each candidate index to the entity names it mentions.
+
+        Prefers entities recorded in the memory's metadata; falls back to
+        scanning the content. First-person pronouns count as a mention of the
+        agent itself.
+        """
+
+        def present_entities(content: str) -> set:
+            content_lower = content.lower()
+            present = set()
+            for name in entity_names:
+                pattern = rf"\b{re.escape(name.lower())}\b"
+                if re.search(pattern, content_lower):
+                    present.add(name)
+            if agent_node_name and any(
+                re.search(rf"\b{re.escape(pr)}\b", content_lower)
+                for pr in FIRST_PERSON_PRONOUNS
+            ):
+                present.add(agent_node_name)
+            return present
+
+        cand_entities = {}
+        for idx, cand in enumerate(raw_candidates):
+            payload_meta = cand.get("metadata") or {}
+            if "entities" in payload_meta and isinstance(
+                payload_meta["entities"], list
+            ):
+                cand_entities[idx] = set(payload_meta["entities"])
+                if agent_node_name and any(
+                    re.search(rf"\b{re.escape(pr)}\b", cand["content"].lower())
+                    for pr in FIRST_PERSON_PRONOUNS
+                ):
+                    cand_entities[idx].add(agent_node_name)
+            else:
+                cand_entities[idx] = present_entities(cand["content"])
+        return cand_entities
+
+    def _apply_goal_buffer_boost(self, raw_candidates) -> None:
+        """Prime candidates that mention concepts held in the active goal buffer."""
+        active_concepts = [c[0] for c in self.goal_buffer.concepts]
+        if not active_concepts:
+            return
+        for cand in raw_candidates:
+            content_lower = cand["content"].lower()
+            match_count = sum(1 for c in active_concepts if c in content_lower)
+            if match_count > 0:
+                w_j = 1.5 / len(active_concepts)
+                boost = match_count * w_j * 1.2
+                cand["score"] += boost
+                logger.debug(
+                    f"GoalBuffer Prime: Added +{boost:.3f} spreading activation to memory {cand.get('id') or cand.get('content', 'N/A')}"
+                )
+
+    @staticmethod
+    def _format_results(raw_candidates, threshold) -> list:
+        """Drop sub-threshold candidates and project them to the public shape."""
+        results = []
+        for cand in raw_candidates:
+            if cand["score"] <= threshold:
+                continue
+            results.append(
+                {
+                    "content": cand["content"],
+                    "raw_content": cand["raw_content"],
+                    "wing": cand["wing"],
+                    "room": cand["room"],
+                    "score": cand["score"],
+                    "valence": cand["valence"],
+                    "created_at": cand["created_at"].isoformat()
+                    if cand["created_at"]
+                    else None,
+                    "recall_count": cand["recall_count"],
+                    "metadata": cand["metadata"],
+                    # Eriksonian columns
+                    "lifespan_stage": cand.get("lifespan_stage"),
+                    "crisis": cand.get("crisis"),
+                    "virtue": cand.get("virtue"),
+                    "relations": cand.get("relations"),
+                    "relation_circles": cand.get("relation_circles"),
+                    "modality": cand.get("modality"),
+                }
+            )
+        return results
+
+    # --- L3 sub-conscious archive search and promotion -------------------
+
+    def _expand_archive_cues(
+        self, query_words, dynamic_stop_words, matched_cues, resolved_cues, user_id
+    ) -> set:
+        """Build the lexical cue set used to probe archived (L3) memories.
+
+        Unlike the active-tier cues, the speaker's own name is *kept* here: an
+        archived memory is often only findable by who it was about. Cues are
+        then widened by stemming and the learned mental lexicon.
+        """
+        archive_stop_words = set(dynamic_stop_words)
+        if user_id:
+            for w in re.findall(r"\b\w{3,}\b", user_id.lower()):
+                archive_stop_words.discard(w)
+        archive_cues = [w for w in query_words if w not in archive_stop_words]
+
+        # Also include any resolved cues (agent name / resolved user name)
+        for cue in resolved_cues:
+            if cue not in archive_cues:
+                archive_cues.append(cue)
+
+        if not archive_cues:
+            archive_cues = list(matched_cues)
+
+        # Apply lexical priming/synonym expansion to cues
+        expanded_cues = set()
+        for cue in archive_cues:
+            expanded_cues.add(cue)
+            stem = _get_stem(cue)
+            expanded_cues.add(stem)
+            # Learned lexical priming: pull the cue's strongest acquired
+            # associates (empty until the lexicon has learned them).
+            expanded_cues.update(self.lexicon.expand(cue))
+            expanded_cues.update(self.lexicon.expand(stem))
+        return expanded_cues
+
+    async def _fetch_archive_rows(self, expanded_cues_list, wing, vector_str) -> list:
+        """Hybrid semantic + lexical lookup against archived_memories."""
+        patterns = [f"%{cue}%" for cue in expanded_cues_list]
+        # Fetch more candidates than needed so they can be re-ranked by keyword
+        # match count and ACT-R score before the promotion cut.
+        archive_limit = 250
+        try:
+            async with self.pool.acquire() as conn:
+                if self.is_sqlite:
+                    where_clause = " OR ".join(
+                        "lower(content) LIKE ?" for _ in expanded_cues_list
+                    )
+                    query = f"""
+                        SELECT * FROM archived_memories
+                        WHERE wing = ? AND ({where_clause})
+                        ORDER BY importance_score DESC, last_recalled_at DESC
+                        LIMIT ?
+                    """
+                    return await conn.fetch(query, wing, *patterns, archive_limit)
+                # Postgres pgvector: hybrid semantic + lexical synonym search
+                # using the HNSW index over halfvec.
+                query = """
+                    SELECT *, (1 - (embedding <=> $2::halfvec))::double precision AS similarity_arch
+                    FROM archived_memories
+                    WHERE wing = $1 AND (embedding <=> $2::halfvec < 0.45 OR content ILIKE ANY($3))
+                    ORDER BY coalesce((1 - (embedding <=> $2::halfvec)), 0.0) DESC, importance_score DESC, last_recalled_at DESC
+                    LIMIT $4
+                """
+                return await conn.fetch(
+                    query, wing, vector_str, patterns, archive_limit
+                )
+        except Exception as arch_err:
+            logger.error(f"Archived memories hybrid lookup failed: {arch_err}")
+            return []
+
+    @staticmethod
+    def _parse_stored_embedding(emb_val):
+        """Parse an archived embedding stored as JSON text, a vector literal, or a list."""
+        if not emb_val:
+            return None
+        if isinstance(emb_val, list):
+            return emb_val
+        if isinstance(emb_val, str):
+            try:
+                return json.loads(emb_val)
+            except Exception:
+                try:
+                    return [
+                        float(x)
+                        for x in re.findall(
+                            r"[-+]?\d*\.\d+|\d+e[-+]?\d+|[-+]?\d+", emb_val
+                        )
+                    ]
+                except Exception:
+                    return None
+        return None
+
+    def _archive_row_activation(
+        self,
+        row,
+        similarity,
+        *,
+        current_valence,
+        current_arousal,
+        current_cortisol,
+        current_time,
+    ):
+        """ACT-R activation for one archived row.
+
+        Returns (score, spread_activation, dist_emo, recall_count) - the extra
+        terms are reused when the row is promoted and rescored as active.
+        """
+        recall_count = max(1, row.get("recall_count") or 1)
+        last_recall = row.get("last_recalled_at")
+        now = (
+            self._as_aware_utc(current_time)
+            if current_time is not None
+            else datetime.now(timezone.utc)
+        )
+        last_recall = now if last_recall is None else self._as_aware_utc(last_recall)
+
+        hours_since = max(0.001, (now - last_recall).total_seconds() / 3600.0)
+        memory_valence = row.get("valence") or 0.0
+        emotion_weight_row = row.get("emotional_weight") or 0.0
+
+        dist_emo = math.sqrt(
+            (memory_valence - current_valence) ** 2
+            + (emotion_weight_row - current_arousal) ** 2
+        )
+
+        base_activation = self._base_activation(
+            recall_count, hours_since, row.get("importance_score") or 0.5, dist_emo
+        )
+        effective_similarity = self._effective_similarity(
+            similarity,
+            memory_valence,
+            emotion_weight_row,
+            current_arousal,
+            current_cortisol,
+        )
+        spread_activation = self.spread_weight * effective_similarity
+        score = (
+            base_activation + spread_activation - ACTR_EMO_DISTANCE_PENALTY * dist_emo
+        )
+        return score, spread_activation, dist_emo, recall_count, now
+
+    async def _rank_archive_rows(
+        self,
+        archive_rows,
+        expanded_cues,
+        query_vector,
+        *,
+        limit,
+        current_valence,
+        current_arousal,
+        current_cortisol,
+        current_time,
+    ) -> list:
+        """Score archived rows and keep the best few for promotion."""
+        scored_archive_rows = []
+        for row in archive_rows:
+            content = row.get("content", "")
+            similarity = row.get("similarity_arch")
+            if similarity is None:
+                similarity = self._archive_similarity_fallback(row, query_vector)
+
+            score, _spread, _dist, _recall, _now = self._archive_row_activation(
+                row,
+                similarity,
+                current_valence=current_valence,
+                current_arousal=current_arousal,
+                current_cortisol=current_cortisol,
+                current_time=current_time,
+            )
+
+            # Lexical match count boost so direct query matches sort higher
+            # (HippoRAG key-relevance ranking).
+            content_lower = content.lower()
+            match_count = sum(1 for cue in expanded_cues if cue in content_lower)
+            ranking_score = score + DIRECT_CUE_BOOST * match_count
+
+            scored_archive_rows.append((ranking_score, score, similarity, row))
+
+        scored_archive_rows.sort(key=lambda x: x[0], reverse=True)
+        # Limit the promotion list to prevent flooding the active tier
+        promote_limit = min(5, limit) if limit else 5
+        return scored_archive_rows[:promote_limit]
+
+    @staticmethod
+    def _archive_similarity_fallback(row, query_vector) -> float:
+        """Cosine similarity computed in Python when the DB did not supply one."""
+        emb = MemoryStore._parse_stored_embedding(row.get("embedding"))
+        if not emb or not query_vector:
+            return 0.0
+        import numpy as np
+
+        q_arr = np.array(query_vector)
+        emb_arr = np.array(emb)
+        norm_q = np.linalg.norm(q_arr)
+        norm_emb = np.linalg.norm(emb_arr)
+        if norm_q > 0 and norm_emb > 0:
+            return float(np.dot(q_arr, emb_arr) / (norm_q * norm_emb))
+        return 0.0
+
+    async def _write_promoted_memory(self, mem_id, content, row, emb, recall_count, now, payload_meta):
+        """Move one archived row back into the active tier (SQL + Qdrant)."""
+        insert_values = (
+            mem_id,
+            content,
+            row.get("raw_content"),
+            row.get("wing"),
+            row.get("room"),
+            str(emb),
+            row.get("importance_score"),
+            row.get("emotional_weight"),
+            row.get("valence"),
+            row.get("certainty"),
+            row.get("source"),
+            recall_count + 1,
+            now,
+            row.get("created_at"),
+            json.dumps(payload_meta),
+            row.get("lifespan_stage"),
+            row.get("crisis"),
+            row.get("virtue"),
+            row.get("relations"),
+            row.get("relation_circles"),
+            row.get("modality"),
+        )
+        async with self.pool.acquire() as conn:
+            if self.is_sqlite:
+                await conn.execute(_PROMOTE_INSERT_SQLITE, *insert_values)
+                await conn.execute(
+                    "DELETE FROM archived_memories WHERE id = ?", mem_id
+                )
+            else:
+                await conn.execute(_PROMOTE_INSERT_PG, *insert_values)
+                await conn.execute(
+                    "DELETE FROM archived_memories WHERE id = $1", mem_id
+                )
+
+        # Upsert Qdrant
+        if self.qdrant_store and self.qdrant_store.client:
+            await asyncio.to_thread(
+                self.qdrant_store.add_vector_memory,
+                mem_id,
+                emb,
+                content,
+                payload_meta,
+            )
+
+        logger.info(
+            f"📥 [Memory Promotion] Promoted memory '{content[:40]}...' from archive back to active storage."
+        )
+
+    @staticmethod
+    def _build_promotion_payload(row, raw_meta) -> dict:
+        """Qdrant payload for a memory being promoted out of the archive."""
+        return {
+            "wing": row.get("wing", "personal"),
+            "room": row.get("room") or "",
+            "importance_score": row.get("importance_score"),
+            "emotional_weight": row.get("emotional_weight"),
+            "valence": row.get("valence"),
+            "certainty": row.get("certainty"),
+            "source": row.get("source"),
+            "created_at": row.get("created_at").isoformat()
+            if row.get("created_at")
+            else None,
+            "lifespan_stage": row.get("lifespan_stage") or "",
+            "crisis": row.get("crisis") or "",
+            "virtue": row.get("virtue") or "",
+            "relations": row.get("relations") or "",
+            "relation_circles": row.get("relation_circles") or "",
+            "modality": row.get("modality") or "",
+            **(raw_meta or {}),
+        }
+
+    async def _promote_archived_rows(
+        self,
+        scored_archive_rows,
+        matched_cues,
+        *,
+        threshold,
+        current_valence,
+        current_arousal,
+        current_cortisol,
+        current_time,
+    ) -> list:
+        """Promote qualifying archived rows to the active tier and return them."""
+        promoted_results = []
+        for _ranking_score, score, similarity, row in scored_archive_rows:
+            content = row["content"]
+
+            emb = self._parse_stored_embedding(row.get("embedding"))
+            # Fallback to the embedding API if the archived row has none
+            if not emb:
+                emb = await self.get_embedding(content)
+                if not emb:
+                    continue
+
+            (
+                _score,
+                spread_activation,
+                dist_emo,
+                recall_count,
+                now,
+            ) = self._archive_row_activation(
+                row,
+                similarity,
+                current_valence=current_valence,
+                current_arousal=current_arousal,
+                current_cortisol=current_cortisol,
+                current_time=current_time,
+            )
+
+            # Only promote if it passes the threshold or is a milestone memory
+            if not (
+                score > (threshold - 2.5)
+                or (row.get("importance_score") or 0.5) >= 0.7
+            ):
+                continue
+
+            mem_id = str(row.get("id") or uuid.uuid4())
+            raw_meta = row.get("metadata")
+            if isinstance(raw_meta, str):
+                try:
+                    raw_meta = json.loads(raw_meta)
+                except Exception:
+                    raw_meta = {}
+            elif not isinstance(raw_meta, dict):
+                raw_meta = {}
+
+            payload_meta = self._build_promotion_payload(row, raw_meta)
+
+            try:
+                await self._write_promoted_memory(
+                    mem_id, content, row, emb, recall_count, now, payload_meta
+                )
+            except Exception as prom_err:
+                logger.error(f"Failed to promote memory {mem_id}: {prom_err}")
+
+            created = row.get("created_at")
+            if created and created.tzinfo is None:
+                created = created.replace(tzinfo=timezone.utc)
+
+            # Rescore as an active memory: recall_count was incremented on
+            # promotion and last_recalled_at is now, so recency is ~0.
+            base_activation_active = self._base_activation(
+                recall_count + 1, 0.001, row.get("importance_score") or 0.5, dist_emo
+            )
+            score_active = (
+                base_activation_active
+                + spread_activation
+                - ACTR_EMO_DISTANCE_PENALTY * dist_emo
+            )
+            # Apply direct cue boost since it was promoted for keyword matches
+            match_count = sum(1 for mc in matched_cues if mc in content.lower())
+            score_active += DIRECT_CUE_BOOST * match_count
+
+            promoted_results.append(
+                {
+                    "content": content,
+                    "raw_content": row.get("raw_content") or content,
+                    "wing": row.get("wing", "personal"),
+                    "room": row.get("room"),
+                    "score": score_active,
+                    "valence": row.get("valence") or 0.0,
+                    "created_at": created.isoformat() if created else None,
+                    "recall_count": recall_count + 1,
+                    "metadata": raw_meta or {},
+                    "lifespan_stage": row.get("lifespan_stage"),
+                    "crisis": row.get("crisis"),
+                    "virtue": row.get("virtue"),
+                    "relations": row.get("relations"),
+                    "relation_circles": row.get("relation_circles"),
+                    "modality": row.get("modality"),
+                }
+            )
+        return promoted_results
+
+    async def _recall_from_archive(
+        self,
+        *,
+        query_words,
+        dynamic_stop_words,
+        matched_cues,
+        resolved_cues,
+        user_id,
+        wing,
+        vector_str,
+        query_vector,
+        existing_results,
+        excluded,
+        limit,
+        threshold,
+        current_valence,
+        current_arousal,
+        current_cortisol,
+        current_time,
+    ) -> list:
+        """L3 sub-conscious search: surface archived memories and promote the best."""
+        expanded_cues = self._expand_archive_cues(
+            query_words, dynamic_stop_words, matched_cues, resolved_cues, user_id
+        )
+        archive_rows = await self._fetch_archive_rows(
+            list(expanded_cues), wing, vector_str
+        )
+        if not archive_rows:
+            return []
+
+        active_contents = {res["content"] for res in existing_results}
+        archive_rows = [
+            r
+            for r in archive_rows
+            if r.get("content")
+            and r["content"] not in active_contents
+            and r["content"] not in excluded
+        ]
+        if not archive_rows:
+            return []
+
+        scored_archive_rows = await self._rank_archive_rows(
+            archive_rows,
+            expanded_cues,
+            query_vector,
+            limit=limit,
+            current_valence=current_valence,
+            current_arousal=current_arousal,
+            current_cortisol=current_cortisol,
+            current_time=current_time,
+        )
+        return await self._promote_archived_rows(
+            scored_archive_rows,
+            matched_cues,
+            threshold=threshold,
+            current_valence=current_valence,
+            current_arousal=current_arousal,
+            current_cortisol=current_cortisol,
+            current_time=current_time,
+        )
+
     async def search_memories(
         self,
         query_text,
@@ -766,10 +2242,15 @@ class MemoryStore:
         current_time=None,
     ):
         """
-        ACT-R Based Retrieval with Hieraining & Neuromodulatory Gating:
-            Score = Bᵢ + w_spread·Similarity_eff + w_emotion·EmotionalAlignment
+        ACT-R Based Retrieval with Hierarchical & Neuromodulatory Gating:
+            Score = B_i + w_spread*Similarity_eff + w_emotion*EmotionalAlignment
 
         Filters results by 'wing' and optionally 'room' before scoring.
+
+        The pipeline runs as: L1 cache -> embed + MRL gating -> candidate fetch
+        (Qdrant, else SQL) -> lexical/graph cue analysis -> spreading-activation
+        boosts -> threshold + format -> L3 archive promotion -> sort/limit.
+        Each stage is a `_`-prefixed helper defined above.
         """
         # L1 Cache lookup to bypass DB and math activation loops for active topics
         cache_key = (
@@ -814,1526 +2295,146 @@ class MemoryStore:
             if not query_vector:
                 return []
 
-            # Dynamic Matryoshka Representation Learning (MRL) dimension gating based on stress/arousal/fatigue
-            # Higher stress/arousal/fatigue restricts search bandwidth to a smaller Matryoshka prefix to bound latency.
-            stress_index = max(current_arousal, current_cortisol)
-            if stress_index > 0.8:
-                mrl_dim = 256
-                candidate_limit = max(10, limit * 2 if limit is not None else 10)
-            elif stress_index > 0.6:
-                mrl_dim = 512
-                candidate_limit = max(30, limit * 3 if limit is not None else 30)
-            else:
-                mrl_dim = 768
-                candidate_limit = (
-                    max(120, limit * 6 if limit is not None else 120)
-                    if refresh_on_recall
-                    else max(20, limit * 3 if limit is not None else 20)
-                )
+            mrl_dim, candidate_limit = self._compute_mrl_gating(
+                current_arousal, current_cortisol, limit, refresh_on_recall
+            )
 
             # Slice query_vector to mrl_dim and pad with zeros to 768
             mrl_query_vector = list(query_vector)
             for i in range(mrl_dim, len(mrl_query_vector)):
                 mrl_query_vector[i] = 0.0
 
-            # Topic-Shift check:
-            if self._last_query_vector is not None:
-                try:
-                    dot = sum(
-                        a * b for a, b in zip(query_vector, self._last_query_vector)
-                    )
-                    norm1 = math.sqrt(sum(a * a for a in query_vector))
-                    norm2 = math.sqrt(sum(b * b for b in self._last_query_vector))
-                    sim = (
-                        dot / (norm1 * norm2) if norm1 > 1e-9 and norm2 > 1e-9 else 1.0
-                    )
-                    if sim < 0.15:
-                        logger.info(
-                            f"🔄 Topic Shift Detected (similarity {sim:.3f} < 0.15). Flushing Goal Buffer."
-                        )
-                        self.goal_buffer.flush()
-                except Exception as ts_err:
-                    logger.debug(f"Topic-shift calculation failed: {ts_err}")
-            self._last_query_vector = query_vector
+            self._detect_topic_shift(query_vector)
 
             vector_str = str(mrl_query_vector)
             excluded = {content for content in (exclude_contents or []) if content}
-
             is_sqlite = self.is_sqlite
-            raw_candidates = []
-
-            # Non-blocking wrapper to query Qdrant via a thread pool
-            async def safe_qdrant_search():
-                try:
-                    if self.qdrant_store.client:
-                        return await asyncio.to_thread(
-                            self.qdrant_store.search_vector_memories,
-                            query_vector=mrl_query_vector,
-                            limit=candidate_limit,
-                        )
-                except Exception as qe:
-                    logger.error(f"Qdrant retrieval failed: {qe}")
-                return []
-
-            async def _dummy_list():
-                return []
 
             # Concurrently fetch vector candidates and Neo4j graph data
-            candidates, entity_records, relation_records = await asyncio.gather(
-                safe_qdrant_search(),
-                self.graph_db.execute_query(
-                    "MATCH (e:Entity) RETURN e.name AS name, e.description AS description",
-                    use_cache=True,
-                )
-                if self.graph_db
-                else _dummy_list(),
-                self.graph_db.execute_query(
-                    "MATCH (s:Entity)-[r]-(t:Entity) RETURN s.name AS source, t.name AS target",
-                    use_cache=True,
-                )
-                if self.graph_db
-                else _dummy_list(),
-            )
-
-            # Defensive type checks
-            if not isinstance(entity_records, list):
-                entity_records = []
-            if not isinstance(relation_records, list):
-                relation_records = []
+            (
+                candidates,
+                entity_records,
+                relation_records,
+            ) = await self._gather_candidate_sources(mrl_query_vector, candidate_limit)
 
             # 1. Qdrant Selective Vector Path
+            raw_candidates = []
             if self.qdrant_store.client and candidates:
-                try:
-                    db_metadata = {}
-                    try:
-                        cand_ids = [c["id"] for c in candidates if c.get("id")]
-                        if cand_ids:
-                            async with self.pool.acquire() as conn:
-                                if self.is_sqlite:
-                                    placeholders = ",".join("?" for _ in cand_ids)
-                                    rows = await conn.fetch(
-                                        f"SELECT id, importance_score, emotional_weight, valence, recall_count, last_recalled_at FROM memories WHERE id IN ({placeholders})",
-                                        *cand_ids,
-                                    )
-                                else:
-                                    rows = await conn.fetch(
-                                        "SELECT id, importance_score, emotional_weight, valence, recall_count, last_recalled_at FROM memories WHERE id = ANY($1)",
-                                        cand_ids,
-                                    )
-                                for r in rows:
-                                    db_metadata[str(r["id"])] = r
-                    except Exception as db_err:
-                        logger.warning(
-                            f"Failed to fetch updated memory metadata from SQL DB for Qdrant candidates: {db_err}"
-                        )
+                raw_candidates = await self._score_qdrant_candidates(
+                    candidates,
+                    wing=wing,
+                    room=room,
+                    excluded=excluded,
+                    threshold=threshold,
+                    current_valence=current_valence,
+                    current_arousal=current_arousal,
+                    current_cortisol=current_cortisol,
+                    current_time=current_time,
+                    now_ts=now_ts,
+                )
 
-                    for cand in candidates:
-                        meta = cand["metadata"]
-                        c_wing = meta.get("wing")
-                        c_room = meta.get("room")
-                        if wing is not None and c_wing != wing:
-                            continue
-                        if room is not None and c_room != room:
-                            continue
-
-                        c_content = cand["content"]
-                        if c_content in excluded:
-                            continue
-
-                        memory_id = cand["id"]
-                        db_meta = db_metadata.get(str(memory_id))
-
-                        memory_valence = (
-                            db_meta.get("valence")
-                            if (db_meta and db_meta.get("valence") is not None)
-                            else meta.get("valence", 0.0)
-                        )
-                        emotion_weight_row = (
-                            db_meta.get("emotional_weight")
-                            if (db_meta and db_meta.get("emotional_weight") is not None)
-                            else meta.get("emotional_weight", 0.0)
-                        )
-                        importance_score = (
-                            db_meta.get("importance_score")
-                            if (db_meta and db_meta.get("importance_score") is not None)
-                            else meta.get("importance_score", 0.5)
-                        )
-                        recall_count = max(
-                            1,
-                            db_meta.get("recall_count")
-                            if (db_meta and db_meta.get("recall_count") is not None)
-                            else meta.get("recall_count", 1),
-                        )
-
-                        try:
-                            if db_meta and db_meta.get("last_recalled_at"):
-                                last_recall_time = db_meta.get("last_recalled_at")
-                                if isinstance(last_recall_time, (int, float)):
-                                    last_recall_time = float(last_recall_time)
-                                else:
-                                    if hasattr(last_recall_time, "timestamp"):
-                                        last_recall_time = last_recall_time.timestamp()
-                                    else:
-                                        dt = datetime.fromisoformat(
-                                            str(last_recall_time).replace(" ", "T")
-                                        )
-                                        if dt.tzinfo is None:
-                                            dt = dt.replace(tzinfo=timezone.utc)
-                                        last_recall_time = dt.timestamp()
-                            else:
-                                last_recall_time = float(
-                                    meta.get("last_recalled_at", now_ts)
-                                )
-                        except (ValueError, TypeError):
-                            last_recall_time = now_ts
-
-                        hours_since = max(0.001, (now_ts - last_recall_time) / 3600.0)
-
-                        # 2D/3D Emotional Distance matching the research simulator
-                        dist_emo = math.sqrt(
-                            (memory_valence - current_valence) ** 2
-                            + (emotion_weight_row - current_arousal) ** 2
-                        )
-
-                        base_activation = self._base_activation(
-                            recall_count, hours_since, importance_score, dist_emo
-                        )
-
-                        similarity = cand["score"]
-                        effective_similarity = self._effective_similarity(
-                            similarity,
-                            memory_valence,
-                            emotion_weight_row,
-                            current_arousal,
-                            current_cortisol,
-                        )
-
-                        spread_activation = self.spread_weight * effective_similarity
-                        score = (
-                            base_activation
-                            + spread_activation
-                            - ACTR_EMO_DISTANCE_PENALTY * dist_emo
-                        )
-
-                        if score <= (threshold - 2.5) and importance_score < 0.7:
-                            continue
-
-                        created_val = meta.get("created_at")
-                        try:
-                            created = (
-                                datetime.fromtimestamp(float(created_val), timezone.utc)
-                                if created_val
-                                else (
-                                    current_time
-                                    if current_time is not None
-                                    else datetime.now(timezone.utc)
-                                )
-                            )
-                        except Exception:
-                            created = (
-                                current_time
-                                if current_time is not None
-                                else datetime.now(timezone.utc)
-                            )
-
-                        custom_metadata = {}
-                        if "custom_metadata" in meta:
-                            try:
-                                custom_metadata = orjson.loads(meta["custom_metadata"])
-                            except Exception:
-                                pass
-
-                        raw_candidates.append(
-                            {
-                                "id": memory_id,
-                                "content": c_content,
-                                "raw_content": c_content,
-                                "wing": c_wing or "personal",
-                                "room": c_room,
-                                "score": score,
-                                "valence": memory_valence,
-                                "created_at": created,
-                                "recall_count": recall_count,
-                                "metadata": custom_metadata,
-                                "lifespan_stage": meta.get("lifespan_stage"),
-                                "crisis": meta.get("crisis"),
-                                "virtue": meta.get("virtue"),
-                                "relations": meta.get("relations"),
-                                "relation_circles": meta.get("relation_circles"),
-                                "modality": meta.get("modality"),
-                                "similarity": similarity,
-                                "last_recalled_at": datetime.fromtimestamp(
-                                    last_recall_time, timezone.utc
-                                ),
-                            }
-                        )
-                except Exception as qe:
-                    logger.error(
-                        f"Qdrant retrieval failed, falling back to database: {qe}"
-                    )
-
-            # 2. Database Fallback (if Qdrant is offline or returned no candidates)
+            # 2. Database Fallback (Qdrant offline or returned no candidates)
             if not raw_candidates:
                 async with self.pool.acquire() as conn:
                     if is_sqlite:
-                        # SQLite fallback: fetch relevant memories and compute similarity in Python
-                        if room is not None:
-                            rows = await conn.fetch(
-                                "SELECT * FROM memories WHERE wing = ? AND room = ?",
-                                wing,
-                                room,
-                            )
-                        else:
-                            rows = await conn.fetch(
-                                "SELECT * FROM memories WHERE wing = ?", wing
-                            )
-
-                        # Manual cosine similarity and ACT-R scoring (Delegated to Rust PyO3)
-                        import cognitive_rust
-
-                        now = (
-                            current_time
-                            if current_time is not None
-                            else datetime.now(timezone.utc)
+                        # The SQLite path recomputes "now"; keep its value, it is
+                        # what stamps the L1 cache entry below.
+                        raw_candidates, now_ts = await self._fetch_sqlite_candidates(
+                            conn,
+                            query_vector=query_vector,
+                            wing=wing,
+                            room=room,
+                            excluded=excluded,
+                            threshold=threshold,
+                            current_valence=current_valence,
+                            current_arousal=current_arousal,
+                            current_cortisol=current_cortisol,
+                            current_time=current_time,
                         )
-                        now_ts = now.timestamp()
-
-                        # Preprocess timestamps for Rust
-                        for row in rows:
-                            last_recall = row.get("last_recalled_at")
-                            if last_recall is None:
-                                row["_last_recall_ts"] = now_ts
-                            elif isinstance(last_recall, datetime):
-                                row["_last_recall_ts"] = last_recall.timestamp()
-                            elif isinstance(last_recall, (int, float)):
-                                row["_last_recall_ts"] = float(last_recall)
-                            elif isinstance(last_recall, str):
-                                try:
-                                    row["_last_recall_ts"] = float(last_recall)
-                                except ValueError:
-                                    try:
-                                        dt = datetime.fromisoformat(
-                                            last_recall.replace(" ", "T")
-                                        )
-                                        if dt.tzinfo is None:
-                                            dt = dt.replace(tzinfo=timezone.utc)
-                                        row["_last_recall_ts"] = dt.timestamp()
-                                    except Exception:
-                                        row["_last_recall_ts"] = now_ts
-                            else:
-                                row["_last_recall_ts"] = now_ts
-
-                        scored_indices = cognitive_rust.score_memories_actr_sqlite(
-                            query_vector,
-                            rows,
-                            excluded,
-                            current_valence,
-                            current_arousal,
-                            current_cortisol,
-                            self.decay_rate,
-                            self.spread_weight,
-                            threshold,
-                            now_ts,
-                        )
-
-                        for idx, score, similarity in scored_indices:
-                            row = rows[idx]
-                            last_recall = row.get("last_recalled_at")
-                            if last_recall is None:
-                                last_recall = now
-                            elif isinstance(last_recall, str):
-                                try:
-                                    last_recall = datetime.fromisoformat(last_recall)
-                                except Exception:
-                                    last_recall = now
-                            if last_recall.tzinfo is None:
-                                last_recall = last_recall.replace(tzinfo=timezone.utc)
-
-                            created = row.get("created_at")
-                            if isinstance(created, str):
-                                try:
-                                    created = datetime.fromisoformat(created)
-                                except Exception:
-                                    created = now
-                            if created and created.tzinfo is None:
-                                created = created.replace(tzinfo=timezone.utc)
-
-                            raw_meta = row.get("metadata")
-                            if isinstance(raw_meta, str):
-                                try:
-                                    raw_meta = orjson.loads(raw_meta)
-                                except Exception:
-                                    raw_meta = {}
-
-                            raw_candidates.append(
-                                {
-                                    "id": row.get("id"),
-                                    "content": row["content"],
-                                    "raw_content": row.get("raw_content")
-                                    or row["content"],
-                                    "wing": row.get("wing", "personal"),
-                                    "room": row.get("room"),
-                                    "score": score,
-                                    "valence": row.get("valence") or 0.0,
-                                    "created_at": created,
-                                    "recall_count": max(
-                                        1, row.get("recall_count") or 1
-                                    ),
-                                    "metadata": raw_meta or {},
-                                    "lifespan_stage": row.get("lifespan_stage"),
-                                    "crisis": row.get("crisis"),
-                                    "virtue": row.get("virtue"),
-                                    "relations": row.get("relations"),
-                                    "relation_circles": row.get("relation_circles"),
-                                    "modality": row.get("modality"),
-                                    "similarity": similarity,
-                                    "last_recalled_at": last_recall,
-                                }
-                            )
                     else:
-                        # PostgreSQL fast-path via custom C-level vector procedure
-                        try:
-                            rows = await conn.fetch(
-                                """
-                                SELECT
-                                    m.id AS id,
-                                    s.content,
-                                    s.raw_content,
-                                    s.wing,
-                                    s.room,
-                                    s.importance_score,
-                                    s.emotional_weight,
-                                    s.valence,
-                                    s.recall_count,
-                                    s.last_recalled_at,
-                                    s.created_at,
-                                    s.metadata,
-                                    s.similarity,
-                                    s.score,
-                                    m.lifespan_stage,
-                                    m.crisis,
-                                    m.virtue,
-                                    m.relations,
-                                    m.relation_circles,
-                                    m.modality
-                                FROM surface_actr_memories($1::vector(768), $2::text, $3::text, $4::double precision, $5::double precision, $6::double precision, $7::double precision, $8::double precision, $9::double precision, $10::double precision, $11::integer, $12::timestamptz) s
-                                LEFT JOIN memories m ON m.content = s.content AND m.wing = s.wing
-                                """,
-                                vector_str,
-                                wing,
-                                room,
-                                self.decay_rate,
-                                self.spread_weight,
-                                self.emotion_weight,
-                                current_valence,
-                                current_arousal,
-                                current_cortisol,
-                                threshold - 2.5,
-                                candidate_limit,
-                                current_time,
-                            )
-                        except Exception as pg_err:
-                            logger.warning(
-                                f"Eriksonian JOIN pg query failed, falling back to legacy schema: {pg_err}"
-                            )
-                            rows = await conn.fetch(
-                                """
-                                SELECT
-                                    m.id AS id,
-                                    s.content,
-                                    s.raw_content,
-                                    s.wing,
-                                    s.room,
-                                    s.importance_score,
-                                    s.emotional_weight,
-                                    s.valence,
-                                    s.recall_count,
-                                    s.last_recalled_at,
-                                    s.created_at,
-                                    s.metadata,
-                                    s.similarity,
-                                    s.score
-                                FROM surface_actr_memories($1::vector(768), $2::text, $3::text, $4::double precision, $5::double precision, $6::double precision, $7::double precision, $8::double precision, $9::double precision, $10::double precision, $11::integer, $12::timestamptz) s
-                                LEFT JOIN memories m ON m.content = s.content AND m.wing = s.wing
-                                """,
-                                vector_str,
-                                wing,
-                                room,
-                                self.decay_rate,
-                                self.spread_weight,
-                                self.emotion_weight,
-                                current_valence,
-                                current_arousal,
-                                current_cortisol,
-                                threshold - 2.5,
-                                candidate_limit,
-                                current_time,
-                            )
+                        raw_candidates = await self._fetch_postgres_candidates(
+                            conn,
+                            vector_str=vector_str,
+                            wing=wing,
+                            room=room,
+                            excluded=excluded,
+                            threshold=threshold,
+                            candidate_limit=candidate_limit,
+                            current_valence=current_valence,
+                            current_arousal=current_arousal,
+                            current_cortisol=current_cortisol,
+                            current_time=current_time,
+                        )
 
-                        for row in rows:
-                            if row["content"] in excluded:
-                                continue
-
-                            similarity = row.get("similarity") or 0.0
-                            recall_count = max(1, row.get("recall_count") or 1)
-
-                            # Recalculate score with neuromodulatory gating
-                            last_recall = row.get("last_recalled_at")
-                            now = (
-                                self._as_aware_utc(current_time)
-                                if current_time is not None
-                                else datetime.now(timezone.utc)
-                            )
-                            last_recall = (
-                                now
-                                if last_recall is None
-                                else self._as_aware_utc(last_recall)
-                            )
-
-                            hours_since = max(
-                                0.001, (now - last_recall).total_seconds() / 3600.0
-                            )
-
-                            memory_valence = row.get("valence") or 0.0
-                            emotion_weight_row = row.get("emotional_weight") or 0.0
-
-                            # 2D/3D Emotional Distance matching the research simulator
-                            dist_emo = math.sqrt(
-                                (memory_valence - current_valence) ** 2
-                                + (emotion_weight_row - current_arousal) ** 2
-                            )
-
-                            base_activation = self._base_activation(
-                                recall_count,
-                                hours_since,
-                                row.get("importance_score") or 0.5,
-                                dist_emo,
-                            )
-
-                            # Neuromodulatory distance mapping
-                            effective_similarity = self._effective_similarity(
-                                similarity,
-                                memory_valence,
-                                emotion_weight_row,
-                                current_arousal,
-                                current_cortisol,
-                            )
-
-                            spread_activation = (
-                                self.spread_weight * effective_similarity
-                            )
-                            score = (
-                                base_activation
-                                + spread_activation
-                                - ACTR_EMO_DISTANCE_PENALTY * dist_emo
-                            )
-
-                            if (
-                                score <= (threshold - 2.5)
-                                and (row.get("importance_score") or 0.5) < 0.7
-                            ):
-                                continue
-
-                            created = row.get("created_at")
-                            if created and created.tzinfo is None:
-                                created = created.replace(tzinfo=timezone.utc)
-
-                            raw_meta = row.get("metadata")
-                            if isinstance(raw_meta, str):
-                                try:
-                                    raw_meta = orjson.loads(raw_meta)
-                                except Exception:
-                                    raw_meta = {}
-
-                            raw_candidates.append(
-                                {
-                                    "id": row.get("id"),
-                                    "content": row["content"],
-                                    "raw_content": row.get("raw_content")
-                                    or row["content"],
-                                    "wing": row.get("wing", "personal"),
-                                    "room": row.get("room"),
-                                    "score": score,
-                                    "valence": row.get("valence") or 0.0,
-                                    "created_at": created,
-                                    "recall_count": recall_count,
-                                    "metadata": raw_meta or {},
-                                    "lifespan_stage": row.get("lifespan_stage"),
-                                    "crisis": row.get("crisis"),
-                                    "virtue": row.get("virtue"),
-                                    "relations": row.get("relations"),
-                                    "relation_circles": row.get("relation_circles"),
-                                    "modality": row.get("modality"),
-                                    "similarity": similarity,
-                                    "last_recalled_at": last_recall,
-                                }
-                            )
-
-            # 3. Post-process candidate list in Python (Direct Cue Boost + Spreading Activation)
-            # Dynamically extract cues and entities from query and candidates without hardcoded mock data
-            stop_words = {
-                "the",
-                "and",
-                "but",
-                "yet",
-                "for",
-                "nor",
-                "with",
-                "this",
-                "that",
-                "these",
-                "those",
-                "you",
-                "your",
-                "yours",
-                "him",
-                "her",
-                "them",
-                "his",
-                "hers",
-                "their",
-                "theirs",
-                "was",
-                "were",
-                "been",
-                "have",
-                "has",
-                "had",
-                "did",
-                "does",
-                "what",
-                "where",
-                "when",
-                "who",
-                "why",
-                "how",
-                "can",
-                "could",
-                "would",
-                "should",
-                "shall",
-                "will",
-                "about",
-                "above",
-                "after",
-                "again",
-                "against",
-                "all",
-                "am",
-                "an",
-                "any",
-                "are",
-                "arent",
-                "as",
-                "at",
-                "be",
-                "because",
-                "before",
-                "being",
-                "below",
-                "between",
-                "both",
-                "by",
-                "cant",
-                "cannot",
-                "didnt",
-                "dont",
-                "down",
-                "during",
-                "each",
-                "few",
-                "from",
-                "further",
-                "hadnt",
-                "hasnt",
-                "havent",
-                "having",
-                "he",
-                "hed",
-                "hell",
-                "hes",
-                "here",
-                "heres",
-                "herself",
-                "himself",
-                "i",
-                "id",
-                "ill",
-                "im",
-                "ive",
-                "if",
-                "in",
-                "into",
-                "isnt",
-                "it",
-                "its",
-                "itself",
-                "lets",
-                "me",
-                "more",
-                "most",
-                "mustnt",
-                "my",
-                "myself",
-                "no",
-                "nor",
-                "not",
-                "of",
-                "off",
-                "on",
-                "once",
-                "only",
-                "or",
-                "other",
-                "ought",
-                "our",
-                "ours",
-                "ourselves",
-                "out",
-                "over",
-                "own",
-                "same",
-                "shant",
-                "she",
-                "shed",
-                "shell",
-                "shes",
-                "shouldnt",
-                "so",
-                "some",
-                "such",
-                "than",
-                "that",
-                "thats",
-                "the",
-                "their",
-                "theirs",
-                "them",
-                "themselves",
-                "then",
-                "there",
-                "theres",
-                "these",
-                "they",
-                "theyd",
-                "theyll",
-                "theyre",
-                "theyve",
-                "this",
-                "those",
-                "through",
-                "to",
-                "too",
-                "under",
-                "until",
-                "up",
-                "very",
-                "wasnt",
-                "we",
-                "wed",
-                "well",
-                "were",
-                "weve",
-                "werent",
-                "what",
-                "whats",
-                "when",
-                "whens",
-                "where",
-                "wheres",
-                "which",
-                "while",
-                "who",
-                "whos",
-                "whom",
-                "why",
-                "whys",
-                "with",
-                "wont",
-                "wouldnt",
-                "you",
-                "youd",
-                "youll",
-                "youre",
-                "youve",
-                "your",
-                "yours",
-                "yourself",
-                "yourselves",
-                "describe",
-                "compare",
-                "influence",
-                "influenced",
-                "friend",
-                "companion",
-                "robot",
-                "human",
-                "development",
-                "developer",
-                "developers",
-                "project",
-                "workspace",
-                "shared",
-                "recall",
-                "recalled",
-                "experience",
-                "experiences",
-                "about",
-                "related",
-            }
-
-            import re
-
+            # 3. Post-process in Python: direct cue boost + spreading activation
             query_words = re.findall(r"\b\w{3,}\b", query_text.lower())
-
-            # Dynamic stop words resolution to avoid hardcoding production names
-            dynamic_stop_words = set(stop_words)
-            if hasattr(self, "_db_stop_words") and self._db_stop_words:
-                dynamic_stop_words.update(self._db_stop_words)
-            ai_name_cfg = getattr(Config, "AI_NAME", None)
-            if ai_name_cfg:
-                for w in re.findall(r"\b\w{3,}\b", ai_name_cfg.lower()):
-                    dynamic_stop_words.add(w)
-            if user_id:
-                for w in re.findall(r"\b\w{3,}\b", user_id.lower()):
-                    dynamic_stop_words.add(w)
-
+            dynamic_stop_words = self._resolve_dynamic_stop_words(user_id)
             matched_cues = [w for w in query_words if w not in dynamic_stop_words]
             self.goal_buffer.update_buffer(query_text, dynamic_stop_words)
-
-            # Direct cue boost and dynamic pronoun resolution
-            direct_boosted_indices = set()
 
             entity_names = []
             adj = {}
             agent_node_name = None
             user_node_name = None
-
-            # Process entity and relationship records fetched in the parallel task
             try:
-                entity_names = [r["name"] for r in entity_records]
-
-                # Build adjacency list/set for fast connection lookup
-                for r in relation_records:
-                    src = r["source"]
-                    tgt = r["target"]
-                    adj.setdefault(src, set()).add(tgt)
-                    adj.setdefault(tgt, set()).add(src)
-
-                # Add co-occurrence connections from candidate memories
-                for cand in raw_candidates:
-                    payload_meta = cand.get("metadata") or {}
-                    cand_ents = payload_meta.get("entities", [])
-                    if not cand_ents:
-                        content_lower = cand["content"].lower()
-                        cand_ents = []
-                        for name in entity_names:
-                            pattern = rf"\b{re.escape(name.lower())}\b"
-                            if re.search(pattern, content_lower):
-                                cand_ents.append(name)
-
-                    for i in range(len(cand_ents)):
-                        for j in range(i + 1, len(cand_ents)):
-                            e1 = cand_ents[i]
-                            e2 = cand_ents[j]
-                            adj.setdefault(e1, set()).add(e2)
-                            adj.setdefault(e2, set()).add(e1)
-
-                # 1. Discover Agent Node Name dynamically
-                for r in entity_records:
-                    desc = r.get("description") or ""
-                    if "central cognitive system" in desc.lower():
-                        agent_node_name = r["name"]
-                        break
-                if not agent_node_name:
-                    ai_name = getattr(Config, "AI_NAME", "AI Friend")
-                    for name in entity_names:
-                        if name.lower() == ai_name.lower():
-                            agent_node_name = name
-                            break
-                if not agent_node_name:
-                    agent_node_name = getattr(Config, "AI_NAME", "AI Friend")
-
-                # 2. Discover User Node Name dynamically
-                if user_id:
-                    for name in entity_names:
-                        if name.lower() == user_id.lower():
-                            user_node_name = name
-                            break
-                if not user_node_name:
-                    for r in entity_records:
-                        desc = r.get("description") or ""
-                        if (
-                            "user" in desc.lower()
-                            or "companion" in desc.lower()
-                            or "friend" in desc.lower()
-                        ):
-                            if r["name"] != agent_node_name:
-                                user_node_name = r["name"]
-                                break
-                if not user_node_name and entity_names:
-                    ai_names = {
-                        "ai friend",
-                        "my friend",
-                        agent_node_name.lower(),
-                    }
-                    if hasattr(Config, "AI_NAME") and Config.AI_NAME:
-                        ai_names.add(Config.AI_NAME.lower())
-                    candidates_names = [
-                        name for name in entity_names if name.lower() not in ai_names
-                    ]
-                    if candidates_names:
-                        candidates_names.sort(
-                            key=lambda name: len(adj.get(name, set())), reverse=True
-                        )
-                        user_node_name = candidates_names[0]
-                if not user_node_name:
-                    user_node_name = user_id or "user"
-
+                entity_names, adj = self._build_entity_graph(
+                    entity_records, relation_records, raw_candidates
+                )
+                agent_node_name, user_node_name = self._resolve_identity_nodes(
+                    entity_records, entity_names, adj, user_id
+                )
             except Exception as e:
                 logger.debug(f"Failed to process entities: {e}")
 
-            # 3. Context-Aware Speaker/Listener Pronoun Resolution mapping
-            first_person_pronouns = {"i", "me", "my", "myself", "we", "our", "us"}
-            second_person_pronouns = {"you", "your", "yours", "yourself", "yourselves"}
-
-            query_words_all = re.findall(r"\b\w+\b", query_text.lower())
-            resolved_cues = set()
-
-            if is_self_reflection:
-                # Agent speaking: "I" -> Agent, "you" -> User
-                if any(p in query_words_all for p in first_person_pronouns):
-                    if agent_node_name:
-                        resolved_cues.add(agent_node_name.lower())
-                if any(p in query_words_all for p in second_person_pronouns):
-                    if user_node_name:
-                        resolved_cues.add(user_node_name.lower())
-            else:
-                # User speaking: "I" -> User, "you" -> Agent
-                if any(p in query_words_all for p in first_person_pronouns):
-                    if user_node_name:
-                        resolved_cues.add(user_node_name.lower())
-                if any(p in query_words_all for p in second_person_pronouns):
-                    if agent_node_name:
-                        resolved_cues.add(agent_node_name.lower())
-
-            # Add user/agent names if explicitly mentioned in query
-            user_aliases = {"user"}
-            if user_id:
-                user_aliases.add(user_id.lower())
-            if user_node_name:
-                user_aliases.add(user_node_name.lower())
-
-            agent_aliases = {"ai friend", "my friend"}
-            if hasattr(Config, "AI_NAME") and Config.AI_NAME:
-                agent_aliases.add(Config.AI_NAME.lower())
-            if agent_node_name:
-                agent_aliases.add(agent_node_name.lower())
-
-            for word in query_words_all:
-                if word in user_aliases:
-                    if user_node_name:
-                        resolved_cues.add(user_node_name.lower())
-                if word in agent_aliases:
-                    if agent_node_name:
-                        resolved_cues.add(agent_node_name.lower())
-
+            resolved_cues = self._resolve_pronoun_cues(
+                query_text,
+                agent_node_name,
+                user_node_name,
+                user_id,
+                is_self_reflection,
+            )
             for cue in resolved_cues:
                 if cue not in matched_cues:
                     matched_cues.append(cue)
 
-            # Apply direct cue boost (DIRECT_CUE_BOOST per matched cue)
-            if matched_cues:
-                for idx, cand in enumerate(raw_candidates):
-                    content_lower = cand["content"].lower()
-                    match_count = sum(1 for mc in matched_cues if mc in content_lower)
-                    if match_count > 0:
-                        cand["score"] += DIRECT_CUE_BOOST * match_count
-                        direct_boosted_indices.add(idx)
-
-            # HippoRAG-Inspired Personalized PageRank (PPR) Engine
-            if entity_names:
-                try:
-                    # Identify query/context seed nodes
-                    seeds = set()
-
-                    # 1. Query cues that match entity names
-                    for cue in matched_cues:
-                        for idx, name in enumerate(entity_names):
-                            if name.lower() == cue.lower():
-                                seeds.add(idx)
-
-                    # 2. If no direct query seeds, use entities from directly cued memories (for vector-guided associative recall)
-                    if not seeds:
-                        for idx in direct_boosted_indices:
-                            cand = raw_candidates[idx]
-                            payload_meta = cand.get("metadata") or {}
-                            cand_ents = payload_meta.get("entities", [])
-                            if not cand_ents:
-                                content_lower = cand["content"].lower()
-                                for e_idx, name in enumerate(entity_names):
-                                    pattern = rf"\b{re.escape(name.lower())}\b"
-                                    if re.search(pattern, content_lower):
-                                        seeds.add(e_idx)
-                            else:
-                                for ent in cand_ents:
-                                    for e_idx, name in enumerate(entity_names):
-                                        if name.lower() == ent.lower():
-                                            seeds.add(e_idx)
-
-                    # Compute Personalized PageRank Vector (3-iteration power
-                    # method, delegated to the Rust hot loop with a Python
-                    # fallback). PPR_DAMPING is the canonical teleport factor.
-                    N = len(entity_names)
-                    if not seeds:
-                        ppr = {}
-                    else:
-                        p = self._personalized_pagerank(
-                            entity_names, adj, seeds, PPR_DAMPING, 3
-                        )
-                        ppr = {entity_names[i]: p[i] for i in range(N)}
-
-                    # Helper to find which entities are present in a memory content (fallback scanning)
-                    def get_present_entities(content: str) -> set[str]:
-                        content_lower = content.lower()
-                        present = set()
-                        for name in entity_names:
-                            name_lower = name.lower()
-                            pattern = rf"\b{re.escape(name_lower)}\b"
-                            if re.search(pattern, content_lower):
-                                present.add(name)
-
-                        if agent_node_name and any(
-                            re.search(rf"\b{re.escape(pr)}\b", content_lower)
-                            for pr in {"i", "me", "my", "myself", "we", "our", "us"}
-                        ):
-                            present.add(agent_node_name)
-                        return present
-
-                    # Map candidate indices to their present entities
-                    cand_entities = {}
-                    for idx, cand in enumerate(raw_candidates):
-                        payload_meta = cand.get("metadata") or {}
-                        if "entities" in payload_meta and isinstance(
-                            payload_meta["entities"], list
-                        ):
-                            cand_entities[idx] = set(payload_meta["entities"])
-                            if agent_node_name and any(
-                                re.search(
-                                    rf"\b{re.escape(pr)}\b", cand["content"].lower()
-                                )
-                                for pr in {"i", "me", "my", "myself", "we", "our", "us"}
-                            ):
-                                cand_entities[idx].add(agent_node_name)
-                        else:
-                            cand_entities[idx] = get_present_entities(cand["content"])
-
-                    # Apply spreading activation boost to all candidate memories based on PPR probability
-                    for idx, cand in enumerate(raw_candidates):
-                        if idx in direct_boosted_indices:
-                            continue
-                        boost_sum = 0.0
-                        for ent in cand_entities[idx]:
-                            if ent in ppr:
-                                deg = len(adj.get(ent, set()))
-                                # HippoRAG-inspired degree-scaled activation boost
-                                boost = (1.2 * ppr[ent]) / (1.0 + math.log(max(1, deg)))
-                                boost_sum += boost
-                        if boost_sum > 0:
-                            cand["score"] += boost_sum
-
-                except Exception as ne_err:
-                    logger.error(f"PPR spreading activation failed: {ne_err}")
-
-            # Native Goal Buffer Spreading Activation
-            active_concepts = [c[0] for c in self.goal_buffer.concepts]
-            if active_concepts:
-                for cand in raw_candidates:
-                    content_lower = cand["content"].lower()
-                    match_count = sum(1 for c in active_concepts if c in content_lower)
-                    if match_count > 0:
-                        w_j = 1.5 / len(active_concepts)
-                        boost = match_count * w_j * 1.2
-                        cand["score"] += boost
-                        logger.debug(
-                            f"GoalBuffer Prime: Added +{boost:.3f} spreading activation to memory {cand.get('id') or cand.get('content', 'N/A')}"
-                        )
+            direct_boosted_indices = self._apply_direct_cue_boost(
+                raw_candidates, matched_cues
+            )
+            self._apply_ppr_spreading_activation(
+                raw_candidates,
+                entity_names,
+                adj,
+                matched_cues,
+                direct_boosted_indices,
+                agent_node_name,
+            )
+            self._apply_goal_buffer_boost(raw_candidates)
 
             # 4. Filter by final threshold, format and return results
-            results = []
-            for cand in raw_candidates:
-                if cand["score"] <= threshold:
-                    continue
-
-                res_dict = {
-                    "content": cand["content"],
-                    "raw_content": cand["raw_content"],
-                    "wing": cand["wing"],
-                    "room": cand["room"],
-                    "score": cand["score"],
-                    "valence": cand["valence"],
-                    "created_at": cand["created_at"].isoformat()
-                    if cand["created_at"]
-                    else None,
-                    "recall_count": cand["recall_count"],
-                    "metadata": cand["metadata"],
-                }
-
-                # Include Eriksonian columns
-                res_dict["lifespan_stage"] = cand.get("lifespan_stage")
-                res_dict["crisis"] = cand.get("crisis")
-                res_dict["virtue"] = cand.get("virtue")
-                res_dict["relations"] = cand.get("relations")
-                res_dict["relation_circles"] = cand.get("relation_circles")
-                res_dict["modality"] = cand.get("modality")
-
-                results.append(res_dict)
+            results = self._format_results(raw_candidates, threshold)
 
             # L3 Sub-conscious Search and Promotion
             if matched_cues:
-                # 1. Fetch top candidates from archived_memories
-                archive_rows = []
-
-                # Use query words except standard/dynamic stop words, but preserve user_id names for L3 search
-                archive_stop_words = set(dynamic_stop_words)
-                if user_id:
-                    for w in re.findall(r"\b\w{3,}\b", user_id.lower()):
-                        archive_stop_words.discard(w)
-                archive_cues = [w for w in query_words if w not in archive_stop_words]
-
-                # Also include any resolved cues (like agent name / resolved user name)
-                for cue in resolved_cues:
-                    if cue not in archive_cues:
-                        archive_cues.append(cue)
-
-                if not archive_cues:
-                    archive_cues = list(matched_cues)
-
-                # Apply lexical priming/synonym expansion to cues
-                expanded_cues = set()
-                for cue in archive_cues:
-                    expanded_cues.add(cue)
-                    stem = _get_stem(cue)
-                    expanded_cues.add(stem)
-                    # Learned lexical priming: pull the cue's strongest acquired
-                    # associates (empty until the lexicon has learned them).
-                    expanded_cues.update(self.lexicon.expand(cue))
-                    expanded_cues.update(self.lexicon.expand(stem))
-
-                expanded_cues_list = list(expanded_cues)
-                patterns = [f"%{cue}%" for cue in expanded_cues_list]
-                archive_limit = 250  # Fetch more candidates to rank by keyword match count and ACT-R score
-
-                try:
-                    async with self.pool.acquire() as conn:
-                        if self.is_sqlite:
-                            where_clause = " OR ".join(
-                                "lower(content) LIKE ?" for _ in expanded_cues_list
-                            )
-                            query = f"""
-                                SELECT * FROM archived_memories
-                                WHERE wing = ? AND ({where_clause})
-                                ORDER BY importance_score DESC, last_recalled_at DESC
-                                LIMIT ?
-                            """
-                            archive_rows = await conn.fetch(
-                                query, wing, *patterns, archive_limit
-                            )
-                        else:
-                            # Postgres pgvector: Hybrid Semantic + Lexical Synonym search using HNSW index over halfvec
-                            query = """
-                                SELECT *, (1 - (embedding <=> $2::halfvec))::double precision AS similarity_arch
-                                FROM archived_memories
-                                WHERE wing = $1 AND (embedding <=> $2::halfvec < 0.45 OR content ILIKE ANY($3))
-                                ORDER BY coalesce((1 - (embedding <=> $2::halfvec)), 0.0) DESC, importance_score DESC, last_recalled_at DESC
-                                LIMIT $4
-                            """
-                            archive_rows = await conn.fetch(
-                                query, wing, vector_str, patterns, archive_limit
-                            )
-                except Exception as arch_err:
-                    logger.error(f"Archived memories hybrid lookup failed: {arch_err}")
-
-                if archive_rows:
-                    active_contents = {res["content"] for res in results}
-                    archive_rows = [
-                        r
-                        for r in archive_rows
-                        if r.get("content")
-                        and r["content"] not in active_contents
-                        and r["content"] not in excluded
-                    ]
-
-                if archive_rows:
-                    # Sort archive_rows by score and keyword matches
-                    # Rank candidates by matching cues and ACT-R score calculated in Python
-                    scored_archive_rows = []
-                    for row in archive_rows:
-                        content = row.get("content", "")
-
-                        # Get similarity
-                        similarity = row.get("similarity_arch")
-                        if similarity is None:
-                            # Fallback: parse embedding and compute similarity
-                            emb_val = row.get("embedding")
-                            emb = None
-                            if emb_val:
-                                if isinstance(emb_val, str):
-                                    try:
-                                        import json
-
-                                        emb = json.loads(emb_val)
-                                    except Exception:
-                                        import re
-
-                                        try:
-                                            emb = [
-                                                float(x)
-                                                for x in re.findall(
-                                                    r"[-+]?\d*\.\d+|\d+e[-+]?\d+|[-+]?\d+",
-                                                    emb_val,
-                                                )
-                                            ]
-                                        except Exception:
-                                            pass
-                                elif isinstance(emb_val, list):
-                                    emb = emb_val
-                            if emb and query_vector:
-                                import numpy as np
-
-                                q_arr = np.array(query_vector)
-                                emb_arr = np.array(emb)
-                                norm_q = np.linalg.norm(q_arr)
-                                norm_emb = np.linalg.norm(emb_arr)
-                                if norm_q > 0 and norm_emb > 0:
-                                    similarity = float(
-                                        np.dot(q_arr, emb_arr) / (norm_q * norm_emb)
-                                    )
-                                else:
-                                    similarity = 0.0
-                            else:
-                                similarity = 0.0
-
-                        recall_count = max(1, row.get("recall_count") or 1)
-                        last_recall = row.get("last_recalled_at")
-                        now = (
-                            self._as_aware_utc(current_time)
-                            if current_time is not None
-                            else datetime.now(timezone.utc)
-                        )
-                        last_recall = (
-                            now if last_recall is None else self._as_aware_utc(last_recall)
-                        )
-
-                        hours_since = max(
-                            0.001, (now - last_recall).total_seconds() / 3600.0
-                        )
-                        memory_valence = row.get("valence") or 0.0
-                        emotion_weight_row = row.get("emotional_weight") or 0.0
-
-                        dist_emo = math.sqrt(
-                            (memory_valence - current_valence) ** 2
-                            + (emotion_weight_row - current_arousal) ** 2
-                        )
-
-                        base_activation = self._base_activation(
-                            recall_count,
-                            hours_since,
-                            row.get("importance_score") or 0.5,
-                            dist_emo,
-                        )
-
-                        effective_similarity = self._effective_similarity(
-                            similarity,
-                            memory_valence,
-                            emotion_weight_row,
-                            current_arousal,
-                            current_cortisol,
-                        )
-
-                        spread_activation = self.spread_weight * effective_similarity
-                        score = (
-                            base_activation
-                            + spread_activation
-                            - ACTR_EMO_DISTANCE_PENALTY * dist_emo
-                        )
-
-                        # Lexical match count boost to ensure direct query matches sort higher
-                        content_lower = content.lower()
-                        match_count = sum(
-                            1 for cue in expanded_cues if cue in content_lower
-                        )
-
-                        # Massive ranking boost for keyword match count ( HippoRAG key relevance )
-                        ranking_score = score + DIRECT_CUE_BOOST * match_count
-
-                        scored_archive_rows.append(
-                            (ranking_score, score, similarity, row)
-                        )
-
-                    # Sort scored candidates by ranking score descending
-                    scored_archive_rows.sort(key=lambda x: x[0], reverse=True)
-
-                    # Limit the actual promotion list to prevent flooding
-                    promote_limit = min(5, limit) if limit else 5
-                    scored_archive_rows = scored_archive_rows[:promote_limit]
-
-                # 2. Score and promote candidates
-                promoted_results = []
-                if archive_rows:
-                    for ranking_score, score, similarity, row in scored_archive_rows:
-                        content = row["content"]
-
-                        # Parse or retrieve the embedding
-                        emb_val = row.get("embedding")
-                        emb = None
-                        if emb_val:
-                            if isinstance(emb_val, str):
-                                try:
-                                    import json
-
-                                    emb = json.loads(emb_val)
-                                except Exception:
-                                    import re
-
-                                    try:
-                                        emb = [
-                                            float(x)
-                                            for x in re.findall(
-                                                r"[-+]?\d*\.\d+|\d+e[-+]?\d+|[-+]?\d+",
-                                                emb_val,
-                                            )
-                                        ]
-                                    except Exception:
-                                        pass
-                            elif isinstance(emb_val, list):
-                                emb = emb_val
-
-                        # Fallback to call embedding API if missing
-                        if not emb:
-                            emb = await self.get_embedding(content)
-                            if not emb:
-                                continue
-
-                        recall_count = max(1, row.get("recall_count") or 1)
-                        last_recall = row.get("last_recalled_at")
-                        now = (
-                            self._as_aware_utc(current_time)
-                            if current_time is not None
-                            else datetime.now(timezone.utc)
-                        )
-                        last_recall = (
-                            now if last_recall is None else self._as_aware_utc(last_recall)
-                        )
-
-                        hours_since = max(
-                            0.001, (now - last_recall).total_seconds() / 3600.0
-                        )
-                        memory_valence = row.get("valence") or 0.0
-                        emotion_weight_row = row.get("emotional_weight") or 0.0
-
-                        dist_emo = math.sqrt(
-                            (memory_valence - current_valence) ** 2
-                            + (emotion_weight_row - current_arousal) ** 2
-                        )
-
-                        effective_similarity = similarity * (
-                            1.0
-                            + 0.1 * memory_valence * emotion_weight_row
-                            - 0.2 * current_arousal * current_cortisol
-                        )
-
-                        spread_activation = self.spread_weight * effective_similarity
-
-                        # Only promote if it passes the threshold or is a milestone (importance_score >= 0.7)
-                        if (
-                            score > (threshold - 2.5)
-                            or (row.get("importance_score") or 0.5) >= 0.7
-                        ):
-                            import uuid
-
-                            mem_id = str(row.get("id") or uuid.uuid4())
-                            raw_meta = row.get("metadata")
-                            import json
-
-                            if isinstance(raw_meta, str):
-                                try:
-                                    raw_meta = json.loads(raw_meta)
-                                except Exception:
-                                    raw_meta = {}
-                            elif not isinstance(raw_meta, dict):
-                                raw_meta = {}
-
-                            # Ensure entities are computed
-                            payload_meta = {
-                                "wing": row.get("wing", "personal"),
-                                "room": row.get("room") or "",
-                                "importance_score": row.get("importance_score"),
-                                "emotional_weight": row.get("emotional_weight"),
-                                "valence": row.get("valence"),
-                                "certainty": row.get("certainty"),
-                                "source": row.get("source"),
-                                "created_at": row.get("created_at").isoformat()
-                                if row.get("created_at")
-                                else None,
-                                "lifespan_stage": row.get("lifespan_stage") or "",
-                                "crisis": row.get("crisis") or "",
-                                "virtue": row.get("virtue") or "",
-                                "relations": row.get("relations") or "",
-                                "relation_circles": row.get("relation_circles") or "",
-                                "modality": row.get("modality") or "",
-                                **(raw_meta or {}),
-                            }
-
-                            # SQLite vs Postgres insert
-                            try:
-                                async with self.pool.acquire() as conn:
-                                    if self.is_sqlite:
-                                        await conn.execute(
-                                            """
-                                            INSERT INTO memories (
-                                                id, content, raw_content, wing, room, embedding, importance_score, emotional_weight,
-                                                valence, certainty, source, recall_count, last_recalled_at, created_at,
-                                                metadata, lifespan_stage, crisis, virtue, relations, relation_circles, modality
-                                            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                                            ON CONFLICT(id) DO UPDATE SET
-                                                recall_count = excluded.recall_count,
-                                                last_recalled_at = excluded.last_recalled_at,
-                                                importance_score = excluded.importance_score
-                                            """,
-                                            mem_id,
-                                            content,
-                                            row.get("raw_content"),
-                                            row.get("wing"),
-                                            row.get("room"),
-                                            str(emb),
-                                            row.get("importance_score"),
-                                            row.get("emotional_weight"),
-                                            row.get("valence"),
-                                            row.get("certainty"),
-                                            row.get("source"),
-                                            recall_count + 1,
-                                            now,
-                                            row.get("created_at"),
-                                            json.dumps(payload_meta),
-                                            row.get("lifespan_stage"),
-                                            row.get("crisis"),
-                                            row.get("virtue"),
-                                            row.get("relations"),
-                                            row.get("relation_circles"),
-                                            row.get("modality"),
-                                        )
-                                        await conn.execute(
-                                            "DELETE FROM archived_memories WHERE id = ?",
-                                            mem_id,
-                                        )
-                                    else:
-                                        await conn.execute(
-                                            """
-                                            INSERT INTO memories (
-                                                id, content, raw_content, wing, room, embedding, importance_score, emotional_weight,
-                                                valence, certainty, source, recall_count, last_recalled_at, created_at,
-                                                metadata, lifespan_stage, crisis, virtue, relations, relation_circles, modality
-                                            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
-                                            ON CONFLICT(id) DO UPDATE SET
-                                                recall_count = EXCLUDED.recall_count,
-                                                last_recalled_at = EXCLUDED.last_recalled_at,
-                                                importance_score = EXCLUDED.importance_score
-                                            """,
-                                            mem_id,
-                                            content,
-                                            row.get("raw_content"),
-                                            row.get("wing"),
-                                            row.get("room"),
-                                            str(emb),
-                                            row.get("importance_score"),
-                                            row.get("emotional_weight"),
-                                            row.get("valence"),
-                                            row.get("certainty"),
-                                            row.get("source"),
-                                            recall_count + 1,
-                                            now,
-                                            row.get("created_at"),
-                                            json.dumps(payload_meta),
-                                            row.get("lifespan_stage"),
-                                            row.get("crisis"),
-                                            row.get("virtue"),
-                                            row.get("relations"),
-                                            row.get("relation_circles"),
-                                            row.get("modality"),
-                                        )
-                                        await conn.execute(
-                                            "DELETE FROM archived_memories WHERE id = $1",
-                                            mem_id,
-                                        )
-
-                                # Upsert Qdrant
-                                if self.qdrant_store and self.qdrant_store.client:
-                                    await asyncio.to_thread(
-                                        self.qdrant_store.add_vector_memory,
-                                        mem_id,
-                                        emb,
-                                        content,
-                                        payload_meta,
-                                    )
-
-                                logger.info(
-                                    f"📥 [Memory Promotion] Promoted memory '{content[:40]}...' from archive back to active storage."
-                                )
-                            except Exception as prom_err:
-                                logger.error(
-                                    f"Failed to promote memory {mem_id}: {prom_err}"
-                                )
-
-                            created = row.get("created_at")
-                            if created and created.tzinfo is None:
-                                created = created.replace(tzinfo=timezone.utc)
-
-                            # Recalculate active score since it is now promoted and last_recalled_at is set to now (hours_since = 0.001)
-                            # We use recall_count + 1 since the recall_count has been incremented upon recall/promotion
-                            # recall_count + 1 (already incremented on promotion)
-                            # and a near-zero recency (last_recalled_at is now).
-                            base_activation_active = self._base_activation(
-                                recall_count + 1,
-                                0.001,
-                                row.get("importance_score") or 0.5,
-                                dist_emo,
-                            )
-                            score_active = (
-                                base_activation_active
-                                + spread_activation
-                                - ACTR_EMO_DISTANCE_PENALTY * dist_emo
-                            )
-                            # Apply direct cue boost since it was promoted due to keyword matches
-                            match_count = sum(
-                                1 for mc in matched_cues if mc in content.lower()
-                            )
-                            score_active += DIRECT_CUE_BOOST * match_count
-
-                            promoted_results.append(
-                                {
-                                    "content": content,
-                                    "raw_content": row.get("raw_content") or content,
-                                    "wing": row.get("wing", "personal"),
-                                    "room": row.get("room"),
-                                    "score": score_active,
-                                    "valence": row.get("valence") or 0.0,
-                                    "created_at": created.isoformat()
-                                    if created
-                                    else None,
-                                    "recall_count": recall_count + 1,
-                                    "metadata": raw_meta or {},
-                                    "lifespan_stage": row.get("lifespan_stage"),
-                                    "crisis": row.get("crisis"),
-                                    "virtue": row.get("virtue"),
-                                    "relations": row.get("relations"),
-                                    "relation_circles": row.get("relation_circles"),
-                                    "modality": row.get("modality"),
-                                }
-                            )
-
-                    if promoted_results:
-                        results.extend(promoted_results)
+                promoted_results = await self._recall_from_archive(
+                    query_words=query_words,
+                    dynamic_stop_words=dynamic_stop_words,
+                    matched_cues=matched_cues,
+                    resolved_cues=resolved_cues,
+                    user_id=user_id,
+                    wing=wing,
+                    vector_str=vector_str,
+                    query_vector=query_vector,
+                    existing_results=results,
+                    excluded=excluded,
+                    limit=limit,
+                    threshold=threshold,
+                    current_valence=current_valence,
+                    current_arousal=current_arousal,
+                    current_cortisol=current_cortisol,
+                    current_time=current_time,
+                )
+                if promoted_results:
+                    results.extend(promoted_results)
 
             if results:
                 # Sort and limit results to maintain full compatibility with offline tests
@@ -2342,7 +2443,7 @@ class MemoryStore:
                     results = results[:limit]
 
                 logger.info(
-                    f"🧠 ACT-R Recall: {len(results)} memories for: '{query_text[:30]}...'"
+                    f"\U0001f9e0 ACT-R Recall: {len(results)} memories for: '{query_text[:30]}...'"
                 )
 
             if results and refresh_on_recall:
@@ -2372,6 +2473,7 @@ class MemoryStore:
             traceback.print_exc()
             logger.error(f"Memory search failed: {e}")
             return []
+
 
     async def _refresh_memories(
         self, memories: list[dict], current_valence: float = 0.0, current_time=None

--- a/backend/tests/test_f1_decomposed_stages.py
+++ b/backend/tests/test_f1_decomposed_stages.py
@@ -1,0 +1,417 @@
+"""
+Unit tests for the stages extracted from the two god-functions (F1).
+
+Before the decomposition none of this was reachable without driving the whole
+~1600-line search_memories / ~520-line ActionService.execute pipeline end to
+end. Each stage is now independently testable, which is the point of the
+refactor: it makes the memory and action paths safe to iterate on.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.cognitive.action import (
+    ActionService,
+    ControlMarkupSanitizer,
+    _ChatStreamState,
+    _CHAT_GUIDELINE,
+)
+from app.state.memory_store import (
+    DIRECT_CUE_BOOST,
+    SEARCH_STOP_WORDS,
+    MemoryStore,
+)
+
+
+# --------------------------------------------------------------------------
+# memory_store stages
+# --------------------------------------------------------------------------
+
+
+def _store():
+    store = MemoryStore(MagicMock(), MagicMock())
+    store.qdrant_store.client = None
+    return store
+
+
+@pytest.mark.parametrize(
+    "arousal,cortisol,expected_dim",
+    [
+        (0.9, 0.0, 256),  # high stress -> narrowest Matryoshka prefix
+        (0.0, 0.9, 256),  # cortisol alone is enough
+        (0.7, 0.0, 512),  # mid stress
+        (0.1, 0.1, 768),  # calm -> full width
+    ],
+)
+def test_mrl_gating_narrows_under_stress(arousal, cortisol, expected_dim):
+    dim, _limit = MemoryStore._compute_mrl_gating(arousal, cortisol, 5, True)
+    assert dim == expected_dim
+
+
+def test_mrl_gating_candidate_pool_shrinks_as_stress_rises():
+    calm = MemoryStore._compute_mrl_gating(0.1, 0.0, 5, True)[1]
+    mid = MemoryStore._compute_mrl_gating(0.7, 0.0, 5, True)[1]
+    high = MemoryStore._compute_mrl_gating(0.9, 0.0, 5, True)[1]
+    assert calm > mid > high
+
+
+def test_mrl_gating_without_refresh_uses_smaller_pool():
+    with_refresh = MemoryStore._compute_mrl_gating(0.1, 0.0, 5, True)[1]
+    without = MemoryStore._compute_mrl_gating(0.1, 0.0, 5, False)[1]
+    assert without < with_refresh
+
+
+def test_mrl_gating_tolerates_none_limit():
+    assert MemoryStore._compute_mrl_gating(0.9, 0.0, None, True) == (256, 10)
+    assert MemoryStore._compute_mrl_gating(0.1, 0.0, None, False) == (768, 20)
+
+
+def test_pronoun_cues_flip_between_user_and_self_reflection():
+    """"I"/"you" swap referents depending on who is speaking."""
+    kwargs = dict(agent_node_name="Aniket", user_node_name="Raj", user_id="Raj")
+
+    user_speaking = MemoryStore._resolve_pronoun_cues(
+        "what did I tell you", is_self_reflection=False, **kwargs
+    )
+    assert "raj" in user_speaking and "aniket" in user_speaking
+
+    self_reflecting = MemoryStore._resolve_pronoun_cues(
+        "what did I tell you", is_self_reflection=True, **kwargs
+    )
+    # Same sentence, same two names surface - the mapping is what inverts.
+    assert "raj" in self_reflecting and "aniket" in self_reflecting
+
+    only_first = MemoryStore._resolve_pronoun_cues(
+        "what did I do", is_self_reflection=False, **kwargs
+    )
+    assert only_first == {"raj"}
+
+    only_first_reflecting = MemoryStore._resolve_pronoun_cues(
+        "what did I do", is_self_reflection=True, **kwargs
+    )
+    assert only_first_reflecting == {"aniket"}
+
+
+def test_pronoun_cues_pick_up_explicit_names():
+    cues = MemoryStore._resolve_pronoun_cues(
+        "tell me about Raj", "Aniket", "Raj", "Raj", False
+    )
+    assert "raj" in cues
+
+
+def test_direct_cue_boost_scales_with_match_count_and_reports_indices():
+    candidates = [
+        {"content": "cricket in kolkata", "score": 0.0},
+        {"content": "nothing relevant here", "score": 0.0},
+        {"content": "cricket cricket", "score": 0.0},
+    ]
+    boosted = MemoryStore._apply_direct_cue_boost(candidates, ["cricket", "kolkata"])
+
+    assert boosted == {0, 2}
+    assert candidates[0]["score"] == pytest.approx(2 * DIRECT_CUE_BOOST)
+    assert candidates[1]["score"] == 0.0
+    # "cricket" appears once as a substring check per cue, not per occurrence
+    assert candidates[2]["score"] == pytest.approx(1 * DIRECT_CUE_BOOST)
+
+
+def test_direct_cue_boost_no_cues_is_a_noop():
+    candidates = [{"content": "anything", "score": 1.0}]
+    assert MemoryStore._apply_direct_cue_boost(candidates, []) == set()
+    assert candidates[0]["score"] == 1.0
+
+
+def test_format_results_drops_sub_threshold_and_projects_shape():
+    from datetime import datetime, timezone
+
+    created = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    raw = [
+        {
+            "content": "keep me",
+            "raw_content": "keep me",
+            "wing": "personal",
+            "room": "social",
+            "score": 2.0,
+            "valence": 0.3,
+            "created_at": created,
+            "recall_count": 2,
+            "metadata": {"k": "v"},
+            "lifespan_stage": "adulthood",
+            "crisis": "intimacy",
+            "virtue": "love",
+            "relations": "friend",
+            "relation_circles": "inner",
+            "modality": "text",
+        },
+        {
+            "content": "drop me",
+            "raw_content": "drop me",
+            "wing": "personal",
+            "room": None,
+            "score": 0.5,
+            "valence": 0.0,
+            "created_at": None,
+            "recall_count": 1,
+            "metadata": {},
+        },
+    ]
+    results = MemoryStore._format_results(raw, threshold=1.0)
+
+    assert [r["content"] for r in results] == ["keep me"]
+    assert results[0]["created_at"] == created.isoformat()
+    assert results[0]["lifespan_stage"] == "adulthood"
+    # score is strictly greater-than the threshold, not >=
+    assert MemoryStore._format_results(raw, threshold=2.0) == []
+
+
+def test_build_entity_graph_is_symmetric_and_adds_cooccurrence():
+    entity_records = [{"name": "Raj"}, {"name": "Kolkata"}, {"name": "Aniket"}]
+    relation_records = [{"source": "Raj", "target": "Aniket"}]
+    candidates = [{"content": "Raj visited Kolkata", "metadata": {}}]
+
+    names, adj = MemoryStore._build_entity_graph(
+        entity_records, relation_records, candidates
+    )
+
+    assert names == ["Raj", "Kolkata", "Aniket"]
+    # explicit relation, both directions
+    assert "Aniket" in adj["Raj"] and "Raj" in adj["Aniket"]
+    # co-occurrence discovered from the memory text, both directions
+    assert "Kolkata" in adj["Raj"] and "Raj" in adj["Kolkata"]
+
+
+def test_resolve_identity_nodes_prefers_described_agent():
+    entity_records = [
+        {"name": "Bruno", "description": "A dog"},
+        {"name": "Aniket", "description": "The central cognitive system."},
+        {"name": "Raj", "description": "User / Companion"},
+    ]
+    names = [r["name"] for r in entity_records]
+    agent, user = MemoryStore._resolve_identity_nodes(entity_records, names, {}, "Raj")
+    assert agent == "Aniket"
+    assert user == "Raj"
+
+
+def test_resolve_identity_nodes_falls_back_when_graph_is_empty():
+    agent, user = MemoryStore._resolve_identity_nodes([], [], {}, None)
+    assert agent  # configured AI_NAME
+    assert user == "user"
+
+
+def test_normalize_recall_ts_handles_every_stored_shape():
+    from datetime import datetime, timezone
+
+    now_ts = 1_700_000_000.0
+    dt = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    assert MemoryStore._normalize_recall_ts(None, now_ts) == now_ts
+    assert MemoryStore._normalize_recall_ts(dt, now_ts) == dt.timestamp()
+    assert MemoryStore._normalize_recall_ts(123.5, now_ts) == 123.5
+    assert MemoryStore._normalize_recall_ts("123.5", now_ts) == 123.5
+    assert MemoryStore._normalize_recall_ts("2026-01-01 00:00:00", now_ts) == (
+        dt.timestamp()
+    )
+    assert MemoryStore._normalize_recall_ts("not a date", now_ts) == now_ts
+
+
+def test_parse_stored_embedding_accepts_json_list_and_literal():
+    assert MemoryStore._parse_stored_embedding([0.1, 0.2]) == [0.1, 0.2]
+    assert MemoryStore._parse_stored_embedding("[0.1, 0.2]") == [0.1, 0.2]
+    # pgvector-style literal that is not valid JSON still yields floats
+    assert MemoryStore._parse_stored_embedding("(0.5,-0.25)") == [0.5, -0.25]
+    assert MemoryStore._parse_stored_embedding(None) is None
+
+
+def test_stop_words_are_generic_not_corpus_specific():
+    """B1 guard: the hoisted list must not re-acquire benchmark proper nouns."""
+    for leaked in ("rasgulla", "kolkata", "mimi", "bruno", "aniket", "raj"):
+        assert leaked not in SEARCH_STOP_WORDS
+    for generic in ("the", "and", "because", "yourselves"):
+        assert generic in SEARCH_STOP_WORDS
+
+
+def test_goal_buffer_boost_is_noop_without_active_concepts():
+    store = _store()
+    store.goal_buffer.flush()
+    candidates = [{"content": "anything at all", "score": 1.0}]
+    store._apply_goal_buffer_boost(candidates)
+    assert candidates[0]["score"] == 1.0
+
+
+# --------------------------------------------------------------------------
+# action stages
+# --------------------------------------------------------------------------
+
+
+def _service():
+    return ActionService(llm_service=MagicMock(), memory_store=MagicMock())
+
+
+def test_endocrine_options_none_when_no_signal():
+    assert ActionService._compute_endocrine_options({}) is None
+
+
+def test_endocrine_cortisol_lowers_temperature():
+    calm = ActionService._compute_endocrine_options({"cortisol": 0.0})
+    stressed = ActionService._compute_endocrine_options({"cortisol": 1.0})
+    assert calm["temperature"] > stressed["temperature"]
+    assert stressed["temperature"] == pytest.approx(0.3)
+
+
+def test_endocrine_dopamine_raises_top_p_and_fatigue_shortens_output():
+    low = ActionService._compute_endocrine_options({"dopamine": 0.0})
+    high = ActionService._compute_endocrine_options({"dopamine": 1.0})
+    assert high["top_p"] > low["top_p"]
+
+    fresh = ActionService._compute_endocrine_options({"fatigue": 0.0})
+    tired = ActionService._compute_endocrine_options({"fatigue": 1.0})
+    assert fresh["num_predict"] == 250
+    assert tired["num_predict"] == 100
+
+
+def test_endocrine_num_predict_stays_bounded_for_out_of_range_fatigue():
+    over = ActionService._compute_endocrine_options({"fatigue": 99.0})
+    under = ActionService._compute_endocrine_options({"fatigue": -5.0})
+    assert over["num_predict"] == 100
+    assert under["num_predict"] == 250
+
+
+def test_endocrine_bad_types_fall_back_to_defaults():
+    opts = ActionService._compute_endocrine_options(
+        {"cortisol": "nope", "dopamine": "nope", "fatigue": "nope"}
+    )
+    assert opts["temperature"] == 0.7
+    assert opts["top_p"] == 0.8
+    assert opts["num_predict"] == 250
+
+
+def test_endocrine_missing_field_uses_neutral_default():
+    opts = ActionService._compute_endocrine_options({"cortisol": 0.5})
+    assert opts["top_p"] == 0.8  # dopamine absent -> neutral
+
+
+@pytest.mark.parametrize(
+    "arousal,valence,expected",
+    [
+        (0.9, -0.9, "<breath_fast> "),  # agitated + negative
+        (0.2, -0.2, "<sigh_soft> "),  # subdued + negative
+        (0.9, 0.9, ""),  # positive -> no opener
+        (0.5, 0.5, ""),
+    ],
+)
+def test_prepended_affect_tag(arousal, valence, expected):
+    assert ActionService._prepended_affect_tag(arousal, valence) == expected
+
+
+def test_build_tom_context_empty_without_model():
+    assert ActionService._build_tom_context(None) == ""
+    assert ActionService._build_tom_context({}) == ""
+
+
+def test_build_tom_context_caps_known_concepts_at_ten():
+    ctx = ActionService._build_tom_context(
+        {"known_concepts": [f"c{i}" for i in range(25)], "implied_goals": ["vent"]}
+    )
+    assert "c24" in ctx and "c15" in ctx
+    assert "c14" not in ctx  # only the last 10 survive
+    assert "vent" in ctx
+
+
+def test_build_tom_context_survives_wrong_goals_type():
+    ctx = ActionService._build_tom_context({"implied_goals": "not-a-list"})
+    assert "Implied Goals" not in ctx  # coerced to empty, not crashed
+
+
+def test_build_shared_history_edge_loads_most_relevant():
+    memories = [
+        {"content": "A", "score": 0.9},
+        {"content": "B", "score": 0.8},
+        {"content": "C", "score": 0.7},
+    ]
+    block = ActionService._build_shared_history(memories)
+    lines = [ln for ln in block.split("\n") if ln.startswith("- ")]
+    # Highest-relevance items bracket the block (A first, B last)
+    assert lines[0] == "- A"
+    assert lines[-1] == "- B"
+
+
+def test_build_shared_history_empty_for_no_memories():
+    assert ActionService._build_shared_history([]) == ""
+
+
+def test_split_thought_returns_tail_after_closing_tag():
+    assert ActionService._split_thought("<thought>reasoning</thought>spoken") == (
+        "spoken"
+    )
+    assert ActionService._split_thought("<thought>only</thought>") == ""
+
+
+def test_chat_guideline_carries_the_grounding_contract():
+    assert "GROUNDING" in _CHAT_GUIDELINE
+    assert "Do not invent memories" in _CHAT_GUIDELINE
+    assert _CHAT_GUIDELINE.startswith("Guideline:")
+
+
+def test_chat_stream_state_defaults():
+    state = _ChatStreamState(dominance=0.3)
+    assert state.accumulated_response == ""
+    assert state.in_thought is False
+    assert state.has_hesitated is False
+    assert state.dominance == 0.3
+
+
+@pytest.mark.asyncio
+async def test_emit_validated_injects_one_hesitation_only():
+    svc = _service()
+    state = _ChatStreamState(dominance=0.2)
+
+    first = [o async for o in svc._emit_validated("well, ok", state, "ENGAGE")]
+    assert first[0]["data"] == "well <hesitate>, ok"
+    assert state.has_hesitated is True
+
+    second = [o async for o in svc._emit_validated("more, text", state, "ENGAGE")]
+    assert second[0]["data"] == "more, text"  # budget already spent
+
+
+@pytest.mark.asyncio
+async def test_emit_validated_skips_hesitation_when_disallowed():
+    svc = _service()
+    state = _ChatStreamState(dominance=0.1)
+    out = [
+        o
+        async for o in svc._emit_validated(
+            "a, b", state, "ENGAGE", allow_hesitation=False
+        )
+    ]
+    assert out[0]["data"] == "a, b"
+    assert state.has_hesitated is False
+
+
+@pytest.mark.asyncio
+async def test_emit_validated_accumulates_and_raises_on_violation():
+    from app.cognitive.action import MetacognitiveException
+
+    svc = _service()
+    state = _ChatStreamState(dominance=0.9)
+
+    [o async for o in svc._emit_validated("hello ", state, "ENGAGE")]
+    assert state.accumulated_response == "hello "
+
+    with pytest.raises(MetacognitiveException):
+        [o async for o in svc._emit_validated("as an AI I cannot", state, "ENGAGE")]
+    # a rejected chunk must not be accumulated
+    assert state.accumulated_response == "hello "
+
+
+def test_control_markup_sanitizer_drops_emotion_keeps_timing():
+    s = ControlMarkupSanitizer()
+    assert s.feed("<emotion happy>hi</emotion> there") == "hi there"
+    s2 = ControlMarkupSanitizer()
+    assert s2.feed("wait <pause=300ms> ok") == "wait <pause=300ms> ok"
+
+
+def test_control_markup_sanitizer_holds_partial_tag_until_flush():
+    s = ControlMarkupSanitizer()
+    assert s.feed("text <emo") == "text "
+    assert s.feed("tion sad>rest") == "rest"
+    assert s.flush() == ""


### PR DESCRIPTION
## Summary

Closes the last open item from the original audit (F1) — the two functions flagged as the riskiest area of the codebase to change safely.

- `MemoryStore.search_memories`: **1623 → 248 lines** (-84%). Decomposed into ~25 named stages (MRL gating, topic-shift detection, candidate fetch per backend, cue extraction, entity graph, identity/pronoun resolution, PPR spreading activation, goal-buffer priming, result formatting, L3 archive recall + promotion).
- `ActionService.execute`: **523 → 24 lines** (-95%). Now a dispatcher over `_execute_respond_chat`/`_execute_store_memory`; the "hesitate → validate → yield → accumulate" block that was duplicated **six times** is now one `_emit_validated` helper.

Real duplication removed along the way: the archive-promotion path had an inline copy of the effective-similarity formula (constants `0.1`/`0.2` == `ACTR_VALENCE_GAIN`/`ACTR_STRESS_SUPPRESSION`), now calling the shared helper. The 188-word stop-word literal was being rebuilt on every single `search_memories` call; it's now a module-level constant, proven membership-identical to the original.

Two subtleties deliberately preserved (not "cleaned up"):
- The SQLite candidate-fetch path rebinds `now_ts`, and that value stamps the L1 cache entry — the extracted helper returns it explicitly rather than losing the rebind.
- The two trailing-flush emit sites skip hesitation injection, unlike the other four — preserved via an `allow_hesitation` flag on `_emit_validated`.

## How "no behavior change" was verified (not just assumed)

- **search_memories**: a characterization harness snapshots exact output over 17 scenarios (pronoun resolution both directions, PPR spreading, cue boost, goal-buffer priming across a topic-shift sequence, all three MRL stress tiers, exclusions, thresholds, limits, room filter). Run before and after the refactor → **byte-identical JSON**.
- **execute**: the pre-refactor module was restored from git as a sibling module and driven side-by-side with the new one over 29 scenarios (CoT split across chunks, hesitation budget, emotion-tag sanitization, partial tags spanning chunks, all four System-3 violation classes, grounding failure, retry-also-fails fallback, endocrine edge cases, ToM edge cases, LLM exceptions, every non-chat action type), comparing the full emitted chunk sequence, the exact prompts/options sent to the LLM, and published interrupt events. **All 29 identical.**
- `_CHAT_GUIDELINE` (the static half of the system prompt) was AST-extracted from the original f-string and proven to reconstruct it byte-for-byte (944 chars).

New `tests/test_f1_decomposed_stages.py` (42 tests) locks in the extracted stages, none of which were reachable in isolation before this refactor. Mutation-checked on both sides (a broken MRL tier, a dropped hesitation flag) to confirm the suite actually detects regressions.

## Test plan
- [x] `cd backend && python -m pytest` — 317 passed (275 existing + 42 new)
- [x] `ruff check .` — clean
- [x] Characterization harness (search_memories): byte-identical output, 17 scenarios
- [x] Equivalence harness (execute): identical chunks/prompts/publishes, 29 scenarios
- [x] Mutation testing on both extracted stage suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of memory retrieval, ranking, context assembly, and archive promotion.
  * Preserved chat streaming, validation, grounding checks, retries, and fallback behavior while improving consistency.
  * Improved handling of stress signals, pronouns, goals, timestamps, embeddings, and malformed inputs.

* **Tests**
  * Added comprehensive coverage for memory retrieval, chat processing, formatting, sanitization, fallback behavior, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->