### PR TITLE
feat(vision,cognitive): somatic homeostasis — vision reaches the endocrine system

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -2559,3 +2559,103 @@ fails as expected. The F1 equivalence harness was re-run after the parser
 rewrite: still 28/29, the sole difference remaining the intended STORE_MEMORY
 change — the new parser corrects cases the harness never covered and disturbs
 none that it does.
+
+## 2026-07-18 Vision became a sense — somatic homeostasis, and the container question settled
+
+Vision was a captioner bolted to the side of the system. `VisualAppraisalService`
+turned frames into sentences, `_on_vision_description` stored the sentence as
+prompt text, and that was the end of it: the agent could describe something it
+loved and feel precisely nothing. The roadmap's §E Somatic Vision-Homeostasis
+called for a `vision_appraisal.py` that never existed — `grep -rn "somatic"
+backend/app/` returned two incidental hits, both string literals in a category
+list. This closes that gap.
+
+### The comforts are learned, not listed
+
+`learning.py` already extracts conversational facts and tags each with a
+category, one of which is `somatic`; those land in Neo4j as triplets. The new
+`SomaticAppraiser` (`app/cognitive/somatic.py`) reads them back. So the agent's
+comforts come from its own life. With no learned somatic facts — a fresh agent,
+or one running without Neo4j — it recognises nothing and no spike ever fires.
+That cold start is deliberate and matches the mental lexicon's design (B1): no
+comfort vocabulary is baked into a perception path.
+
+Matching is whole-word (so "tea" does not fire on "steam"), confidence-weighted,
+saturating (three comforts in one frame are warmer than one, not three times
+warmer), and refractory for 120s per term — staring at the same mug must not
+re-spike every appraisal interval, the affective counterpart to the habituation
+threshold already in the VLM config.
+
+### Where the roadmap could not be followed literally
+
+§C specifies `D_t = min(1.0, D_{t-1} + 0.25)`. That is not implementable here:
+`AgentState.dopamine` is a **derived property** (`max(0, valence) * arousal`), not
+a stored field, so there is no `D_{t-1}`. Lifting valence and arousal is how
+dopamine rises in this architecture — it follows by construction. The constants
+were chosen so a recognised comfort moves dopamine by roughly the intended
+magnitude. Named `app/cognitive/somatic.py` rather than the roadmap's
+`vision_appraisal.py`, because `app/vision/appraisal.py` already exists and does
+something different (frames→text vs text→affect), and because the appraiser needs
+the graph and state service — keeping it in the cognitive layer lets the vision
+agent stay a pure sensor with no database credentials.
+
+`StateService.apply_somatic_perception` mirrors `apply_sensory_perception`
+exactly, including its central caution: a non-match returns `None` and is skipped,
+never applied as a zero spike. Blending zeros in every interval would drag mood
+toward neutral and flatten the agent the longer it looked at nothing in
+particular — the identical failure mode documented for a missing acoustic
+emotion estimate.
+
+### Docker vs host: measured, not assumed
+
+The question was settled empirically on this machine (Windows host, Linux Docker
+engine):
+
+- `/dev/video*` does not exist in the container.
+- `docker run --device=/dev/video0` is rejected by the daemon outright.
+- `/tmp/.X11-unix` is absent and `DISPLAY` is unset.
+- `mss` fails on import-time capture with `ScreenShotError: Library libxcb.so not found`.
+
+On a Windows or macOS host the container runs inside a Linux VM with no route to
+the host's display or USB webcam, so **no configuration fixes this** — capture
+must run on the host. On a **Linux** host it does work with device passthrough
+and/or an X11 socket mount, so the compose service now exists under an opt-in
+`vision` profile with both passthrough options present but commented out (a
+missing device would otherwise fail the whole service to start).
+
+`docs/ARCHITECTURE.md` had claimed a "native Windows/macOS bridge to bypass
+container limitations." No such bridge exists; the line was aspirational. Replaced
+with what was actually measured.
+
+### The healthcheck was E1 all over again
+
+The commented-out service probed `pgrep python`, which passes perfectly while
+every frame comes back `None` — `ScreenLink` catches its own error, sets
+`headless`, and returns `None` forever. That is precisely the shape of finding E1,
+where a healthcheck passed *because* the STT it checked had been stubbed. The
+agent now runs a capture preflight at startup and logs prominently when it is
+blind, touches a sentinel file on each successful capture, and the healthcheck
+reads that sentinel's freshness. All three states (fresh / stale / missing) were
+verified in a real container.
+
+### Verification
+
+`tests/test_somatic_vision.py` (31 tests). Six mutations applied and all caught —
+but only after two corrections worth recording. Removing the zero-spike guard
+initially broke **nothing**, because adding `0.0` genuinely leaves affect
+unchanged; the guard's only observable effect is skipping the persistence path, so
+the test now asserts that instead of state equality it could never distinguish.
+And the whole-word-matching mutation first reported a false "pattern miss" from
+shell escaping rather than a real absence — retried by line index, it fails
+correctly.
+
+Full backend suite: **397 passed** (366 + 31). `ruff check .` clean.
+`docker compose config` valid, with `vision_agent` correctly absent by default
+and present under `--profile vision`.
+
+**NOT done:** no live camera or screen has driven this end to end — the somatic
+path is verified at unit and integration level only, with no VLM in the loop. The
+comfort vocabulary also depends on `learning.py` having run against real
+conversation and Neo4j being reachable; neither is exercised here. And the visual
+pillar remains the only one of the three whose capture cannot be containerised on
+this platform, which is a deployment property, not a bug to fix.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,37 @@ CVS-3.5 utilizes a **Dual-STT fan-out** with a 3-stage interruption arbitration 
 
 <!-- -->
 
