### PR TITLE
fix(cognitive,memory): resolve 11 pre-existing bugs surfaced by the PR #66 review

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -2431,3 +2431,90 @@ inside a loop — correct, but a batching opportunity now that it is isolated in
 
 With this, every finding from the original audit (A1-A7, B1-B3, C1-C4, D1-D4,
 E1-E3, F1-F4) is either resolved or explicitly accepted.
+
+## 2026-07-18 PR #66 review fallout — eleven pre-existing bugs the decomposition exposed
+
+CodeRabbit posted 11 actionable findings on the F1 PR. Every one was checked
+against `git show main:` first: **all 11 predate F1 and were byte-identical in
+the pre-refactor code.** None were regressions. The decomposition did not
+introduce them, it made them legible — they had been buried inside a 1600-line
+and a 520-line function where nobody could see them. That is the return on F1,
+arriving one PR later than the refactor itself.
+
+PR #66 was merged as-is rather than amended, to keep its proven zero-drift
+property intact; these fixes land separately, where their behaviour changes are
+the point rather than a contamination of the equivalence claim.
+
+### Privacy
+- **Hidden reasoning was logged at INFO.** `_split_thought` wrote the whole
+  `<thought>` block to the application log. That block quotes the user's message
+  and every surfaced memory verbatim, so private conversation content was being
+  persisted into production logs on every chain-of-thought turn. Now only the
+  stripped character count is recorded, at DEBUG.
+
+### Correctness
+- **`is_self_reflection` was missing from the L1 cache key.** Pronoun cues
+  resolve in opposite directions under that flag ("I"/"my" bind to the agent when
+  self-reflecting, to the user otherwise), so for the cache TTL a self-reflection
+  query could be served the user's memories and vice versa. A perspective bug,
+  not merely a stale read.
+- **The self-correction retry leaked raw `<thought>` blocks.** Only the primary
+  stream ran the CoT parser. The retry yielded reasoning straight to the user.
+  Both paths now share one `_visible_segments` state machine rather than the
+  retry growing a second copy of it.
+- **The retry reused the aborted primary stream's sanitizer**, so a partial
+  control tag left buffered by the abandoned take corrupted the retry's first
+  chunk. It now gets a fresh sanitizer and fresh CoT state.
+- **A failed self-correction emitted `done` with no content** — the user heard
+  "Wait, let me rephrase that..." followed by silence. It now yields the safe
+  fallback line first.
+- **Malformed `known_concepts` aborted the turn with no terminal event**, since
+  `_build_tom_context` runs before the streaming `try`. Both it and
+  `implied_goals` are now type-guarded and member-coerced.
+
+### Data integrity
+- **STORE_MEMORY always claimed success.** `add_memory` returns `False` on a
+  failed write and an absent store writes nothing at all; both reported "Got it,
+  I've committed that to memory." Confirmation is now gated on a real write.
+  The shared `mock_memory_store` fixture returned `None` here, which had been
+  misrepresenting the contract — corrected to `True`.
+- **The legacy-schema fallback caught every exception.** A constraint violation,
+  serialization conflict, or transient outage would silently re-insert the row
+  with its Eriksonian metadata stripped. Narrowed to genuine missing-column
+  errors via `_is_missing_column_error` (Postgres SQLSTATE 42703; SQLite message
+  text), everything else re-raised.
+- **Archived metadata was conflated with the Qdrant payload.** The full search
+  payload was persisted as the SQL `metadata` column, and `raw_meta` was splatted
+  at the top level where a stored key named `wing` or `room` silently overwrote
+  the authoritative one. Custom fields now sit under `custom_metadata`, serialized
+  to match `add_memory`'s writer and the `orjson.loads()` on the read path.
+- **Failed promotions were still returned as promoted results** and cached as
+  active — surfacing a memory the next turn could not find again. Now skipped.
+- **SQLite archive timestamps are TEXT**, and the archive path did datetime
+  arithmetic and `.isoformat()`/`.tzinfo` access straight on them. `_as_aware_utc`
+  now parses ISO strings (including the space-separated `CURRENT_TIMESTAMP` form
+  and a trailing `Z`), degrading to `None` rather than raising mid-retrieval.
+
+### Verification
+`tests/test_pr66_review_fixes.py` (35 tests), one or more per finding. Mutation
+tested: each fix was individually reverted and the corresponding test confirmed
+to fail. The first pass caught only 10 of 11 — reverting the missing-column guard
+broke nothing, because the tests exercised the predicate in isolation but never
+proved `_insert_memory_row` actually called it. Two integration tests were added
+to close that gap, and the mutation now fails three tests.
+
+The F1 equivalence harness was re-run against the merged pre-fix module after the
+CoT state machine was rewired onto the shared helper: **28 of 29 scenarios
+byte-identical**, the sole difference being STORE_MEMORY, which is the intended
+change above. That confirms sharing the parser between the two streams did not
+disturb the primary path.
+
+Full backend suite: **352 passed** (317 + 35 new). `ruff check .` clean.
+
+**NOT done:** promotion is transactional on PostgreSQL only. The SQLite shim
+commits per `execute()` and exposes no transaction API, so there the archive
+delete is merely ordered after the insert; the insert is an idempotent upsert, so
+a partial failure re-converges on retry rather than duplicating. Making this
+genuinely atomic on both backends requires adding transaction support to
+`SQLiteConnection`, which is a change to the pool abstraction rather than to this
+call site.

--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -2518,3 +2518,44 @@ a partial failure re-converges on retry rather than duplicating. Making this
 genuinely atomic on both backends requires adding transaction support to
 `SQLiteConnection`, which is a change to the pool abstraction rather than to this
 call site.
+
+### PR #67 review round — four more, two of them self-inflicted
+
+CodeRabbit's review of the fix PR raised five findings. One (a local named
+`secret` tripping the credential scanner) was already fixed. The other four were
+real, and two were caused by this branch:
+
+- **`_as_aware_utc` returning `None` was never honoured by its callers.** The
+  new ISO-parsing path degrades to `None` on a malformed timestamp, but three
+  call sites subtracted the result directly, so a single bad archive row raised
+  and discarded the entire search result set. The docstring promised a fallback
+  the callers did not provide. All three now use `... or now`.
+- **Skipping a promotion on any exception was too blunt.** `_write_promoted_memory`
+  commits SQL *before* updating Qdrant, so a vector-store failure made the caller
+  skip a memory that had in fact been promoted — stranding it out of both the
+  returned results and the archive. SQL is now authoritative: the Qdrant upsert
+  logs and continues, while a genuine SQL failure still propagates.
+
+And two pre-existing, both worse than they first appeared:
+
+- **CoT stripping only worked when `<thought>` arrived whole in one chunk.**
+  Models stream token by token, so "<" + "thought" + ">" is the *common* case,
+  not an edge case. The old check saw a first chunk of "<", concluded no tag was
+  present, spoke it, and latched `checked_start`, after which the entire
+  reasoning block passed straight through to the user. It also dropped visible
+  text preceding a block and recognised only the first block per stream.
+  Replaced with a real incremental parser that holds partial tags across chunk
+  boundaries. This makes the earlier logging fix meaningful: there was no point
+  keeping reasoning out of the logs while speaking it aloud.
+- **A retry that produced nothing emitted only `done`**, so an expired budget or
+  an empty stream left the user with "Wait, let me rephrase that..." and silence
+  — the same hole as the exception path, one branch over.
+
+Verification: 17 further tests (49 in the file, 366 in the suite). Each of the
+four fixes was mutation-tested. The first attempt at the timestamp mutation
+passed spuriously because it patched the `_fetch_postgres_candidates` call site
+rather than the archive one the test exercises; retargeted by indentation, it
+fails as expected. The F1 equivalence harness was re-run after the parser
+rewrite: still 28/29, the sole difference remaining the intended STORE_MEMORY
+change — the new parser corrects cases the harness never covered and disturbs
+none that it does.

--- a/backend/app/cognitive/action.py
+++ b/backend/app/cognitive/action.py
@@ -335,8 +335,17 @@ class ActionService:
                 f"[Action] Unexpected type for implied_goals in user_mental_model: {type(impl_goals)}. Falling back to empty list."
             )
             impl_goals = []
-        # Take the last 10 known concepts to keep it concise and avoid context bloat
-        known_con = user_tom.get("known_concepts", [])[-10:]
+        impl_goals = [str(goal) for goal in impl_goals]
+        # Take the last 10 known concepts to keep it concise and avoid context bloat.
+        # Guarded like implied_goals above: this runs before the streaming try
+        # block, so a malformed value would abort the turn with no terminal event.
+        known_con = user_tom.get("known_concepts", [])
+        if not isinstance(known_con, list):
+            logger.warning(
+                f"[Action] Unexpected type for known_concepts in user_mental_model: {type(known_con)}. Falling back to empty list."
+            )
+            known_con = []
+        known_con = [str(concept) for concept in known_con[-10:]]
 
         tom_context = "\n\nYour Inferred Perspective of the User (Theory of Mind):\n"
         tom_context += (
@@ -425,12 +434,66 @@ class ActionService:
         """Split a completed <thought>...</thought> block off the buffer.
 
         Returns the content that follows the closing tag; the reasoning itself
-        is logged, never spoken.
+        is discarded, never spoken.
+
+        Only the stripped length is logged. The reasoning block quotes the user
+        message and any surfaced memories verbatim, so emitting it at INFO
+        persisted private conversation content into production logs.
         """
         parts = thought_buffer.split("</thought>", 1)
         thought_content = parts[0].replace("<thought>", "").strip()
-        logger.info(f"[CoT Thought] {thought_content}")
+        logger.debug("[CoT Thought] stripped %d characters", len(thought_content))
         return parts[1]
+
+    def _visible_segments(self, clean_chunk: str, state: "_ChatStreamState") -> list:
+        """Advance the CoT state machine by one chunk; return speakable text.
+
+        `<thought>...</thought>` reasoning is buffered and dropped; only what
+        falls outside it is returned. State is carried on `state` so the machine
+        survives a tag split across chunk boundaries. Both the primary and the
+        self-correction streams run through this, so the retry can no longer
+        leak raw reasoning to the user.
+        """
+        segments = []
+        if not state.checked_start:
+            state.thought_buffer += clean_chunk
+            if "<thought" in state.thought_buffer:
+                state.in_thought = True
+                state.checked_start = True
+                if "</thought>" in state.thought_buffer:
+                    remaining_content = self._split_thought(state.thought_buffer)
+                    if remaining_content:
+                        segments.append(remaining_content)
+                    state.thought_buffer = ""
+                    state.in_thought = False
+            else:
+                segments.append(state.thought_buffer)
+                state.thought_buffer = ""
+                state.checked_start = True
+        elif state.in_thought:
+            state.thought_buffer += clean_chunk
+            if "</thought>" in state.thought_buffer:
+                remaining_content = self._split_thought(state.thought_buffer)
+                if remaining_content:
+                    segments.append(remaining_content)
+                state.thought_buffer = ""
+                state.in_thought = False
+        else:
+            segments.append(clean_chunk)
+        return segments
+
+    def _visible_trailing(self, trailing: str, state: "_ChatStreamState") -> list:
+        """Same machine, for whatever the sanitizer held back at flush time."""
+        if not trailing:
+            return []
+        if state.in_thought:
+            state.thought_buffer += trailing
+            if "</thought>" in state.thought_buffer:
+                remaining_content = self._split_thought(state.thought_buffer)
+                if remaining_content:
+                    return [remaining_content]
+            return []
+        return [trailing]
 
     async def _emit_validated(
         self, text: str, state: "_ChatStreamState", goal: str, allow_hesitation: bool = True
@@ -499,62 +562,16 @@ class ActionService:
                 continue
 
             # CoT strip check
-            if not state.checked_start:
-                state.thought_buffer += clean_chunk
-                if "<thought" in state.thought_buffer:
-                    state.in_thought = True
-                    state.checked_start = True
-                    if "</thought>" in state.thought_buffer:
-                        remaining_content = self._split_thought(state.thought_buffer)
-                        if remaining_content:
-                            async for out in self._emit_validated(
-                                remaining_content, state, plan.goal
-                            ):
-                                yield out
-                        state.thought_buffer = ""
-                        state.in_thought = False
-                else:
-                    async for out in self._emit_validated(
-                        state.thought_buffer, state, plan.goal
-                    ):
-                        yield out
-                    state.thought_buffer = ""
-                    state.checked_start = True
-                    continue
-
-            elif state.in_thought:
-                state.thought_buffer += clean_chunk
-                if "</thought>" in state.thought_buffer:
-                    remaining_content = self._split_thought(state.thought_buffer)
-                    if remaining_content:
-                        async for out in self._emit_validated(
-                            remaining_content, state, plan.goal
-                        ):
-                            yield out
-                    state.thought_buffer = ""
-                    state.in_thought = False
-                continue
-            else:
-                async for out in self._emit_validated(clean_chunk, state, plan.goal):
+            for segment in self._visible_segments(clean_chunk, state):
+                async for out in self._emit_validated(segment, state, plan.goal):
                     yield out
 
         # Flush whatever the markup sanitizer was still holding back.
-        trailing = sanitizer.flush()
-        if trailing:
-            if state.in_thought:
-                state.thought_buffer += trailing
-                if "</thought>" in state.thought_buffer:
-                    remaining_content = self._split_thought(state.thought_buffer)
-                    if remaining_content:
-                        async for out in self._emit_validated(
-                            remaining_content, state, plan.goal, allow_hesitation=False
-                        ):
-                            yield out
-            else:
-                async for out in self._emit_validated(
-                    trailing, state, plan.goal, allow_hesitation=False
-                ):
-                    yield out
+        for segment in self._visible_trailing(sanitizer.flush(), state):
+            async for out in self._emit_validated(
+                segment, state, plan.goal, allow_hesitation=False
+            ):
+                yield out
 
         # Post-generation grounding gate: the whole utterance is now known, so
         # check it for fabricated shared-memory claims and route any hit
@@ -588,7 +605,6 @@ class ActionService:
         system_instruction: str,
         model,
         endocrine_options,
-        sanitizer: "ControlMarkupSanitizer",
         stream_budget: int,
         surfaced: list,
         msg: str,
@@ -597,7 +613,13 @@ class ActionService:
 
         Any further violation (constraint or grounding, mid-stream or trailing)
         collapses to a single safe fallback line rather than a third attempt.
+
+        The retry gets its own sanitizer and CoT state: the primary stream was
+        abandoned mid-flight and may have left a partial control tag buffered or
+        an unclosed `<thought>` open, which would corrupt the retry's first chunk.
         """
+        sanitizer = ControlMarkupSanitizer()
+        cot_state = _ChatStreamState()
         stream_iter = self.llm.generate_stream(
             prompt=user_prompt,
             system=system_instruction,
@@ -608,7 +630,7 @@ class ActionService:
         accumulated_retry_response = ""
         is_valid = True
 
-        while True:
+        while is_valid:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
                 break
@@ -618,35 +640,39 @@ class ActionService:
                 )
             except StopAsyncIteration:
                 break
-            clean_chunk = sanitizer.feed(chunk)
-            if not clean_chunk:
+            raw_chunk = sanitizer.feed(chunk)
+            if not raw_chunk:
                 continue
 
-            candidate = accumulated_retry_response + clean_chunk
-            is_valid, _ = self._validate_partial_response(candidate, plan.goal)
-            if not is_valid:
-                logger.warning(
-                    "[System 3] Retry also violated constraints; yielding safe fallback."
-                )
-                yield {"type": "content", "data": _SAFE_FALLBACK_LINE}
-                break
+            for clean_chunk in self._visible_segments(raw_chunk, cot_state):
+                candidate = accumulated_retry_response + clean_chunk
+                is_valid, _ = self._validate_partial_response(candidate, plan.goal)
+                if not is_valid:
+                    logger.warning(
+                        "[System 3] Retry also violated constraints; yielding safe fallback."
+                    )
+                    yield {"type": "content", "data": _SAFE_FALLBACK_LINE}
+                    break
 
-            # Check grounding on the accumulated response so far
-            is_retry_grounded, retry_ground_reason = self._check_response_grounding(
-                candidate, surfaced, msg
-            )
-            if not is_retry_grounded:
-                logger.warning(
-                    f"[System 3] Retry fabricated a memory claim: {retry_ground_reason}. Yielding safe fallback."
+                # Check grounding on the accumulated response so far
+                is_retry_grounded, retry_ground_reason = self._check_response_grounding(
+                    candidate, surfaced, msg
                 )
-                yield {"type": "content", "data": _SAFE_FALLBACK_LINE}
-                break
+                if not is_retry_grounded:
+                    logger.warning(
+                        f"[System 3] Retry fabricated a memory claim: {retry_ground_reason}. Yielding safe fallback."
+                    )
+                    is_valid = False
+                    yield {"type": "content", "data": _SAFE_FALLBACK_LINE}
+                    break
 
-            yield {"type": "content", "data": clean_chunk}
-            accumulated_retry_response = candidate
+                yield {"type": "content", "data": clean_chunk}
+                accumulated_retry_response = candidate
 
         if is_valid:
-            trailing = sanitizer.flush()
+            trailing = "".join(
+                self._visible_trailing(sanitizer.flush(), cot_state)
+            )
             if trailing:
                 candidate = accumulated_retry_response + trailing
                 is_valid_trail, _ = self._validate_partial_response(
@@ -752,7 +778,6 @@ class ActionService:
                         system_instruction=system_instruction,
                         model=model,
                         endocrine_options=endocrine_options,
-                        sanitizer=sanitizer,
                         stream_budget=stream_budget,
                         surfaced=surfaced,
                         msg=msg,
@@ -760,6 +785,9 @@ class ActionService:
                         yield out
                 except Exception as inner_e:
                     logger.error(f"[System 3] Self-correction generation failed: {inner_e}")
+                    # Without this the user hears "Wait, let me rephrase that..."
+                    # followed by silence.
+                    yield {"type": "content", "data": _SAFE_FALLBACK_LINE}
                     yield {"type": "done", "data": "finished"}
 
             except asyncio.TimeoutError:
@@ -781,14 +809,28 @@ class ActionService:
     async def _execute_store_memory(self, plan: ActionPlan):
         """Commit an explicitly requested memory."""
         content = plan.payload.get("content", "")
-        # Using the new intelligent MemoryStore
-        if self.memory:
-            await self.memory.add_memory(
-                content=content,
-                importance=0.7,  # High importance for explicit 'remember' commands
-                emotion=0.2,
-                source="user",
-            )
+        # Using the new intelligent MemoryStore. Confirmation is gated on an
+        # actual successful write: add_memory() returns False when persistence
+        # fails, and an absent store writes nothing at all. Claiming "committed
+        # to memory" in either case is a promise the agent cannot keep.
+        if not self.memory:
+            logger.error("[Action] STORE_MEMORY requested but no memory store is attached.")
+            yield {"type": "error", "data": "Memory storage is unavailable."}
+            yield {"type": "done", "data": ""}
+            return
+
+        stored = await self.memory.add_memory(
+            content=content,
+            importance=0.7,  # High importance for explicit 'remember' commands
+            emotion=0.2,
+            source="user",
+        )
+        if not stored:
+            logger.error("[Action] Memory persistence failed for an explicit store request.")
+            yield {"type": "error", "data": "Memory could not be stored."}
+            yield {"type": "done", "data": ""}
+            return
+
         yield {"type": "system", "data": "Memory securely consolidated."}
         yield {"type": "content", "data": "Got it, I've committed that to memory."}
         yield {"type": "done", "data": ""}

--- a/backend/app/cognitive/action.py
+++ b/backend/app/cognitive/action.py
@@ -445,55 +445,91 @@ class ActionService:
         logger.debug("[CoT Thought] stripped %d characters", len(thought_content))
         return parts[1]
 
-    def _visible_segments(self, clean_chunk: str, state: "_ChatStreamState") -> list:
-        """Advance the CoT state machine by one chunk; return speakable text.
+    _THOUGHT_OPEN = "<thought"
+    _THOUGHT_CLOSE = "</thought>"
 
-        `<thought>...</thought>` reasoning is buffered and dropped; only what
-        falls outside it is returned. State is carried on `state` so the machine
-        survives a tag split across chunk boundaries. Both the primary and the
-        self-correction streams run through this, so the retry can no longer
-        leak raw reasoning to the user.
+    @staticmethod
+    def _held_partial(data: str, token: str) -> str:
+        """Longest suffix of `data` that is a proper prefix of `token`.
+
+        This is what makes the parser safe across chunk boundaries: a stream
+        ending in "<tho" must hold those characters back rather than speak them,
+        because the next chunk may complete the tag.
+        """
+        for length in range(min(len(data), len(token) - 1), 0, -1):
+            if data[-length:] == token[:length]:
+                return data[-length:]
+        return ""
+
+    def _visible_segments(self, clean_chunk: str, state: "_ChatStreamState") -> list:
+        """Advance the CoT parser by one chunk; return speakable text.
+
+        `<thought>...</thought>` reasoning is dropped, everything outside it is
+        returned. Both the primary and the self-correction streams run through
+        this, so neither can leak raw reasoning to the user.
+
+        This is an incremental parser rather than a "does the buffer contain a
+        tag yet" check, because models stream token by token: "<thought>" very
+        commonly arrives as "<" + "thought" + ">". The previous approach saw a
+        first chunk of "<" , concluded no tag was present, spoke it, and latched
+        into a state where the whole reasoning block passed straight through --
+        so CoT stripping only worked when the opening tag happened to land
+        whole in one chunk. It also dropped any visible text preceding a tag and
+        handled only a single block per stream. All of that is handled here.
         """
         segments = []
-        if not state.checked_start:
-            state.thought_buffer += clean_chunk
-            if "<thought" in state.thought_buffer:
-                state.in_thought = True
-                state.checked_start = True
-                if "</thought>" in state.thought_buffer:
-                    remaining_content = self._split_thought(state.thought_buffer)
-                    if remaining_content:
-                        segments.append(remaining_content)
-                    state.thought_buffer = ""
-                    state.in_thought = False
-            else:
-                segments.append(state.thought_buffer)
-                state.thought_buffer = ""
-                state.checked_start = True
-        elif state.in_thought:
-            state.thought_buffer += clean_chunk
-            if "</thought>" in state.thought_buffer:
-                remaining_content = self._split_thought(state.thought_buffer)
-                if remaining_content:
-                    segments.append(remaining_content)
-                state.thought_buffer = ""
+        data = state.thought_buffer + clean_chunk
+        state.thought_buffer = ""
+
+        while data:
+            if state.in_thought:
+                idx = data.find(self._THOUGHT_CLOSE)
+                if idx == -1:
+                    # Still reasoning. Retain only a possible partial closing
+                    # tag; the rest is reasoning and is discarded unspoken.
+                    state.thought_buffer = self._held_partial(
+                        data, self._THOUGHT_CLOSE
+                    )
+                    break
+                data = data[idx + len(self._THOUGHT_CLOSE) :]
                 state.in_thought = False
-        else:
-            segments.append(clean_chunk)
+                continue
+
+            idx = data.find(self._THOUGHT_OPEN)
+            if idx == -1:
+                held = self._held_partial(data, self._THOUGHT_OPEN)
+                visible = data[: len(data) - len(held)] if held else data
+                if visible:
+                    segments.append(visible)
+                state.thought_buffer = held
+                break
+
+            if idx > 0:
+                segments.append(data[:idx])
+            close_bracket = data.find(">", idx)
+            if close_bracket == -1:
+                # "<thought" seen but the tag is not terminated yet.
+                state.thought_buffer = data[idx:]
+                break
+            state.in_thought = True
+            data = data[close_bracket + 1 :]
+
+        state.checked_start = True
         return segments
 
     def _visible_trailing(self, trailing: str, state: "_ChatStreamState") -> list:
-        """Same machine, for whatever the sanitizer held back at flush time."""
-        if not trailing:
-            return []
-        if state.in_thought:
-            state.thought_buffer += trailing
-            if "</thought>" in state.thought_buffer:
-                remaining_content = self._split_thought(state.thought_buffer)
-                if remaining_content:
-                    return [remaining_content]
-            return []
-        return [trailing]
+        """Same parser, for whatever the sanitizer held back at flush time.
+
+        Anything still buffered afterwards was an unterminated tag or an
+        unclosed thought block; neither is speakable, so it is dropped.
+        """
+        segments = self._visible_segments(trailing, state) if trailing else []
+        leftover = state.thought_buffer
+        state.thought_buffer = ""
+        if leftover and not state.in_thought:
+            # A partial that never completed (e.g. a literal trailing "<").
+            segments.append(leftover)
+        return segments
 
     async def _emit_validated(
         self, text: str, state: "_ChatStreamState", goal: str, allow_hesitation: bool = True
@@ -629,6 +665,7 @@ class ActionService:
         deadline = time.monotonic() + stream_budget
         accumulated_retry_response = ""
         is_valid = True
+        emitted_any = False
 
         while is_valid:
             remaining = deadline - time.monotonic()
@@ -651,6 +688,7 @@ class ActionService:
                     logger.warning(
                         "[System 3] Retry also violated constraints; yielding safe fallback."
                     )
+                    emitted_any = True
                     yield {"type": "content", "data": _SAFE_FALLBACK_LINE}
                     break
 
@@ -663,9 +701,11 @@ class ActionService:
                         f"[System 3] Retry fabricated a memory claim: {retry_ground_reason}. Yielding safe fallback."
                     )
                     is_valid = False
+                    emitted_any = True
                     yield {"type": "content", "data": _SAFE_FALLBACK_LINE}
                     break
 
+                emitted_any = True
                 yield {"type": "content", "data": clean_chunk}
                 accumulated_retry_response = candidate
 
@@ -682,6 +722,7 @@ class ActionService:
                     logger.warning(
                         "[System 3] Retry trailing also violated constraints; yielding safe fallback."
                     )
+                    emitted_any = True
                     yield {"type": "content", "data": _SAFE_FALLBACK_LINE}
                 else:
                     # Check grounding on trailing content too
@@ -692,9 +733,18 @@ class ActionService:
                         logger.warning(
                             f"[System 3] Retry trailing fabricated a memory claim: {trail_ground_reason}. Yielding safe fallback."
                         )
+                        emitted_any = True
                         yield {"type": "content", "data": _SAFE_FALLBACK_LINE}
                     else:
+                        emitted_any = True
                         yield {"type": "content", "data": trailing}
+
+        if not emitted_any:
+            # An empty retry stream, an expired budget, or a deadline that had
+            # already passed all land here. Without this the user hears
+            # "Wait, let me rephrase that..." and then nothing at all.
+            logger.warning("[System 3] Retry produced no content; yielding safe fallback.")
+            yield {"type": "content", "data": _SAFE_FALLBACK_LINE}
 
         yield {"type": "done", "data": "finished"}
 

--- a/backend/app/state/memory_store.py
+++ b/backend/app/state/memory_store.py
@@ -288,6 +288,25 @@ class MemoryStore:
         return isinstance(getattr(conn, "conn", None), sqlite3.Connection)
 
     @staticmethod
+    def _is_missing_column_error(exc: BaseException) -> bool:
+        """True only when a write failed because a column does not exist.
+
+        Distinguishes an un-migrated schema (worth retrying without the
+        Eriksonian columns) from constraint violations, serialization
+        conflicts, and transient outages (which must propagate). Postgres
+        reports SQLSTATE 42703; SQLite only says so in the message text.
+        """
+        sqlstate = getattr(exc, "sqlstate", None) or getattr(exc, "pgcode", None)
+        if sqlstate == "42703":  # undefined_column
+            return True
+        if type(exc).__name__ == "UndefinedColumnError":
+            return True
+        message = str(exc).lower()
+        if isinstance(exc, sqlite3.OperationalError):
+            return "no column named" in message or "has no column" in message
+        return False
+
+    @staticmethod
     def _as_aware_utc(dt):
         """Coerce a datetime to timezone-aware UTC so recency arithmetic never
         mixes naive and aware operands (which raises TypeError).
@@ -298,9 +317,27 @@ class MemoryStore:
         current_time). Naive inputs are assumed to already be UTC -- which is how
         the stored timestamps are written -- and aware inputs are converted.
         None passes through so callers can apply their own fallback.
+
+        SQLite hands back TEXT for timestamp columns, so archived rows can carry
+        an ISO string where the active path carries a datetime. Those are parsed
+        here rather than at each call site; anything unparseable degrades to None
+        so callers fall back instead of raising mid-retrieval.
         """
         if dt is None:
             return None
+        if isinstance(dt, str):
+            raw = dt.strip()
+            if not raw:
+                return None
+            # SQLite CURRENT_TIMESTAMP writes "YYYY-MM-DD HH:MM:SS"; fromisoformat
+            # handles that plus the "T"-separated and offset-bearing variants.
+            if raw.endswith("Z"):
+                raw = raw[:-1] + "+00:00"
+            try:
+                dt = datetime.fromisoformat(raw)
+            except ValueError:
+                logger.debug("Unparseable stored timestamp %r; treating as missing.", dt)
+                return None
         if dt.tzinfo is None:
             return dt.replace(tzinfo=timezone.utc)
         return dt.astimezone(timezone.utc)
@@ -608,7 +645,13 @@ class MemoryStore:
 
         try:
             await _insert(include_eriksonian=True)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - narrowed by _is_missing_column_error
+            # Only an un-migrated schema justifies dropping the Eriksonian
+            # columns. Retrying on *any* failure meant a constraint violation,
+            # a serialization conflict, or a transient outage would silently
+            # re-insert the row with its developmental metadata stripped.
+            if not self._is_missing_column_error(e):
+                raise
             logger.warning(
                 f"Eriksonian insert failed, falling back to legacy schema: {e}"
             )
@@ -1987,8 +2030,23 @@ class MemoryStore:
             return float(np.dot(q_arr, emb_arr) / (norm_q * norm_emb))
         return 0.0
 
-    async def _write_promoted_memory(self, mem_id, content, row, emb, recall_count, now, payload_meta):
-        """Move one archived row back into the active tier (SQL + Qdrant)."""
+    async def _write_promoted_memory(
+        self, mem_id, content, row, emb, recall_count, now, payload_meta, sql_meta
+    ):
+        """Move one archived row back into the active tier (SQL + Qdrant).
+
+        `sql_meta` is the row's own metadata envelope and `payload_meta` the
+        Qdrant search payload; they are deliberately not the same object. Qdrant
+        needs the denormalized scalars flattened for filtering, while the SQL
+        `metadata` column is the authoritative record and must round-trip what
+        `add_memory` would have written.
+
+        Raises on failure so the caller does not report an unpersisted memory.
+        On PostgreSQL the insert and the archive delete run in one transaction;
+        the SQLite shim commits per statement, so there the delete is merely
+        ordered after the insert. The insert is an idempotent upsert, so a
+        partial failure re-converges on retry rather than duplicating.
+        """
         insert_values = (
             mem_id,
             content,
@@ -2004,7 +2062,7 @@ class MemoryStore:
             recall_count + 1,
             now,
             row.get("created_at"),
-            json.dumps(payload_meta),
+            json.dumps(sql_meta),
             row.get("lifespan_stage"),
             row.get("crisis"),
             row.get("virtue"),
@@ -2012,7 +2070,8 @@ class MemoryStore:
             row.get("relation_circles"),
             row.get("modality"),
         )
-        async with self.pool.acquire() as conn:
+
+        async def _move(conn):
             if self.is_sqlite:
                 await conn.execute(_PROMOTE_INSERT_SQLITE, *insert_values)
                 await conn.execute(
@@ -2023,6 +2082,14 @@ class MemoryStore:
                 await conn.execute(
                     "DELETE FROM archived_memories WHERE id = $1", mem_id
                 )
+
+        async with self.pool.acquire() as conn:
+            transaction = getattr(conn, "transaction", None)
+            if not self.is_sqlite and callable(transaction):
+                async with transaction():
+                    await _move(conn)
+            else:
+                await _move(conn)
 
         # Upsert Qdrant
         if self.qdrant_store and self.qdrant_store.client:
@@ -2040,7 +2107,16 @@ class MemoryStore:
 
     @staticmethod
     def _build_promotion_payload(row, raw_meta) -> dict:
-        """Qdrant payload for a memory being promoted out of the archive."""
+        """Qdrant payload for a memory being promoted out of the archive.
+
+        Mirrors the canonical shape `add_memory` writes: the authoritative
+        columns stay sourced from the row itself, and the memory's own metadata
+        goes under `custom_metadata` where the read path expects it. Splatting
+        `raw_meta` at the top level (as this once did) let a stored key named
+        `wing` or `room` silently overwrite the real one, and hid the custom
+        fields from readers looking for the envelope.
+        """
+        created_at = MemoryStore._as_aware_utc(row.get("created_at"))
         return {
             "wing": row.get("wing", "personal"),
             "room": row.get("room") or "",
@@ -2049,16 +2125,16 @@ class MemoryStore:
             "valence": row.get("valence"),
             "certainty": row.get("certainty"),
             "source": row.get("source"),
-            "created_at": row.get("created_at").isoformat()
-            if row.get("created_at")
-            else None,
+            "created_at": created_at.isoformat() if created_at else None,
             "lifespan_stage": row.get("lifespan_stage") or "",
             "crisis": row.get("crisis") or "",
             "virtue": row.get("virtue") or "",
             "relations": row.get("relations") or "",
             "relation_circles": row.get("relation_circles") or "",
             "modality": row.get("modality") or "",
-            **(raw_meta or {}),
+            # Serialized, matching add_memory's writer and the orjson.loads()
+            # in the Qdrant read path.
+            "custom_metadata": orjson.dumps(raw_meta or {}).decode(),
         }
 
     async def _promote_archived_rows(
@@ -2120,14 +2196,23 @@ class MemoryStore:
 
             try:
                 await self._write_promoted_memory(
-                    mem_id, content, row, emb, recall_count, now, payload_meta
+                    mem_id,
+                    content,
+                    row,
+                    emb,
+                    recall_count,
+                    now,
+                    payload_meta,
+                    sql_meta=raw_meta,
                 )
             except Exception as prom_err:
+                # The move did not persist, so this memory is still archived.
+                # Returning it anyway surfaced a result the next turn could not
+                # find again, and cached it as though it were active.
                 logger.error(f"Failed to promote memory {mem_id}: {prom_err}")
+                continue
 
-            created = row.get("created_at")
-            if created and created.tzinfo is None:
-                created = created.replace(tzinfo=timezone.utc)
+            created = self._as_aware_utc(row.get("created_at"))
 
             # Rescore as an active memory: recall_count was incremented on
             # promotion and last_recalled_at is now, so recency is ~0.
@@ -2264,6 +2349,10 @@ class MemoryStore:
             current_cortisol,
             tuple(sorted(exclude_contents or [])),
             user_id,
+            # Pronoun cues resolve in opposite directions depending on this flag
+            # ("I"/"my" bind to the agent when self-reflecting, to the user
+            # otherwise), so the two modes must not share a cache entry.
+            is_self_reflection,
             current_time.isoformat() if current_time is not None else None,
         )
         now_ts = current_time.timestamp() if current_time is not None else time.time()

--- a/backend/app/state/memory_store.py
+++ b/backend/app/state/memory_store.py
@@ -1359,9 +1359,10 @@ class MemoryStore:
                 if current_time is not None
                 else datetime.now(timezone.utc)
             )
-            last_recall = (
-                now if last_recall is None else self._as_aware_utc(last_recall)
-            )
+            # `or now` covers both a missing timestamp and one _as_aware_utc
+            # could not parse; either way the row is treated as just-recalled
+            # rather than raising and discarding the whole result set.
+            last_recall = self._as_aware_utc(last_recall) or now
 
             hours_since = max(0.001, (now - last_recall).total_seconds() / 3600.0)
 
@@ -1945,7 +1946,9 @@ class MemoryStore:
             if current_time is not None
             else datetime.now(timezone.utc)
         )
-        last_recall = now if last_recall is None else self._as_aware_utc(last_recall)
+        # `or now`: an unparseable stored timestamp must not raise here and
+        # discard otherwise valid archive candidates.
+        last_recall = self._as_aware_utc(last_recall) or now
 
         hours_since = max(0.001, (now - last_recall).total_seconds() / 3600.0)
         memory_valence = row.get("valence") or 0.0
@@ -2091,15 +2094,26 @@ class MemoryStore:
             else:
                 await _move(conn)
 
-        # Upsert Qdrant
+        # Upsert Qdrant. The SQL move above is the authoritative promotion and
+        # has already committed: the active row exists and the archive row is
+        # gone. Letting a vector-store failure propagate here would make the
+        # caller skip a memory that is, in fact, promoted -- stranding it out of
+        # both the returned results and the archive. Log and carry on; the
+        # vector index is a search accelerator, rebuildable from SQL.
         if self.qdrant_store and self.qdrant_store.client:
-            await asyncio.to_thread(
-                self.qdrant_store.add_vector_memory,
-                mem_id,
-                emb,
-                content,
-                payload_meta,
-            )
+            try:
+                await asyncio.to_thread(
+                    self.qdrant_store.add_vector_memory,
+                    mem_id,
+                    emb,
+                    content,
+                    payload_meta,
+                )
+            except Exception as qerr:
+                logger.error(
+                    f"Promoted memory {mem_id} committed to SQL but its Qdrant "
+                    f"upsert failed; vector index is stale for this row: {qerr}"
+                )
 
         logger.info(
             f"📥 [Memory Promotion] Promoted memory '{content[:40]}...' from archive back to active storage."
@@ -2819,7 +2833,7 @@ class MemoryStore:
                         if current_time is not None
                         else datetime.now(timezone.utc)
                     )
-                    delta = now - self._as_aware_utc(dt)
+                    delta = now - (self._as_aware_utc(dt) or now)
                     hours_since = max(0.0, delta.total_seconds() / 3600.0)
 
                     # Extract decay_rate from metadata if possible

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -375,7 +375,8 @@ def mock_memory_store():
     """Mock for PGVector MemoryStore"""
     store = MagicMock()
     store.search_memories = AsyncMock(return_value=[])
-    store.add_memory = AsyncMock(return_value=None)
+    # The real add_memory returns True/False; None would read as a failed write.
+    store.add_memory = AsyncMock(return_value=True)
     return store
 
 

--- a/backend/tests/test_pr66_review_fixes.py
+++ b/backend/tests/test_pr66_review_fixes.py
@@ -70,14 +70,16 @@ async def _drain(agen):
 
 def test_split_thought_does_not_log_reasoning_content(caplog):
     """Finding #1: the reasoning block quotes the user and surfaced memories."""
-    secret = "the user's private disclosure about their medical history"
+    private_content = "the user's own disclosure about their medical history"
     with caplog.at_level("DEBUG"):
-        tail = ActionService._split_thought(f"<thought>{secret}</thought>Hello.")
+        tail = ActionService._split_thought(
+            f"<thought>{private_content}</thought>Hello."
+        )
 
     assert tail == "Hello."
-    assert secret not in caplog.text
+    assert private_content not in caplog.text
     # The length is fine to record; the content is not.
-    assert str(len(secret)) in caplog.text
+    assert str(len(private_content)) in caplog.text
 
 
 @pytest.mark.parametrize("bad", ["not a list", 42, {"a": 1}, None])

--- a/backend/tests/test_pr66_review_fixes.py
+++ b/backend/tests/test_pr66_review_fixes.py
@@ -1,0 +1,393 @@
+"""
+Regression tests for the eleven pre-existing bugs surfaced by the PR #66 review.
+
+All of these predated the F1 decomposition: the refactor did not introduce them,
+it made them visible by lifting the logic out of two thousand-line functions.
+Each test below fails against the code as it stood before this branch.
+"""
+
+import asyncio
+import sqlite3
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import orjson
+import pytest
+
+from app.cognitive.action import (
+    ActionService,
+    _ChatStreamState,
+    _SAFE_FALLBACK_LINE,
+)
+from app.cognitive.decision import ActionPlan
+from app.state.memory_store import MemoryStore
+
+
+def _store():
+    store = MemoryStore(MagicMock(), MagicMock())
+    store.qdrant_store.client = None
+    return store
+
+
+def _service(llm=None, memory=None):
+    return ActionService(llm_service=llm or MagicMock(), memory_store=memory)
+
+
+def _plan(action_type="RESPOND_CHAT", **payload):
+    base = {"message": "hi", "identity_prompt": "You are Aniket.", "emotion_state": "neutral"}
+    base.update(payload)
+    return ActionPlan(action_type=action_type, payload=base, goal="ENGAGE")
+
+
+class _ScriptedLLM:
+    """Yields a fixed chunk list per call; later calls reuse the last script."""
+
+    def __init__(self, *scripts):
+        self.scripts = list(scripts)
+        self.calls = 0
+
+    def generate_stream(self, prompt=None, system=None, model=None, options_override=None):
+        script = self.scripts[min(self.calls, len(self.scripts) - 1)]
+        self.calls += 1
+
+        async def _gen():
+            for chunk in script:
+                if isinstance(chunk, Exception):
+                    raise chunk
+                yield chunk
+
+        return _gen()
+
+
+async def _drain(agen):
+    return [item async for item in agen]
+
+
+# --------------------------------------------------------------------------
+# action.py
+# --------------------------------------------------------------------------
+
+
+def test_split_thought_does_not_log_reasoning_content(caplog):
+    """Finding #1: the reasoning block quotes the user and surfaced memories."""
+    secret = "the user's private disclosure about their medical history"
+    with caplog.at_level("DEBUG"):
+        tail = ActionService._split_thought(f"<thought>{secret}</thought>Hello.")
+
+    assert tail == "Hello."
+    assert secret not in caplog.text
+    # The length is fine to record; the content is not.
+    assert str(len(secret)) in caplog.text
+
+
+@pytest.mark.parametrize("bad", ["not a list", 42, {"a": 1}, None])
+def test_build_tom_context_survives_malformed_known_concepts(bad):
+    """Finding #0: this runs before the stream's try block, so a raise here
+    aborted the turn with no terminal event ever reaching the client."""
+    out = ActionService._build_tom_context({"known_concepts": bad, "implied_goals": []})
+    assert "Theory of Mind" in out
+
+
+def test_build_tom_context_coerces_non_string_members():
+    out = ActionService._build_tom_context(
+        {"known_concepts": [1, None, "tea"], "implied_goals": [7, "vent"]}
+    )
+    assert "tea" in out and "vent" in out
+    assert "7" in out
+
+
+def test_build_tom_context_keeps_last_ten_concepts():
+    out = ActionService._build_tom_context(
+        {"known_concepts": [f"c{i}" for i in range(15)], "implied_goals": []}
+    )
+    assert "c14" in out
+    assert "c4" not in out.split("Known Concepts")[1]
+
+
+def test_visible_segments_strips_thought_split_across_chunks():
+    """The CoT machine both paths now share."""
+    svc = _service()
+    state = _ChatStreamState()
+    seen = []
+    for chunk in ["<thought>plan", " harder", "</thought>", "Real reply."]:
+        seen.extend(svc._visible_segments(chunk, state))
+    assert "".join(seen) == "Real reply."
+    assert "plan" not in "".join(seen)
+
+
+def test_visible_segments_passes_through_plain_text():
+    svc = _service()
+    state = _ChatStreamState()
+    seen = []
+    for chunk in ["Hello", " there"]:
+        seen.extend(svc._visible_segments(chunk, state))
+    assert "".join(seen) == "Hello there"
+
+
+def test_self_correction_strips_thought_blocks():
+    """Finding #2: the retry emitted raw <thought> content to the user."""
+    llm = _ScriptedLLM(
+        ["As an AI I cannot"],
+        ["<thought>I must avoid that phrase</thought>Of course, happy to help."],
+    )
+    svc = _service(llm=llm)
+    out = asyncio.run(_drain(svc.execute(_plan())))
+    spoken = "".join(c["data"] for c in out if c["type"] == "content")
+
+    assert "Of course, happy to help." in spoken
+    assert "<thought>" not in spoken
+    assert "I must avoid that phrase" not in spoken
+
+
+def test_self_correction_uses_a_fresh_sanitizer():
+    """Finding #3: the aborted primary stream left a partial control tag
+    buffered, which corrupted the retry's first chunk."""
+    llm = _ScriptedLLM(
+        ["As an AI I cannot <emo"],
+        ["All better now."],
+    )
+    svc = _service(llm=llm)
+    out = asyncio.run(_drain(svc.execute(_plan())))
+    spoken = "".join(c["data"] for c in out if c["type"] == "content")
+
+    assert "All better now." in spoken
+    assert "<emo" not in spoken
+
+
+def test_self_correction_failure_yields_fallback_not_silence():
+    """Finding #4: users heard 'Wait, let me rephrase that...' then nothing."""
+    llm = _ScriptedLLM(["As an AI I cannot"], [RuntimeError("retry stream died")])
+    svc = _service(llm=llm)
+    out = asyncio.run(_drain(svc.execute(_plan())))
+
+    contents = [c["data"] for c in out if c["type"] == "content"]
+    assert _SAFE_FALLBACK_LINE in contents
+    assert out[-1]["type"] == "done"
+
+
+def test_store_memory_reports_failure_when_persistence_fails():
+    """Finding #5: add_memory returning False still claimed success."""
+    memory = MagicMock()
+    memory.add_memory = AsyncMock(return_value=False)
+    svc = _service(memory=memory)
+    out = asyncio.run(_drain(svc.execute(_plan("STORE_MEMORY", content="remember this"))))
+
+    assert any(c["type"] == "error" for c in out)
+    assert not any("committed that to memory" in str(c["data"]) for c in out)
+    assert out[-1]["type"] == "done"
+
+
+def test_store_memory_reports_failure_when_no_store_attached():
+    svc = _service(memory=None)
+    out = asyncio.run(_drain(svc.execute(_plan("STORE_MEMORY", content="remember this"))))
+
+    assert any(c["type"] == "error" for c in out)
+    assert not any("committed that to memory" in str(c["data"]) for c in out)
+
+
+def test_store_memory_confirms_on_success():
+    memory = MagicMock()
+    memory.add_memory = AsyncMock(return_value=True)
+    svc = _service(memory=memory)
+    out = asyncio.run(_drain(svc.execute(_plan("STORE_MEMORY", content="remember this"))))
+
+    assert any("committed that to memory" in str(c["data"]) for c in out)
+    assert not any(c["type"] == "error" for c in out)
+
+
+# --------------------------------------------------------------------------
+# memory_store.py
+# --------------------------------------------------------------------------
+
+
+def test_as_aware_utc_parses_sqlite_timestamp_strings():
+    """Finding #6: SQLite hands back TEXT, and the archive path did datetime
+    arithmetic on it."""
+    got = MemoryStore._as_aware_utc("2026-07-18 12:30:00")
+    assert got == datetime(2026, 7, 18, 12, 30, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("2026-07-18T12:30:00", datetime(2026, 7, 18, 12, 30, tzinfo=timezone.utc)),
+        ("2026-07-18T12:30:00Z", datetime(2026, 7, 18, 12, 30, tzinfo=timezone.utc)),
+        ("2026-07-18T12:30:00+00:00", datetime(2026, 7, 18, 12, 30, tzinfo=timezone.utc)),
+    ],
+)
+def test_as_aware_utc_handles_iso_variants(raw, expected):
+    assert MemoryStore._as_aware_utc(raw) == expected
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "not a timestamp"])
+def test_as_aware_utc_degrades_to_none_on_unparseable(bad):
+    """Callers apply their own fallback; raising mid-retrieval discarded
+    otherwise valid active results."""
+    assert MemoryStore._as_aware_utc(bad) is None
+
+
+def test_as_aware_utc_preserves_existing_behaviour():
+    naive = datetime(2026, 7, 18, 12, 30)
+    aware = datetime(2026, 7, 18, 12, 30, tzinfo=timezone.utc)
+    assert MemoryStore._as_aware_utc(None) is None
+    assert MemoryStore._as_aware_utc(naive) == aware
+    assert MemoryStore._as_aware_utc(aware) == aware
+
+
+def test_missing_column_error_detection():
+    """Finding #7: only an un-migrated schema justifies dropping columns."""
+    assert MemoryStore._is_missing_column_error(
+        sqlite3.OperationalError("table memories has no column named virtue")
+    )
+
+    pg_err = Exception("column \"virtue\" does not exist")
+    pg_err.sqlstate = "42703"
+    assert MemoryStore._is_missing_column_error(pg_err)
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        sqlite3.IntegrityError("UNIQUE constraint failed: memories.id"),
+        sqlite3.OperationalError("database is locked"),
+        ConnectionError("server closed the connection unexpectedly"),
+    ],
+)
+def test_non_schema_errors_are_not_treated_as_missing_columns(exc):
+    """A constraint violation or transient outage must propagate, not silently
+    re-insert the row with its developmental metadata stripped."""
+    assert not MemoryStore._is_missing_column_error(exc)
+
+
+def _insert_kwargs():
+    return dict(
+        memory_id="m1",
+        content="c",
+        raw_val="c",
+        wing="personal",
+        room=None,
+        vector_str="[]",
+        importance=0.5,
+        emotion=0.0,
+        valence=0.0,
+        certainty=1.0,
+        source="user",
+        metadata_json="{}",
+        lifespan_stage="",
+        crisis="",
+        virtue="",
+        relations="",
+        relation_circles="",
+        modality="",
+        current_time=None,
+    )
+
+
+def test_insert_row_falls_back_only_on_a_missing_column():
+    """The predicate is wired into the insert, not merely defined."""
+    store = _store()
+    conn = MagicMock()
+    calls = []
+
+    async def _execute(sql, *args):
+        calls.append(sql)
+        if len(calls) == 1:
+            raise sqlite3.OperationalError("table memories has no column named virtue")
+
+    conn.execute = _execute
+    asyncio.run(store._insert_memory_row(conn, **_insert_kwargs()))
+
+    assert len(calls) == 2, "a schema error should retry without the Eriksonian columns"
+    assert "virtue" in calls[0] and "virtue" not in calls[1]
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        sqlite3.IntegrityError("UNIQUE constraint failed: memories.id"),
+        sqlite3.OperationalError("database is locked"),
+        ConnectionError("server closed the connection unexpectedly"),
+    ],
+)
+def test_insert_row_propagates_non_schema_errors(exc):
+    """Finding #7: retrying on any failure silently re-inserted the row with
+    its developmental metadata stripped."""
+    store = _store()
+    conn = MagicMock()
+    calls = []
+
+    async def _execute(sql, *args):
+        calls.append(sql)
+        raise exc
+
+    conn.execute = _execute
+
+    with pytest.raises(type(exc)):
+        asyncio.run(store._insert_memory_row(conn, **_insert_kwargs()))
+
+    assert len(calls) == 1, "must not retry a non-schema failure"
+
+
+def test_promotion_payload_does_not_let_custom_metadata_overwrite_wing():
+    """Finding #8: a stored key named 'wing' silently replaced the real one."""
+    row = {"wing": "personal", "room": "kitchen", "created_at": None}
+    payload = MemoryStore._build_promotion_payload(
+        row, {"wing": "ATTACKER", "room": "ATTACKER", "note": "keep me"}
+    )
+
+    assert payload["wing"] == "personal"
+    assert payload["room"] == "kitchen"
+    assert orjson.loads(payload["custom_metadata"]) == {
+        "wing": "ATTACKER",
+        "room": "ATTACKER",
+        "note": "keep me",
+    }
+
+
+def test_promotion_payload_round_trips_through_the_qdrant_read_path():
+    """The read path does orjson.loads(meta['custom_metadata'])."""
+    payload = MemoryStore._build_promotion_payload({}, {"topic": "tea"})
+    assert orjson.loads(payload["custom_metadata"]) == {"topic": "tea"}
+
+
+def test_promotion_payload_accepts_string_created_at():
+    payload = MemoryStore._build_promotion_payload(
+        {"created_at": "2026-07-18 12:30:00"}, {}
+    )
+    assert payload["created_at"].startswith("2026-07-18T12:30:00")
+
+
+def test_search_cache_key_separates_self_reflection_modes():
+    """Finding #10: pronoun cues resolve in opposite directions, so the two
+    modes returning each other's memories for the cache TTL was a real
+    perspective bug, not just a stale-read."""
+    store = _store()
+    store.get_embedding = AsyncMock(return_value=None)
+    probed = []
+
+    class _RecordingCache(dict):
+        """The lookup runs on every call, however early the pipeline exits."""
+
+        def __contains__(self, key):
+            probed.append(key)
+            return False
+
+    store._l1_cache = _RecordingCache()
+
+    async def _run():
+        for flag in (False, True):
+            await store.search_memories("what do I like", is_self_reflection=flag)
+
+    asyncio.run(_run())
+
+    assert len(probed) == 2
+    assert probed[0] != probed[1], "self-reflection modes must not share a cache entry"
+    # The flag is the only component that differs. Compared positionally by
+    # identity, since 0.0 == False would make a value comparison lie here.
+    differing = [
+        i
+        for i, (a, b) in enumerate(zip(probed[0], probed[1]))
+        if a is not b
+    ]
+    assert len(differing) == 1
+    assert (probed[0][differing[0]], probed[1][differing[0]]) == (False, True)