+> [!WARNING]
+> **The Vision Agent must run on the host on Windows and macOS.** It is excluded
+> from the default compose stack and gated behind the `vision` profile. Capture is
+> host-bound, verified empirically rather than assumed: inside a Linux container
+> there is no `/dev/video*`, `--device=/dev/video0` is rejected by the daemon,
+> `/tmp/.X11-unix` is absent with `DISPLAY` unset, and `mss` fails outright with
+> `Library libxcb.so not found`. On a Windows/macOS host the container runs in a
+> Linux VM with no route to the host's display or webcam, so no configuration
+> resolves this.
+>
+> ```bash
+> pip install -r backend/requirements-ai.txt   # mss + opencv-python
+> NATS_URL=nats://127.0.0.1:4222 python -m app.vision.agent
+> ```
+>
+> On a **Linux** host the containerised path does work — uncomment the `devices`
+> and/or X11 entries in the `vision_agent` service and run
+> `docker compose --profile vision up vision_agent`.
+>
+> The agent probes capture at startup and logs prominently when it is blind, and
+> its healthcheck reads a sentinel touched on each successful capture rather than
+> `pgrep python`, which passes just as happily when every frame returns `None`.
+>
+> **Somatic response is learned, and starts empty.** Recognising a comfort object
+> lifts valence/arousal (and so dopamine) only for objects the agent has actually
+> learned about — facts `learning.py` tagged `somatic` in Neo4j. A fresh agent, or
+> one running without Neo4j, recognises nothing and no spike fires. That cold start
+> is deliberate: no comfort vocabulary is hardcoded.
+
+<!-- -->
+
 > [!IMPORTANT]
 > **Protocol Description**:
 > Audio arriving via WebRTC is fanned out to two paths: **SenseVoice**

--- a/backend/app/agents/brain_agent.py
+++ b/backend/app/agents/brain_agent.py
@@ -11,6 +11,7 @@ from ..llm.ollama_client import OllamaClient
 from ..state import GraphDB, MemoryStore, ConversationHistoryStore
 from ..config import Config
 from ..cognitive import CognitiveService
+from ..cognitive.somatic import SomaticAppraiser
 from ..runtime_bootstrap import bootstrap_runtime
 from ..contracts import (
     AudioPlaybackProgress,
@@ -57,6 +58,13 @@ class BrainAgent(BaseAgent):
             graph_db=graph_db,
             identity_store=conversation_store,
         )
+
+        # Visual Somatic Homeostasis: recognising a learned comfort object in
+        # what the agent is looking at lifts valence/arousal (and therefore the
+        # derived dopamine term). Lives here rather than in the vision agent
+        # because it needs the graph and the state service, keeping the vision
+        # agent a pure sensor with no database credentials.
+        self.somatic_appraiser = SomaticAppraiser(graph_store=graph_db)
 
         self.last_interaction_time = datetime.now()
         self.last_visual_context = "No visual data available."
@@ -181,6 +189,28 @@ class BrainAgent(BaseAgent):
         self.last_user_distance = (
             data.get("user_distance") if data.get("user_distance") is not None else 1.0
         )