--- a/backend/tests/test_pr66_review_fixes.py
+++ b/backend/tests/test_pr66_review_fixes.py
@@ -117,6 +117,63 @@ def test_visible_segments_strips_thought_split_across_chunks():
     assert "plan" not in "".join(seen)
 
 
+@pytest.mark.parametrize(
+    "chunks,expected",
+    [
+        # The tag arriving whole was the only case the old parser handled.
+        (["<thought>SECRET</thought>Hi."], "Hi."),
+        # Models stream token by token, so these are the common cases, not edge
+        # cases: the old parser spoke the entire reasoning block for all of them.
+        (["<tho", "ught>SECRET</thought>Hi."], "Hi."),
+        (["<", "thought", ">", "SECRET", "</thought>", "Hi."], "Hi."),
+        (["<thought>SECRET</thou", "ght>Tail"], "Tail"),
+        # Visible text before a block used to be dropped entirely.
+        (["Hello <thought>SECRET</thought> Bye"], "Hello  Bye"),
+        # Only the first block was ever recognised.
+        (["A<thought>S1</thought>B<thought>S2</thought>C"], "ABC"),
+        # An unclosed block must not be spoken.
+        (["<thought>SECRET never closes"], ""),
+    ],
+)
+def test_visible_segments_never_leaks_reasoning(chunks, expected):
+    svc = _service()
+    state = _ChatStreamState()
+    out = []
+    for chunk in chunks:
+        out.extend(svc._visible_segments(chunk, state))
+    out.extend(svc._visible_trailing("", state))
+    spoken = "".join(out)
+
+    assert spoken == expected
+    assert "SECRET" not in spoken
+    assert "S1" not in spoken and "S2" not in spoken
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["3 < 4 and 5<6", "Wait <pause=300ms> ok", "no tags here at all"],
+)
+def test_visible_segments_does_not_swallow_non_thought_markup(text):
+    """The partial-tag hold must release anything that never becomes a tag."""
+    svc = _service()
+    state = _ChatStreamState()
+    out = svc._visible_segments(text, state)
+    out.extend(svc._visible_trailing("", state))
+    assert "".join(out) == text
+
+
+def test_self_correction_yields_fallback_when_retry_produces_nothing():
+    """An empty retry stream left the user with 'Wait, let me rephrase that...'
+    and then silence, same as the exception path."""
+    llm = _ScriptedLLM(["As an AI I cannot"], [])
+    svc = _service(llm=llm)
+    out = asyncio.run(_drain(svc.execute(_plan())))
+
+    contents = [c["data"] for c in out if c["type"] == "content"]
+    assert _SAFE_FALLBACK_LINE in contents
+    assert out[-1]["type"] == "done"
+
+
 def test_visible_segments_passes_through_plain_text():
     svc = _service()
     state = _ChatStreamState()
@@ -328,6 +385,84 @@ def test_insert_row_propagates_non_schema_errors(exc):
         asyncio.run(store._insert_memory_row(conn, **_insert_kwargs()))
 
     assert len(calls) == 1, "must not retry a non-schema failure"
+
+
+def test_archive_activation_survives_an_unparseable_stored_timestamp():
+    """_as_aware_utc returning None must not then be subtracted from. Otherwise
+    one malformed archive row discards the entire search result set."""
+    store = _store()
+    row = {
+        "last_recalled_at": "not a timestamp",
+        "recall_count": 2,
+        "valence": 0.1,
+        "emotional_weight": 0.2,
+        "importance_score": 0.6,
+    }
+    score, spread, dist_emo, recall_count, now = store._archive_row_activation(
+        row,
+        0.5,
+        current_valence=0.0,
+        current_arousal=0.5,
+        current_cortisol=0.2,
+        current_time=None,
+    )
+    assert isinstance(score, float)
+    assert recall_count == 2
+
+
+def test_promotion_survives_a_qdrant_failure_after_the_sql_move():
+    """The SQL move is authoritative and has already committed. Treating a
+    vector-store failure as a failed promotion would strand the memory: absent
+    from the results and absent from the archive."""
+    store = _store()
+    # is_sqlite is a read-only structural check (the A5 fix), so satisfy it
+    # honestly with a real sqlite3 connection rather than patching the property.
+    store.pool.connection.conn = sqlite3.connect(":memory:")
+
+    conn = MagicMock()
+    conn.execute = AsyncMock(return_value=None)
+    acquired = MagicMock()
+    acquired.__aenter__ = AsyncMock(return_value=conn)
+    acquired.__aexit__ = AsyncMock(return_value=False)
+    store.pool.acquire = MagicMock(return_value=acquired)
+
+    store.qdrant_store = MagicMock()
+    store.qdrant_store.client = object()
+    store.qdrant_store.add_vector_memory = MagicMock(
+        side_effect=RuntimeError("qdrant unreachable")
+    )
+
+    # Must not raise: the caller uses an exception here to mean "not promoted".
+    asyncio.run(
+        store._write_promoted_memory(
+            "m1", "content", {}, [0.1], 1, datetime.now(timezone.utc), {}, sql_meta={}
+        )
+    )
+    assert conn.execute.await_count == 2  # insert + archive delete
+
+
+def test_promotion_propagates_a_sql_failure():
+    """A genuine SQL failure must still reach the caller so the row is skipped."""
+    store = _store()
+    # is_sqlite is a read-only structural check (the A5 fix), so satisfy it
+    # honestly with a real sqlite3 connection rather than patching the property.
+    store.pool.connection.conn = sqlite3.connect(":memory:")
+
+    conn = MagicMock()
+    conn.execute = AsyncMock(side_effect=RuntimeError("disk full"))
+    acquired = MagicMock()
+    acquired.__aenter__ = AsyncMock(return_value=conn)
+    acquired.__aexit__ = AsyncMock(return_value=False)
+    store.pool.acquire = MagicMock(return_value=acquired)
+    store.qdrant_store = MagicMock()
+    store.qdrant_store.client = None
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(
+            store._write_promoted_memory(
+                "m1", "c", {}, [0.1], 1, datetime.now(timezone.utc), {}, sql_meta={}
+            )
+        )
 
 
 def test_promotion_payload_does_not_let_custom_metadata_overwrite_wing():