+
+        await self._appraise_somatic(description)
+
+    async def _appraise_somatic(self, description: str):
+        """Turn a recognised comfort object into an endocrine response.
+
+        This is the step that makes vision a sense rather than a captioner: the
+        description above only ever became prompt text, so the agent could
+        describe something it loves and feel nothing. Failures are contained --
+        the visual context is still worth having even if the somatic layer is
+        unavailable.
+        """
+        if not description:
+            return
+        try:
+            await self.somatic_appraiser.refresh()
+            somatic = self.somatic_appraiser.appraise(description)
+            if not somatic:
+                return
+            await self.cognitive_core.state.apply_somatic_perception(somatic)
+        except Exception:
+            logger.exception("[Brain] Somatic appraisal failed; visual context kept.")
 
     async def _cancel_active_generation(self, reason: str):
         """Cancel the in-flight generation task and wait for it to fully unwind.

--- a/backend/app/cognitive/somatic.py
+++ b/backend/app/cognitive/somatic.py
@@ -1,0 +1,195 @@
+"""
+Somatic Vision-Homeostasis — the appraiser that turns seeing into feeling.
+
+Until this existed, vision was a captioner bolted onto the side of the system:
+`VisualAppraisalService` turned frames into sentences, the brain stored the
+sentence as prompt context, and nothing else happened. The agent could describe
+a cup of cardamom tea in front of it and feel exactly nothing. This module is
+the missing link between the visual pillar and the endocrine one.
+
+It mirrors the acoustic pillar deliberately. There, SenseVoice perceives *how*
+the user sounds and `StateService.apply_sensory_perception` folds that into
+mood. Here, the VLM perceives *what the agent is looking at* and
+`StateService.apply_somatic_perception` folds a recognised comfort into
+valence and arousal. Same shape, different sense.
+
+**Where the comforts come from.** Nothing here is hardcoded. `learning.py`
+already extracts facts from conversation and tags each with a category, one of
+which is `somatic`; those land in Neo4j as triplets. This module reads them
+back. So the agent's comforts are *learned from its own life* — if it has never
+discussed anything somatic, it recognises nothing and no spike ever fires. That
+is a deliberate, honest cold start, matching the mental lexicon's design (B1:
+no benchmark-fitted constants baked into a retrieval path).
+
+**On the roadmap's dopamine equation.** `docs/cvs4_architecture_roadmap.md` §C
+specifies `D_t = min(1.0, D_{t-1} + 0.25)` alongside a valence spike. That
+cannot be applied literally here: `AgentState.dopamine` is a *derived* property
+(`max(0, valence) * arousal`), not a stored field, so there is no `D_{t-1}` to
+increment. Spiking valence and arousal is how dopamine rises in this
+architecture — it follows by construction rather than being assigned. The
+constants below are chosen so a recognised comfort produces a dopamine movement
+of roughly the intended magnitude.
+"""
+
+import logging
+import re
+import time
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Roadmap §C: a recognised somatic entity lifts valence, and arousal rises with
+# it so the derived dopamine term (max(0, V) * Ar) actually moves. Deliberately
+# smaller than an explicit user statement of affect: seeing a comfort is a
+# gentle background warmth, not an emotional event.
+SOMATIC_VALENCE_SPIKE = 0.15
+SOMATIC_AROUSAL_SPIKE = 0.10
+
+# A single frame naming several comforts should not stack into a euphoria
+# spike; the effect saturates.
+MAX_SOMATIC_SPIKE_MULTIPLIER = 2.0
+
+# Seeing the same mug for ten minutes should not re-spike every appraisal
+# interval. Habituation is already a principle elsewhere in this codebase
+# (VLM_HABITUATION_THRESHOLD); this is the affective counterpart.
+SOMATIC_REFRACTORY_SECONDS = 120.0
+
+# How long the learned-comfort list is trusted before re-reading the graph.
+SOMATIC_CACHE_TTL_SECONDS = 300.0
+
+# Entity names shorter than this are too collision-prone to match on
+# ("it", "he"), and single characters would match almost any description.
+MIN_SOMATIC_TERM_LENGTH = 3
+
+
+class SomaticAppraiser:
+    """Recognises learned comfort objects in a visual description.
+
+    Usage is two-step and intentionally cheap on the hot path: `refresh()`
+    pulls the learned entities from the graph on a TTL, and `appraise()` is a
+    pure string match against the cached set.
+    """
+
+    def __init__(self, graph_store=None, *, now_fn=time.time):
+        self.graph = graph_store
+        self._now = now_fn
+        self._terms: Dict[str, Dict[str, Any]] = {}
+        self._cache_loaded_at: float = 0.0
+        self._last_spike_at: Dict[str, float] = {}
+
+    # -- learned vocabulary -------------------------------------------------
+
+    def _cache_is_stale(self) -> bool:
+        if not self._cache_loaded_at:
+            return True
+        return (self._now() - self._cache_loaded_at) >= SOMATIC_CACHE_TTL_SECONDS
+
+    async def refresh(self, force: bool = False) -> int:
+        """Reload learned somatic entities from the graph.
+
+        Returns the number of terms known afterwards. A graph failure is never
+        propagated: the agent should keep seeing and talking even when Neo4j is
+        down, it simply stops feeling comfort at things until the graph returns.
+        """
+        if not force and not self._cache_is_stale():
+            return len(self._terms)
+        if not self.graph:
+            self._cache_loaded_at = self._now()
+            return len(self._terms)
+
+        query = """
+        MATCH (s)-[r]->(t)
+        WHERE r.category = 'somatic'
+        RETURN t.name AS name, coalesce(r.confidence, 1.0) AS confidence
+        """
+        try:
+            rows = await self.graph.execute_query(query, {})
+        except Exception as exc:
+            logger.warning(
+                "[Somatic] Could not refresh learned comforts from the graph; "
+                "keeping %d cached term(s): %s",
+                len(self._terms),
+                exc,
+            )
+            return len(self._terms)
+
+        terms: Dict[str, Dict[str, Any]] = {}
+        for row in rows or []:
+            name = (row or {}).get("name")
+            if not isinstance(name, str):
+                continue
+            normalized = name.strip().lower()
+            if len(normalized) < MIN_SOMATIC_TERM_LENGTH:
+                continue
+            confidence = (row or {}).get("confidence", 1.0)
+            try:
+                confidence = float(confidence)
+            except (TypeError, ValueError):
+                confidence = 1.0
+            terms[normalized] = {
+                "name": name.strip(),
+                "confidence": max(0.0, min(1.0, confidence)),
+            }
+
+        self._terms = terms
+        self._cache_loaded_at = self._now()
+        logger.info("[Somatic] %d learned comfort term(s) loaded.", len(terms))
+        return len(terms)
+
+    @property
+    def known_terms(self) -> List[str]:
+        return sorted(self._terms)
+
+    # -- recognition --------------------------------------------------------
+
+    @staticmethod
+    def _mentions(description: str, term: str) -> bool:
+        """Whole-word containment, so "tea" does not fire on "steam"."""
+        return re.search(rf"\b{re.escape(term)}\b", description) is not None
+
+    def _in_refractory(self, term: str) -> bool:
+        last = self._last_spike_at.get(term)
+        if last is None:
+            return False
+        return (self._now() - last) < SOMATIC_REFRACTORY_SECONDS
+
+    def appraise(self, description: str) -> Optional[Dict[str, Any]]:
+        """Match a visual description against learned comforts.
+
+        Returns None when nothing is recognised — the overwhelmingly common
+        case, and the caller must treat it as "no evidence", never as a neutral
+        reading to blend in (the same trap documented in
+        `apply_sensory_perception`).
+        """
+        if not description or not self._terms:
+            return None
+
+        haystack = description.lower()
+        matched = []
+        for term, meta in self._terms.items():
+            if not self._mentions(haystack, term):
+                continue
+            if self._in_refractory(term):
+                logger.debug("[Somatic] '%s' still in refractory; no spike.", term)
+                continue
+            matched.append((term, meta))
+
+        if not matched:
+            return None
+
+        now = self._now()
+        for term, _meta in matched:
+            self._last_spike_at[term] = now
+
+        # Saturating, confidence-weighted. Two comforts are warmer than one but
+        # not twice as warm, and a shakily-learned fact moves less than a firm one.
+        multiplier = min(MAX_SOMATIC_SPIKE_MULTIPLIER, float(len(matched)))
+        mean_confidence = sum(m["confidence"] for _t, m in matched) / len(matched)
+        scale = multiplier * mean_confidence
+
+        return {
+            "entities": [m["name"] for _t, m in matched],
+            "valence_spike": SOMATIC_VALENCE_SPIKE * scale,
+            "arousal_spike": SOMATIC_AROUSAL_SPIKE * scale,
+            "confidence": mean_confidence,
+        }

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -115,6 +115,9 @@ class AppSettings(BaseSettings):
     VLM_PROMPT: str = (
         "Describe what you see in this image briefly. Focus on what the user is doing."
     )
+    # Touched on every successful frame capture so a container healthcheck can
+    # probe the real path rather than mere process liveness (see finding E1).
+    VISION_HEALTH_FILE: str = "/tmp/vision_agent_healthy"
 
     STT_MODEL_SIZE: str = "small"
     STT_DEVICE: str = "cpu"

--- a/backend/app/state/agent_state.py
+++ b/backend/app/state/agent_state.py
@@ -771,6 +771,63 @@ class StateService:
             self._enforce_bounds()
         await self._persist_sensory_state_if_due()
 
+    async def apply_somatic_perception(self, somatic: Dict[str, Any]):
+        """Visual Somatic Homeostasis — recognising a comfort object feels good.
+
+        The visual counterpart to `apply_sensory_perception` above: that folds
+        *how the user sounds* into mood, this folds *what the agent is looking
+        at* into valence and arousal. Together they are the two halves of the
+        perception-to-affect path.
+
+        Roadmap §C (`docs/cvs4_architecture_roadmap.md`) specifies a dopamine
+        spike alongside the valence one. `dopamine` here is a derived property
+        (`max(0, valence) * arousal`), not a stored field, so it cannot be
+        assigned; lifting valence and arousal is what raises it, which this does.
+
+        Absence of a match must never reach this method as a zero spike. Doing
+        so would drag mood toward neutral on every appraisal interval and
+        flatten the agent the longer it looks at nothing in particular -- the
+        same failure mode documented for a missing acoustic emotion estimate.
+        """
+        if not somatic:
+            return
+
+        valence_spike = somatic.get("valence_spike", 0.0)
+        arousal_spike = somatic.get("arousal_spike", 0.0)
+        try:
+            valence_spike = float(valence_spike)
+            arousal_spike = float(arousal_spike)
+        except (TypeError, ValueError):
+            logger.warning(
+                "[State] Ignoring somatic perception with non-numeric spikes: %r",
+                somatic,
+            )
+            return
+
+        if valence_spike <= 0.0 and arousal_spike <= 0.0:
+            return
+
+        entities = somatic.get("entities") or []
+        async with self._state_lock:
+            before_valence = self.current_state.valence
+            self.current_state.valence = min(
+                1.0, self.current_state.valence + valence_spike
+            )
+            self.current_state.arousal = min(
+                1.0, self.current_state.arousal + arousal_spike
+            )
+            self._enforce_bounds()
+            after_valence = self.current_state.valence
+
+        logger.info(
+            "👁️  Somatic comfort recognised %s — valence %.2f → %.2f (dopamine now %.2f).",
+            entities,
+            before_valence,
+            after_valence,
+            self.current_state.dopamine,
+        )
+        await self._persist_sensory_state_if_due()
+
     async def handle_system_tick(self, tick_metadata: Dict[str, Any]):
         """
         Idle evolution triggered by NATS system.tick.