### PR DESCRIPTION
## Summary

Resolves all 11 actionable findings CodeRabbit raised on #66.

**Every one of them predates F1.** Before writing a line I checked each against `git show main:` — all 11 are byte-identical in the pre-refactor code. None were regressions. The decomposition didn't introduce these bugs, it made them legible by lifting the logic out of a 1600-line and a 520-line function. That's the return on F1, arriving one PR later than the refactor.

#66 was merged as-is rather than amended, so its proven zero-drift property stays intact. These behaviour changes land separately, where they're the point rather than a contamination of that claim.

## Privacy

- **`_split_thought` logged hidden reasoning at INFO.** The `<thought>` block quotes the user's message and every surfaced memory verbatim, so private conversation content was persisted into production logs on every CoT turn. Now DEBUG, character count only.

## Correctness

- **`is_self_reflection` missing from the L1 cache key.** Pronoun cues resolve in opposite directions under that flag, so for the cache TTL a self-reflection query could be served the user's memories and vice versa. A perspective bug, not a stale read.
- **The self-correction retry leaked raw `<thought>` blocks** — only the primary stream ran the CoT parser. Both paths now share one `_visible_segments` state machine rather than the retry growing a second copy.
- **The retry reused the aborted primary stream's sanitizer**, so a partial control tag left buffered corrupted its first chunk. Fresh sanitizer and CoT state.
- **A failed self-correction emitted `done` with no content** — users heard "Wait, let me rephrase that..." then silence.
- **Malformed `known_concepts` aborted the turn with no terminal event**, since `_build_tom_context` runs before the streaming `try`.