--- a/backend/app/vision/agent.py
+++ b/backend/app/vision/agent.py
@@ -43,6 +43,8 @@ class VisionAgent(BaseAgent):
         self.source = "screen"  # screen | camera
         self.fps = fps
         self.running = False
+        self.can_capture = False
+        self.health_file = getattr(Config, "VISION_HEALTH_FILE", "")
 
         # Tier-4: VLM Appraisal Pipeline
         self.vlm_enabled = Config.VLM_ENABLED
@@ -60,6 +62,56 @@ class VisionAgent(BaseAgent):
                 prompt=Config.VLM_PROMPT,
             )
 
+    def preflight(self) -> bool:
+        """Probe whether this process can actually see anything.
+
+        Capture is host-bound. `mss` needs a real display connection and
+        `cv2.VideoCapture(0)` needs a `/dev/video*` node, so inside a Linux
+        container neither exists unless the host is also Linux and the X11
+        socket plus video device are explicitly passed through. On a Windows or
+        macOS host that passthrough is not possible at all -- Docker runs the
+        container in a Linux VM that has no access to the host's display or USB
+        webcam.
+
+        Without this probe the failure is silent and expensive: ScreenLink
+        catches its own error, sets `headless`, and `capture_frame()` returns
+        None forever while the process stays happily alive. That is exactly the
+        shape of finding E1, where a healthcheck passed because the thing it was
+        checking had been stubbed out.
+        """
+        probe = (
+            self.camera.capture_frame()
+            if self.source == "camera"
+            else self.screen.capture_frame()
+        )
+        if probe:
+            return True
+
+        logger.error(
+            "🚫 [Vision] Cannot capture from '%s'. Screen capture needs a display "
+            "connection and camera capture needs a /dev/video* node. If this is a "
+            "container: run the vision agent on the HOST instead "
+            "(`python -m app.vision.agent`), or on a Linux host pass through "
+            "`/tmp/.X11-unix` + DISPLAY (screen) or `--device=/dev/video0` (camera). "
+            "The agent stays up so the mesh is unaffected, but it is blind.",
+            self.source,
+        )
+        return False
+
+    def _mark_capture_healthy(self):
+        """Touch the sentinel the container healthcheck reads.
+
+        The probe must test the real path, not process liveness: `pgrep python`
+        succeeds just as readily when every frame comes back None.
+        """
+        if not self.health_file:
+            return
+        try:
+            with open(self.health_file, "w") as fh:
+                fh.write(str(time.time()))
+        except OSError as e:
+            logger.debug("[Vision] Could not write health sentinel: %s", e)
+
     async def start(self):
         await self.connect()
 
@@ -68,7 +120,11 @@ class VisionAgent(BaseAgent):
 
         self.running = True
         vlm_status = f"VLM={Config.VLM_MODEL}" if self.vlm_enabled else "VLM=disabled"
-        logger.info(f"📸 {self.name} started. {vlm_status} | {self.fps} FPS")
+        self.can_capture = self.preflight()
+        sight = "seeing" if self.can_capture else "BLIND (no capture device)"
+        logger.info(
+            f"📸 {self.name} started. {vlm_status} | {self.fps} FPS | {sight}"
+        )
 
         asyncio.create_task(self._capture_loop())
 
@@ -91,6 +147,12 @@ class VisionAgent(BaseAgent):
                     frame = self.screen.capture_frame()
 
                 if frame:
+                    if not self.can_capture:
+                        # Recovered: a display or camera appeared after startup.
+                        logger.info("👁️  [Vision] Capture recovered; the agent can see.")
+                        self.can_capture = True
+                    self._mark_capture_healthy()
+
                     # 2. Base64 encode for NATS
                     frame_b64 = base64.b64encode(frame).decode("utf-8")
 

--- a/backend/tests/test_somatic_vision.py
+++ b/backend/tests/test_somatic_vision.py
@@ -1,0 +1,375 @@
+"""
+Visual Somatic Homeostasis — vision finally reaching the endocrine system.
+
+Before this, `_on_vision_description` stored the VLM sentence as prompt text
+and stopped. The agent could describe something it loves and feel nothing.
+These tests cover the path that closes that gap, plus the capture-capability
+probe that makes a blind agent say so instead of failing silently.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.cognitive.somatic import (
+    SOMATIC_AROUSAL_SPIKE,
+    SOMATIC_REFRACTORY_SECONDS,
+    SOMATIC_VALENCE_SPIKE,
+    SomaticAppraiser,
+)
+from app.state.agent_state import StateService
+
+
+class _Clock:
+    """Controllable time so refractory/TTL behaviour is deterministic."""
+
+    def __init__(self, t=1000.0):
+        self.t = t
+
+    def __call__(self):
+        return self.t
+
+    def advance(self, seconds):
+        self.t += seconds
+
+
+def _graph(rows):
+    graph = MagicMock()
+    graph.execute_query = AsyncMock(return_value=rows)
+    return graph
+
+
+def _appraiser(rows, clock=None):
+    clock = clock or _Clock()
+    appraiser = SomaticAppraiser(graph_store=_graph(rows), now_fn=clock)
+    asyncio.run(appraiser.refresh(force=True))
+    return appraiser, clock
+
+
+# --------------------------------------------------------------------------
+# learned vocabulary — nothing is hardcoded
+# --------------------------------------------------------------------------
+
+
+def test_no_learned_comforts_means_no_spike_ever():
+    """The honest cold start: an agent that has never discussed anything
+    somatic recognises nothing, exactly like the mental lexicon (B1)."""
+    appraiser, _ = _appraiser([])
+    assert appraiser.known_terms == []
+    assert appraiser.appraise("a steaming cup of cardamom tea and rasgulla") is None
+
+
+def test_comforts_are_read_from_the_graph_not_a_constant():
+    appraiser, _ = _appraiser(
+        [{"name": "Cardamom Tea", "confidence": 0.9}, {"name": "Rasgulla", "confidence": 0.8}]
+    )
+    assert appraiser.known_terms == ["cardamom tea", "rasgulla"]
+
+
+def test_graph_failure_keeps_previous_terms_and_does_not_raise():
+    """Neo4j being down must not stop the agent seeing or talking."""
+    appraiser, clock = _appraiser([{"name": "chai", "confidence": 1.0}])
+    appraiser.graph.execute_query = AsyncMock(side_effect=RuntimeError("neo4j down"))
+    clock.advance(10_000)
+
+    assert asyncio.run(appraiser.refresh()) == 1
+    assert appraiser.appraise("a cup of chai") is not None
+
+
+def test_absent_graph_is_tolerated():
+    appraiser = SomaticAppraiser(graph_store=None)
+    assert asyncio.run(appraiser.refresh(force=True)) == 0
+    assert appraiser.appraise("chai") is None
+
+
+@pytest.mark.parametrize(
+    "rows",
+    [
+        [{"name": None, "confidence": 1.0}],
+        [{"name": "", "confidence": 1.0}],
+        [{"name": "it", "confidence": 1.0}],  # too short to match safely
+        [{"nope": "chai"}],
+    ],
+)
+def test_malformed_or_unusable_graph_rows_are_skipped(rows):
+    appraiser, _ = _appraiser(rows)
+    assert appraiser.known_terms == []
+
+
+def test_non_numeric_confidence_falls_back_rather_than_raising():
+    appraiser, _ = _appraiser([{"name": "chai", "confidence": "very"}])
+    result = appraiser.appraise("some chai")
+    assert result is not None and result["confidence"] == 1.0
+
+
+# --------------------------------------------------------------------------
+# recognition
+# --------------------------------------------------------------------------
+
+
+def test_recognising_a_comfort_produces_a_positive_spike():
+    appraiser, _ = _appraiser([{"name": "chai", "confidence": 1.0}])
+    result = appraiser.appraise("The user is holding a cup of chai.")
+
+    assert result["entities"] == ["chai"]
+    assert result["valence_spike"] == pytest.approx(SOMATIC_VALENCE_SPIKE)
+    assert result["arousal_spike"] == pytest.approx(SOMATIC_AROUSAL_SPIKE)
+
+
+def test_unrecognised_scene_returns_none_not_a_zero_spike():
+    """None means 'no evidence'. A zero spike blended in every interval would
+    drag mood toward neutral and flatten the agent -- the same trap documented
+    for a missing acoustic emotion estimate."""
+    appraiser, _ = _appraiser([{"name": "chai", "confidence": 1.0}])
+    assert appraiser.appraise("An empty desk and a monitor.") is None
+
+
+def test_matching_is_whole_word():
+    """'tea' must not fire on 'steam'."""
+    appraiser, _ = _appraiser([{"name": "tea", "confidence": 1.0}])
+    assert appraiser.appraise("steam rising from the kettle") is None
+    assert appraiser.appraise("a cup of tea") is not None
+
+
+def test_confidence_scales_the_spike():
+    appraiser, _ = _appraiser([{"name": "chai", "confidence": 0.5}])
+    result = appraiser.appraise("chai")
+    assert result["valence_spike"] == pytest.approx(SOMATIC_VALENCE_SPIKE * 0.5)
+
+
+def test_multiple_comforts_saturate_rather_than_stack():
+    appraiser, _ = _appraiser(
+        [
+            {"name": "chai", "confidence": 1.0},
+            {"name": "rasgulla", "confidence": 1.0},
+            {"name": "kettle", "confidence": 1.0},
+        ]
+    )
+    result = appraiser.appraise("chai, rasgulla and a kettle on the table")
+
+    assert len(result["entities"]) == 3
+    # Three matches, but the multiplier caps at 2.0.
+    assert result["valence_spike"] == pytest.approx(SOMATIC_VALENCE_SPIKE * 2.0)
+
+
+def test_repeat_sightings_are_refractory():
+    """Staring at the same mug must not re-spike every appraisal interval."""
+    appraiser, clock = _appraiser([{"name": "chai", "confidence": 1.0}])
+
+    assert appraiser.appraise("a cup of chai") is not None
+    clock.advance(SOMATIC_REFRACTORY_SECONDS / 2)
+    assert appraiser.appraise("a cup of chai") is None
+
+    clock.advance(SOMATIC_REFRACTORY_SECONDS)
+    assert appraiser.appraise("a cup of chai") is not None
+
+
+def test_empty_description_is_ignored():
+    appraiser, _ = _appraiser([{"name": "chai", "confidence": 1.0}])
+    assert appraiser.appraise("") is None
+
+
+def test_cache_is_reused_within_ttl_then_refreshed():
+    appraiser, clock = _appraiser([{"name": "chai", "confidence": 1.0}])
+    calls_after_initial = appraiser.graph.execute_query.await_count
+
+    asyncio.run(appraiser.refresh())
+    assert appraiser.graph.execute_query.await_count == calls_after_initial
+
+    clock.advance(10_000)
+    asyncio.run(appraiser.refresh())
+    assert appraiser.graph.execute_query.await_count == calls_after_initial + 1
+
+
+# --------------------------------------------------------------------------
+# state application
+# --------------------------------------------------------------------------
+
+
+def _state():
+    service = StateService(graph_store=None)
+    service._persist_sensory_state_if_due = AsyncMock(return_value=None)
+    return service
+
+
+def test_somatic_perception_lifts_valence_arousal_and_dopamine():
+    """The roadmap's dopamine spike is realised through valence/arousal, since
+    dopamine here is derived (max(0, V) * Ar), not a stored field."""
+    service = _state()
+    service.current_state.valence = 0.1
+    service.current_state.arousal = 0.4
+    before_dopamine = service.current_state.dopamine
+
+    asyncio.run(
+        service.apply_somatic_perception(
+            {"entities": ["chai"], "valence_spike": 0.15, "arousal_spike": 0.10}
+        )
+    )
+
+    assert service.current_state.valence == pytest.approx(0.25)
+    assert service.current_state.dopamine > before_dopamine
+
+
+def test_somatic_perception_is_bounded_at_one():
+    service = _state()
+    service.current_state.valence = 0.95
+    service.current_state.arousal = 0.95
+
+    asyncio.run(
+        service.apply_somatic_perception(
+            {"entities": ["chai"], "valence_spike": 0.5, "arousal_spike": 0.5}
+        )
+    )
+
+    assert service.current_state.valence <= 1.0
+    assert service.current_state.arousal <= 1.0
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        {},
+        {"valence_spike": 0.0, "arousal_spike": 0.0},
+        {"valence_spike": "warm", "arousal_spike": "warm"},
+    ],
+)
+def test_no_evidence_never_moves_affect(payload):
+    """A non-match must not be applied as a neutral reading."""
+    service = _state()
+    service.current_state.valence = 0.42
+    service.current_state.arousal = 0.37
+
+    asyncio.run(service.apply_somatic_perception(payload))
+
+    assert service.current_state.valence == pytest.approx(0.42)
+    assert service.current_state.arousal == pytest.approx(0.37)
+    # Adding 0.0 would leave affect unchanged anyway, so state equality alone
+    # cannot tell whether the guard fired. The observable difference is that a
+    # no-evidence reading must not reach the persistence path at all.
+    service._persist_sensory_state_if_due.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------
+# end-to-end: a vision.description actually reaches the endocrine system
+# --------------------------------------------------------------------------
+
+
+def _brain_stub(rows):
+    """The two collaborators _on_vision_description touches, nothing more."""
+    from app.agents.brain_agent import BrainAgent
+
+    agent = BrainAgent.__new__(BrainAgent)
+    agent.somatic_appraiser = SomaticAppraiser(graph_store=_graph(rows))
+    agent.cognitive_core = MagicMock()
+    agent.cognitive_core.state = _state()
+    agent.last_visual_context = ""
+    agent.last_user_distance = 1.0
+    return agent
+
+
+def test_seeing_a_learned_comfort_changes_how_the_agent_feels():
+    """The gap this whole change exists to close: before, a description became
+    prompt text and affect never moved."""
+    agent = _brain_stub([{"name": "chai", "confidence": 1.0}])
+    state = agent.cognitive_core.state
+    state.current_state.valence = 0.0
+    before = state.current_state.valence
+
+    asyncio.run(
+        agent._on_vision_description(
+            {"description": "A warm cup of chai on the desk.", "source": "camera"}
+        )
+    )
+
+    assert state.current_state.valence > before
+    # And the visual context is still recorded as before.
+    assert "chai" in agent.last_visual_context
+
+
+def test_seeing_something_unremarkable_leaves_affect_untouched():
+    agent = _brain_stub([{"name": "chai", "confidence": 1.0}])
+    state = agent.cognitive_core.state
+    state.current_state.valence = 0.3
+
+    asyncio.run(
+        agent._on_vision_description(
+            {"description": "An empty desk.", "source": "screen"}
+        )
+    )
+
+    assert state.current_state.valence == pytest.approx(0.3)
+
+
+def test_somatic_failure_does_not_lose_the_visual_context():
+    """Vision degrading must not take the description with it."""
+    agent = _brain_stub([{"name": "chai", "confidence": 1.0}])
+    agent.somatic_appraiser.refresh = AsyncMock(side_effect=RuntimeError("boom"))
+
+    asyncio.run(
+        agent._on_vision_description(
+            {"description": "A cup of chai.", "source": "camera"}
+        )
+    )
+
+    assert "chai" in agent.last_visual_context
+
+
+# --------------------------------------------------------------------------
+# capture capability probe
+# --------------------------------------------------------------------------
+
+
+def _vision_agent():
+    from app.vision.agent import VisionAgent
+
+    agent = VisionAgent.__new__(VisionAgent)
+    agent.screen = MagicMock()
+    agent.camera = MagicMock()
+    agent.source = "screen"
+    agent.health_file = ""
+    agent.can_capture = False
+    return agent
+
+
+def test_preflight_detects_a_blind_container():
+    """Silent blindness is the failure mode this exists to prevent: ScreenLink
+    swallows its own error and returns None forever while the process lives on
+    (the shape of finding E1)."""
+    agent = _vision_agent()
+    agent.screen.capture_frame = MagicMock(return_value=None)
+    assert agent.preflight() is False
+
+
+def test_preflight_passes_when_capture_works():
+    agent = _vision_agent()
+    agent.screen.capture_frame = MagicMock(return_value=b"jpegbytes")
+    assert agent.preflight() is True
+
+
+def test_preflight_probes_the_selected_source():
+    agent = _vision_agent()
+    agent.source = "camera"
+    agent.camera.capture_frame = MagicMock(return_value=b"frame")
+    agent.screen.capture_frame = MagicMock(return_value=None)
+
+    assert agent.preflight() is True
+    agent.camera.capture_frame.assert_called_once()
+
+
+def test_health_sentinel_is_written_on_capture(tmp_path):
+    """The container healthcheck reads this. `pgrep python` would pass just as
+    happily with every frame coming back None."""
+    agent = _vision_agent()
+    sentinel = tmp_path / "vision_healthy"
+    agent.health_file = str(sentinel)
+
+    agent._mark_capture_healthy()
+    assert sentinel.exists()
+
+
+def test_health_sentinel_write_failure_is_not_fatal():
+    agent = _vision_agent()
+    agent.health_file = "/nonexistent-dir/vision_healthy"
+    agent._mark_capture_healthy()  # must not raise

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -299,28 +299,62 @@ services:
 
 
   # 7. VISION AGENT (OpenCV, Screen/Cam) - Heavy
-#  vision_agent:
-#    build:
-#      context: ./backend
-#      target: full
-#    container_name: vision_agent
-#    command: [ "python", "-m", "app.vision.agent" ]
-#    env_file: .env
-#    environment:
-#      - AGENT_NAME=vision_agent
-#      - NATS_URL=nats://nats_mesh:4222
-#      - OLLAMA_URL=${OLLAMA_URL}
-#    depends_on:
-#      nats:
-#        condition: service_started
-#    networks:
-#      - ai_mesh_network
-#    restart: always
-#    healthcheck:
-#      test: ["CMD-SHELL", "pgrep python || exit 1"]
-#      interval: 30s
-#      timeout: 10s
-#      retries: 35
+  #
+  # OPT-IN, AND LINUX-HOST ONLY. Start with:
+  #     docker compose --profile vision up vision_agent
+  #
+  # Capture is host-bound and cannot be containerised on every platform. This
+  # was verified rather than assumed, on a Windows host with a Linux Docker
+  # engine:
+  #   - /dev/video* does not exist in the container (no camera)
+  #   - `--device=/dev/video0` is rejected by the daemon outright
+  #   - /tmp/.X11-unix is absent and DISPLAY is unset (no screen)
+  #   - mss itself fails with "Library libxcb.so not found"
+  # On a Windows or macOS host the container runs inside a Linux VM with no
+  # route to the host's display or USB webcam, so no amount of configuration
+  # fixes this. RUN THE AGENT ON THE HOST INSTEAD:
+  #     pip install -r backend/requirements-ai.txt
+  #     NATS_URL=nats://127.0.0.1:4222 python -m app.vision.agent
+  #
+  # On a LINUX host the passthrough below does work: uncomment the `devices`
+  # entry for camera capture, and/or the X11 mount plus DISPLAY for screen
+  # capture. Both are commented out because a missing device makes the whole
+  # service fail to start on hosts that do not have it.
+  #
+  # The healthcheck deliberately probes the sentinel the agent touches on each
+  # successful capture, not `pgrep python` — a blind agent keeps its process
+  # alive perfectly well, which is how finding E1 hid a stubbed STT for so long.
+  vision_agent:
+    profiles: [ vision ]
+    build:
+      context: ./backend
+      target: full
+    container_name: vision_agent
+    command: [ "python", "-m", "app.vision.agent" ]
+    env_file: .env
+    environment:
+      - AGENT_NAME=vision_agent
+      - NATS_URL=nats://nats_mesh:4222
+      - OLLAMA_URL=${OLLAMA_URL}
+      - VISION_HEALTH_FILE=/tmp/vision_agent_healthy
+      # Linux host + screen capture: also uncomment the X11 volume below.
+      # - DISPLAY=${DISPLAY}
+    # volumes:
+    #   - /tmp/.X11-unix:/tmp/.X11-unix:ro
+    # devices:
+    #   - /dev/video0:/dev/video0
+    depends_on:
+      nats:
+        condition: service_started
+    networks:
+      - ai_mesh_network
+    restart: always
+    healthcheck:
+      test: [ "CMD-SHELL", "test -f /tmp/vision_agent_healthy && test $(( $(date +%s) - $(stat -c %Y /tmp/vision_agent_healthy) )) -lt 60 || exit 1" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
 
 # Use the existing network created by infra
 networks:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,8 +54,9 @@ Introduced the **Subconscious Agent** to manage background cognition during peri
 
 Introduced the **Vision Agent** to provide spatial and visual grounding for the cognitive mesh.
 
-- **Host-Native Bridge**: Screen and camera processing operate outside Docker constraints using a native Windows/macOS bridge to bypass container limitations.
 - **Visual Appraisal**: The VisionAgent captures frames and queries local `moondream:latest` via Ollama. It publishes `vision.description` back to the BrainAgent for context-aware grounding without sending raw image blobs over the mesh.
+- **Somatic Homeostasis**: `SomaticAppraiser` (`app/cognitive/somatic.py`) matches that description against comfort objects the agent has *learned* — facts `learning.py` tagged `somatic` and wrote to Neo4j — and lifts valence/arousal through `StateService.apply_somatic_perception`. Dopamine is a derived property (`max(0, V) × Ar`), so it rises by construction rather than being assigned. This is the visual mirror of the acoustic path, where SenseVoice emotion feeds `apply_sensory_perception`. Nothing is hardcoded: with no learned somatic facts the agent recognises nothing and no spike fires.
+- **Capture runs on the host, not in a container.** This is a platform constraint, verified rather than assumed: inside a Linux container there is no `/dev/video*`, no `/tmp/.X11-unix`, `DISPLAY` is unset, and `mss` fails with `Library libxcb.so not found`. On a Windows or macOS host the container runs in a Linux VM with no route to the host display or USB webcam, so no configuration fixes it — run `python -m app.vision.agent` on the host. On a **Linux** host the containerised path does work with `--device=/dev/video0` and/or an X11 socket mount; the `vision` compose profile ships both, commented out. The agent runs a capture preflight at startup and says loudly when it is blind, and its healthcheck probes a sentinel touched on each successful capture rather than process liveness — a lesson from finding E1, where a healthcheck passed because the thing it checked had been stubbed.
 
 ### 📖 4. Sovereign Memory Surfacing & 4-Tier Hybrid Storage
 


### PR DESCRIPTION
## The gap this closes

Vision was a captioner bolted to the side of the system. `VisualAppraisalService` turned frames into sentences, `_on_vision_description` stored the sentence as prompt text, and that was the end of it — **the agent could describe something it loved and feel precisely nothing.**

The roadmap's §E *Somatic Vision-Homeostasis* called for an appraiser that never existed. `grep -rn "somatic" backend/app/` returned two hits, both incidental string literals in a category list.

## The comforts are learned, not listed

`learning.py` already extracts conversational facts and tags each with a category — one of which is `somatic` — and writes them to Neo4j. `SomaticAppraiser` reads them back. **A fresh agent, or one running without Neo4j, recognises nothing and no spike fires.** That cold start is deliberate and matches the mental lexicon's design (B1): no comfort vocabulary is baked into a perception path.

Matching is whole-word (`tea` does not fire on `steam`), confidence-weighted, saturating (three comforts are warmer than one, not 3×), and refractory for 120s per term — the affective counterpart to the habituation threshold already in the VLM config.

## Where the roadmap could not be followed literally

§C specifies `D_t = min(1.0, D_{t-1} + 0.25)`. **Not implementable as written:** `AgentState.dopamine` is a *derived* property (`max(0, valence) × arousal`), not a stored field, so there is no `D_{t-1}` to increment. Lifting valence and arousal is how dopamine rises in this architecture — it follows by construction.

Placed in `app/cognitive/somatic.py`, not the roadmap's `vision_appraisal.py`: `app/vision/appraisal.py` already exists doing something different (frames→text vs text→affect), and keeping the appraiser in the cognitive layer lets the vision agent stay a pure sensor with no database credentials.

`apply_somatic_perception` mirrors `apply_sensory_perception` including its central caution — a non-match returns `None` and is skipped, **never applied as a zero spike**, which would drag mood toward neutral every interval and flatten the agent the longer it looked at nothing.

## Docker vs host: measured, not assumed

Verified on this machine (Windows host, Linux Docker engine):

| Probe | Result |
|---|---|
| `ls /dev/video*` in container | absent |
| `docker run --device=/dev/video0` | rejected by daemon |
| `/tmp/.X11-unix`, `DISPLAY` | absent / unset |
| `mss.mss()` in container | `ScreenShotError: Library libxcb.so not found` |

On Windows/macOS the container runs in a Linux VM with no route to the host display or USB webcam — **no configuration fixes this**, capture must run on the host. On a **Linux** host it does work with passthrough, so the service is now enabled under an opt-in `vision` profile with `devices` and X11 mount present but commented out (a missing device would otherwise fail the service to start).

`docs/ARCHITECTURE.md` had claimed a *"native Windows/macOS bridge to bypass container limitations."* No such bridge exists — the line was aspirational. Replaced with what was measured.

## The healthcheck was finding E1 again

The old probe was `pgrep python`, which passes perfectly while every frame returns `None` — `ScreenLink` catches its own error, sets `headless`, and returns `None` forever. That is exactly the shape of E1, where a healthcheck passed *because* the STT it checked had been stubbed.

Now: a capture preflight at startup that logs prominently when blind, a sentinel touched on each successful capture, and a healthcheck reading that sentinel's freshness. All three states (fresh / stale / missing) verified in a real container.

## Verification

- `tests/test_somatic_vision.py` — 31 tests, including end-to-end that a `vision.description` moves affect.
- **Six mutations applied, all caught** — after two corrections worth noting. Removing the zero-spike guard initially broke *nothing*, because adding `0.0` genuinely leaves affect unchanged; the guard's only observable effect is skipping the persistence path, so the test now asserts that rather than state equality it could never distinguish. The whole-word mutation first reported a false "pattern miss" from shell escaping, not a real absence.
- Suite **397 passed** (366 + 31). `ruff check .` clean.
- `docker compose config` valid; `vision_agent` absent by default, present under `--profile vision`.

## Not done

No live camera or screen has driven this end to end — verified at unit and integration level only, with no VLM in the loop. The comfort vocabulary also depends on `learning.py` having run against real conversation with Neo4j reachable; neither is exercised here. Treat the somatic path as **built and tested, not yet observed**.

## Test plan

- [x] `pytest` — 397 passed
- [x] `ruff check .` — clean
- [x] Mutation testing (6/6 caught)
- [x] `docker compose config` + profile gating
- [x] Container healthcheck states verified for real
- [ ] Live camera → VLM → somatic spike (needs host run + Ollama + Neo4j)

🤖 Generated with [Claude Code](https://claude.com/claude-code)