## Data integrity

- **STORE_MEMORY always claimed success**, though `add_memory` returns `False` on a failed write and an absent store writes nothing. Both reported "Got it, I've committed that to memory." The shared `mock_memory_store` fixture returned `None` here, misrepresenting the contract — corrected to `True`.
- **The legacy-schema fallback caught every exception**, so a constraint violation or transient outage silently re-inserted the row with its Eriksonian metadata stripped. Narrowed to genuine missing-column errors (PG SQLSTATE 42703, SQLite message text).
- **`raw_meta` was splatted into the Qdrant payload**, letting a stored key named `wing` or `room` overwrite the authoritative one; the full payload was also persisted as the SQL `metadata` column. Custom fields now nest under `custom_metadata`, serialized to match `add_memory`'s writer and the `orjson.loads()` on the read path.
- **Failed promotions were still returned and cached as active**, surfacing a memory the next turn could not find again.
- **SQLite archive timestamps are TEXT**, and the archive path did datetime arithmetic on them directly.

## Verification

- `tests/test_pr66_review_fixes.py` — 35 tests, one or more per finding.
- **Mutation tested.** Each fix reverted individually to confirm its test fails. The first pass caught only 10 of 11: reverting the missing-column guard broke nothing, because the tests exercised the predicate in isolation but never proved `_insert_memory_row` called it. Two integration tests close that gap; the mutation now fails three tests.
- **F1 equivalence harness re-run** after the CoT parser was rewired onto the shared helper: **28/29 scenarios byte-identical**, the sole difference being the intended STORE_MEMORY change. Confirms sharing the parser between both streams didn't disturb the primary path.
- Full suite **352 passed** (317 + 35). `ruff check .` clean.

## Not done

Promotion is transactional on **PostgreSQL only**. The SQLite shim commits per `execute()` and exposes no transaction API, so there the archive delete is merely ordered after the insert — the insert is an idempotent upsert, so a partial failure re-converges on retry rather than duplicating. Genuine cross-backend atomicity needs transaction support added to `SQLiteConnection`, which is a change to the pool abstraction rather than this call site. Flagged in the ledger rather than papered over.

## Test plan

- [x] `pytest` — 352 passed
- [x] `ruff check .` — clean
- [x] Mutation testing on all 11 fixes
- [x] F1 equivalence harness re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming responses to prevent hidden reasoning content from appearing or being logged.
  * Added safe fallback messages when response generation or self-correction fails.
  * Memory-saving actions now accurately report whether data was persisted.
  * Improved timestamp handling, archived-memory promotion, schema migration recovery, and search caching.
  * Prevented malformed context data from disrupting responses.

* **Tests**
  * Added regression coverage for streaming, memory persistence, timestamp handling, archive promotion, and cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->