### PR TITLE
feat(state): dopamine becomes a hormone instead of a formula (tonic + phasic)

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -2659,3 +2659,68 @@ comfort vocabulary also depends on `learning.py` having run against real
 conversation and Neo4j being reachable; neither is exercised here. And the visual
 pillar remains the only one of the three whose capture cannot be containerised on
 this platform, which is a deployment property, not a bug to fix.
+
+## 2026-07-18 Dopamine became a hormone instead of a formula
+
+The somatic work one commit earlier had to document a deviation: the roadmap's
+`D_t = min(1.0, D_{t-1} + 0.25)` was not implementable, because
+`AgentState.dopamine` was a *derived property* — `max(0, valence) * arousal` —
+with no `D_{t-1}` to increment. This removes that constraint rather than
+continuing to work around it.
+
+### Tonic plus phasic
+
+Dopamine is now `dopamine_tonic + dopamine_phasic`, clamped:
+
+- **Tonic** is the old formula, character-for-character. It tracks ongoing affect
+  and has no memory of its own.
+- **Phasic** is a decaying burst, stored as a peak plus the timestamp it fired,
+  with a 90-second half-life (`DOPAMINE_PHASIC_HALFLIFE_S`).
+
+The split is the standard tonic/phasic distinction in dopamine signalling (Grace
+1991; Schultz's reward-prediction-error work), and it buys the thing the derived
+version structurally could not express: *"something good happened thirty seconds
+ago and I am still lit up."* Previously a reward evaporated the instant mood
+drifted back, because dopamine was a pure function of mood.
+
+**Backward compatibility is exact.** With no burst outstanding, `dopamine`
+returns bit-for-bit what it always did. The whole pre-existing `test_endocrine.py`
+suite — which explicitly asserts the derived values, e.g. `V=0.8, Ar=0.7 → 0.56` —
+passes untouched, and a parametrised test now pins that equivalence deliberately
+against the old formula rather than by coincidence.
+
+Decay is computed from elapsed wall-clock time in the property rather than
+decremented on `system.tick`. That keeps the reading correct if ticks stall,
+avoids drift between a stored value and a computed one, and makes decay testable
+by moving a timestamp instead of stubbing a clock.
+
+The burst is stored **relative to the tonic floor**, so mood may drift underneath
+a live burst without being double-counted into it. `release_dopamine` implements
+the roadmap equation literally against the *total*, then derives the peak.
+
+### Verification
+
+`tests/test_phasic_dopamine.py` (31 tests). Six mutations applied; **four caught
+on the first pass, two escaped**, and both escapes were real gaps rather than
+redundant code:
+
+- Removing the `min(1.0, ...)` inside `release_dopamine` changed nothing
+  observable, because the property clamps anyway — but an over-large stored peak
+  reads as 1.0 while taking *many extra half-lives* to fall back, pinning the
+  agent at peak reward. Now tested by firing twenty bursts and asserting decay.
+- Removing the `amount <= 0.0` guard also changed nothing, because with no burst
+  outstanding a negative amount clamps to zero regardless. The guard is
+  load-bearing only once a burst exists — a bad caller must not be able to
+  cancel a reward. Now tested against an outstanding burst.
+
+Both tests fail against the mutated code and pass against the real code; 6/6
+after the additions. This is the fourth time this session a first-pass mutation
+check has flattered itself, which is itself the argument for running them.
+
+Full backend suite: **428 passed** (397 + 31). `ruff check .` clean.
+
+**NOT done:** cortisol is still derived (`0.5 - V/2 + 0.3·fatigue`) and has the
+same limitation — acute stress cannot outlive the valence dip that caused it. The
+symmetric treatment is straightforward now that the pattern exists, but it was
+not in scope here and no caller currently needs it. The half-life is also a
+guess: 90s is a conversational-timescale choice, not a measured or tuned value.

--- a/backend/app/agents/brain_agent.py
+++ b/backend/app/agents/brain_agent.py
@@ -61,7 +61,7 @@ class BrainAgent(BaseAgent):
 
         # Visual Somatic Homeostasis: recognising a learned comfort object in
         # what the agent is looking at lifts valence/arousal (and therefore the
-        # derived dopamine term). Lives here rather than in the vision agent
+        # dopamine, tonic and phasic). Lives here rather than in the vision agent
         # because it needs the graph and the state service, keeping the vision
         # agent a pure sensor with no database credentials.
         self.somatic_appraiser = SomaticAppraiser(graph_store=graph_db)

--- a/backend/app/cognitive/somatic.py
+++ b/backend/app/cognitive/somatic.py
@@ -22,13 +22,11 @@ is a deliberate, honest cold start, matching the mental lexicon's design (B1:
 no benchmark-fitted constants baked into a retrieval path).
 
 **On the roadmap's dopamine equation.** `docs/cvs4_architecture_roadmap.md` §C
-specifies `D_t = min(1.0, D_{t-1} + 0.25)` alongside a valence spike. That
-cannot be applied literally here: `AgentState.dopamine` is a *derived* property
-(`max(0, valence) * arousal`), not a stored field, so there is no `D_{t-1}` to
-increment. Spiking valence and arousal is how dopamine rises in this
-architecture — it follows by construction rather than being assigned. The
-constants below are chosen so a recognised comfort produces a dopamine movement
-of roughly the intended magnitude.
+specifies `D_t = min(1.0, D_{t-1} + 0.25)` alongside a valence spike. Both now
+happen literally: `apply_somatic_perception` lifts valence and arousal *and*
+fires a real phasic dopamine burst. Dopamine is no longer a purely derived
+quantity — it is a tonic term (the old `max(0, valence) * arousal`) plus a
+decaying burst, so a reward can outlast the mood swing that accompanied it.
 """
 
 import logging
@@ -38,10 +36,11 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
-# Roadmap §C: a recognised somatic entity lifts valence, and arousal rises with
-# it so the derived dopamine term (max(0, V) * Ar) actually moves. Deliberately
-# smaller than an explicit user statement of affect: seeing a comfort is a
-# gentle background warmth, not an emotional event.
+# Roadmap §C: a recognised somatic entity lifts valence and arousal, which
+# raises the tonic dopamine term; the phasic burst is fired separately by
+# `apply_somatic_perception` (SOMATIC_DOPAMINE_SPIKE). Deliberately smaller than
+# an explicit user statement of affect: seeing a comfort is a gentle background
+# warmth, not an emotional event.
 SOMATIC_VALENCE_SPIKE = 0.15
 SOMATIC_AROUSAL_SPIKE = 0.10
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -119,6 +119,12 @@ class AppSettings(BaseSettings):
     # probe the real path rather than mere process liveness (see finding E1).
     VISION_HEALTH_FILE: str = "/tmp/vision_agent_healthy"
 
+    # Half-life of a phasic dopamine burst, in seconds. Real phasic bursts last
+    # only hundreds of milliseconds; this is the felt afterglow of a reward at
+    # conversational timescale, so it is deliberately much slower than biology
+    # and much faster than the ALMA mood decay (PSYCH_LAMBDA_DECAY, hours).
+    DOPAMINE_PHASIC_HALFLIFE_S: float = 90.0
+
     STT_MODEL_SIZE: str = "small"
     STT_DEVICE: str = "cpu"
 

--- a/backend/app/state/agent_state.py
+++ b/backend/app/state/agent_state.py
@@ -35,6 +35,12 @@ def _default_user_mental_model():
 
 logger = logging.getLogger(__name__)
 
+# Roadmap §C: recognising a somatic comfort fires a phasic dopamine burst of
+# this size. Kept here rather than in somatic.py because it is a property of the
+# endocrine response, not of visual recognition -- any future reward channel
+# (a warm reply, a resolved goal) should fire through the same mechanism.
+SOMATIC_DOPAMINE_SPIKE = 0.25
+
 
 @dataclass(slots=True)
 class AgentState:
@@ -70,6 +76,13 @@ class AgentState:
     baseline_valence: float = 0.0
     baseline_arousal: float = 0.5
     baseline_dominance: float = 0.5
+
+    # Phasic dopamine (see the `dopamine` property). Stored as a peak plus the
+    # moment it was released, so the current level is derived from elapsed time
+    # rather than needing a tick to decay it. That keeps the reading correct
+    # even if system.tick stalls, and makes decay testable without a clock stub.
+    dopamine_phasic_peak: float = 0.0
+    dopamine_phasic_at: float = field(default_factory=time.time)
 
     # --- Affect Split Properties ---
     @property
@@ -168,14 +181,68 @@ class AgentState:
         return max(0.0, min(1.0, base_cortisol + fatigue_contribution))
 
     @property
+    def dopamine_tonic(self) -> float:
+        """Background reward tone: positive valence × arousal.
+
+        This is the whole of what `dopamine` used to be. It tracks the ongoing
+        affective state instantaneously and has no memory of its own.
+        """
+        return max(0.0, min(1.0, max(0.0, self.valence) * self.arousal))
+
+    @property
+    def dopamine_phasic(self) -> float:
+        """The decaying remainder of recent reward bursts.
+
+        Real dopamine signalling separates a slow tonic level from fast phasic
+        bursts on reward (Grace 1991; Schultz's reward-prediction-error work).
+        The tonic term above cannot represent "something good happened thirty
+        seconds ago and I am still lit up" -- being a pure function of current
+        valence and arousal, it forgets instantly. This is that memory, decaying
+        exponentially from the peak toward zero.
+        """
+        if self.dopamine_phasic_peak <= 0.0:
+            return 0.0
+        half_life = max(1e-6, float(getattr(Config, "DOPAMINE_PHASIC_HALFLIFE_S", 90.0)))
+        elapsed = max(0.0, time.time() - self.dopamine_phasic_at)
+        return self.dopamine_phasic_peak * math.exp(-math.log(2.0) * elapsed / half_life)
+
+    @property
     def dopamine(self) -> float:
         """
-        Reward hormone. Tracks positive valence × arousal.
+        Reward hormone: tonic tone plus any decaying phasic burst.
         High dopamine → exploratory/playful behavior (higher top_p).
         Low dopamine → conservative/flat behavior (lower top_p).
         Range: 0.0 (no reward signal) to 1.0 (peak reward).
+
+        With no burst outstanding this is exactly the historical derived value
+        (`max(0, V) * Ar`), so every existing reading and test is unaffected.
         """
-        return max(0.0, min(1.0, max(0.0, self.valence) * self.arousal))
+        return max(0.0, min(1.0, self.dopamine_tonic + self.dopamine_phasic))
+
+    def release_dopamine(self, amount: float) -> float:
+        """Fire a phasic burst, returning the new total dopamine level.
+
+        Implements the roadmap's `D_t = min(1.0, D_{t-1} + amount)`
+        (`docs/cvs4_architecture_roadmap.md` §C) literally, which the previous
+        derived-only property could not: with dopamine computed purely from
+        valence and arousal there was no `D_{t-1}` to add to, and the only way
+        to move it was to move mood itself.
+
+        The burst is stored relative to the tonic floor, so that floor stays
+        free to drift with affect underneath a decaying burst instead of being
+        double-counted into it.
+        """
+        try:
+            amount = float(amount)
+        except (TypeError, ValueError):
+            return self.dopamine
+        if amount <= 0.0:
+            return self.dopamine
+
+        target_total = min(1.0, self.dopamine + amount)
+        self.dopamine_phasic_peak = max(0.0, target_total - self.dopamine_tonic)
+        self.dopamine_phasic_at = time.time()
+        return self.dopamine
 
 
 class StateService:
@@ -780,9 +847,11 @@ class StateService:
         perception-to-affect path.
 
         Roadmap §C (`docs/cvs4_architecture_roadmap.md`) specifies a dopamine
-        spike alongside the valence one. `dopamine` here is a derived property
-        (`max(0, valence) * arousal`), not a stored field, so it cannot be
-        assigned; lifting valence and arousal is what raises it, which this does.
+        spike alongside the valence one, and both now happen literally: the
+        valence lift below, and a real phasic burst via `release_dopamine`.
+        Before phasic dopamine existed, the burst could only be approximated by
+        moving mood and letting the derived term follow, which meant the reward
+        vanished the instant valence drifted back.
 
         Absence of a match must never reach this method as a zero spike. Doing
         so would drag mood toward neutral on every appraisal interval and
@@ -807,6 +876,14 @@ class StateService:
         if valence_spike <= 0.0 and arousal_spike <= 0.0:
             return
 
+        # Roadmap §C: D_t = min(1.0, D_{t-1} + 0.25). Falls back to the valence
+        # lift alone when a caller supplies no explicit burst.
+        dopamine_spike = somatic.get("dopamine_spike", SOMATIC_DOPAMINE_SPIKE)
+        try:
+            dopamine_spike = float(dopamine_spike)
+        except (TypeError, ValueError):
+            dopamine_spike = SOMATIC_DOPAMINE_SPIKE
+
         entities = somatic.get("entities") or []
         async with self._state_lock:
             before_valence = self.current_state.valence
@@ -817,6 +894,8 @@ class StateService:
                 1.0, self.current_state.arousal + arousal_spike
             )
             self._enforce_bounds()
+            # After bounds, so the burst is measured against the settled tonic.
+            self.current_state.release_dopamine(dopamine_spike)
             after_valence = self.current_state.valence
 
         logger.info(

--- a/backend/app/state/agent_state.py
+++ b/backend/app/state/agent_state.py
@@ -81,6 +81,14 @@ class AgentState:
     # moment it was released, so the current level is derived from elapsed time
     # rather than needing a tick to decay it. That keeps the reading correct
     # even if system.tick stalls, and makes decay testable without a clock stub.
+    #
+    # Deliberately NOT persisted, unlike the baselines above. A burst has a 90s
+    # half-life, so it is already within rounding distance of zero by the time
+    # any realistic restart completes; carrying it across one would preserve a
+    # value that no longer means anything. Restoring a state with no burst is
+    # also the safe direction -- peak defaults to 0.0, which reads as "no
+    # outstanding reward" rather than as a stale one. If a future hormone decays
+    # on an hours-scale, that one *will* need persisting.
     dopamine_phasic_peak: float = 0.0
     dopamine_phasic_at: float = field(default_factory=time.time)
 
@@ -235,6 +243,13 @@ class AgentState:
         try:
             amount = float(amount)
         except (TypeError, ValueError):
+            return self.dopamine
+        # NaN survives `float()` and then defeats every comparison below:
+        # `nan <= 0.0` is False, so it passes the guard, and `min(1.0, nan)`
+        # returns 1.0 -- a NaN reward would fire a *maximum* burst. Infinity
+        # takes the same route. Both are caller bugs, not rewards.
+        if not math.isfinite(amount):
+            logger.warning("[Endocrine] Ignoring non-finite dopamine release %r.", amount)
             return self.dopamine
         if amount <= 0.0:
             return self.dopamine

--- a/backend/tests/test_phasic_dopamine.py
+++ b/backend/tests/test_phasic_dopamine.py
@@ -1,0 +1,282 @@
+"""
+Phasic dopamine — reward that outlives the mood swing that caused it.
+
+`dopamine` used to be a pure function of current valence and arousal, which
+meant it had no memory: the instant mood drifted back, the reward was gone, and
+the roadmap's `D_t = min(1.0, D_{t-1} + 0.25)` had no `D_{t-1}` to add to. It is
+now a tonic term (the old formula, unchanged) plus a decaying phasic burst.
+
+The first test below is the important one: with no burst outstanding the value
+is bit-for-bit what it always was, so nothing downstream shifts underneath.
+"""
+
+import asyncio
+import math
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.config import Config
+from app.state.agent_state import SOMATIC_DOPAMINE_SPIKE, AgentState, StateService
+
+
+def _old_derived_dopamine(state: AgentState) -> float:
+    """The formula exactly as it stood before phasic dopamine existed."""
+    return max(0.0, min(1.0, max(0.0, state.valence) * state.arousal))
+
+
+def _state_service():
+    service = StateService(graph_store=None)
+    service._persist_sensory_state_if_due = AsyncMock(return_value=None)
+    return service
+
+
+# --------------------------------------------------------------------------
+# backward compatibility
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mood,energy",
+    [(0.8, 0.7), (-0.5, 0.9), (1.0, 0.0), (1.0, 1.0), (0.0, 0.5), (0.33, 0.66)],
+)
+def test_without_a_burst_dopamine_is_exactly_the_old_derived_value(mood, energy):
+    """No burst outstanding must be indistinguishable from the old behaviour."""
+    state = AgentState(mood=mood, energy=energy)
+    assert state.dopamine_phasic == 0.0
+    assert state.dopamine == pytest.approx(_old_derived_dopamine(state))
+
+
+def test_tonic_term_is_the_old_formula():
+    state = AgentState(mood=0.8, energy=0.7)
+    assert state.dopamine_tonic == pytest.approx(0.56, abs=0.01)
+
+
+# --------------------------------------------------------------------------
+# the roadmap equation, now literally implementable
+# --------------------------------------------------------------------------
+
+
+def test_release_implements_the_roadmap_increment():
+    """D_t = min(1.0, D_{t-1} + 0.25)."""
+    state = AgentState(mood=0.4, energy=0.5)  # tonic = 0.20
+    before = state.dopamine
+
+    after = state.release_dopamine(0.25)
+
+    assert after == pytest.approx(min(1.0, before + 0.25))
+    assert state.dopamine == pytest.approx(after)
+
+
+def test_release_saturates_at_one():
+    state = AgentState(mood=1.0, energy=1.0)  # tonic = 1.0 already
+    assert state.release_dopamine(0.5) == pytest.approx(1.0)
+
+
+def test_successive_releases_accumulate_toward_the_cap():
+    state = AgentState(mood=0.0, energy=0.5)  # tonic = 0.0
+    first = state.release_dopamine(0.25)
+    second = state.release_dopamine(0.25)
+
+    assert first == pytest.approx(0.25)
+    assert second == pytest.approx(0.5)
+
+
+@pytest.mark.parametrize("amount", [0.0, -0.3, None, "lots"])
+def test_a_non_positive_or_invalid_release_is_a_no_op(amount):
+    state = AgentState(mood=0.4, energy=0.5)
+    before = state.dopamine
+
+    assert state.release_dopamine(amount) == pytest.approx(before)
+    assert state.dopamine_phasic_peak == 0.0
+
+
+@pytest.mark.parametrize("amount", [0.0, -0.5, None, "lots"])
+def test_a_non_positive_release_cannot_eat_an_outstanding_burst(amount):
+    """With no burst outstanding the guard looks redundant -- a negative amount
+    clamps to zero anyway. It is load-bearing only once a burst exists, which is
+    exactly the case worth protecting: reward must not be cancellable by a bad
+    caller passing a negative number."""
+    state = AgentState(mood=0.0, energy=0.5)
+    state.release_dopamine(0.6)
+    peak = state.dopamine_phasic_peak
+
+    state.release_dopamine(amount)
+
+    assert state.dopamine_phasic_peak == pytest.approx(peak)
+
+
+def test_repeated_releases_cannot_build_an_unboundedly_long_burst():
+    """The cap belongs inside release, not only on the reported value. Storing
+    an over-large peak would read as 1.0 after clamping while taking many extra
+    half-lives to fall back -- the agent pinned at peak reward far too long."""
+    state = AgentState(mood=0.0, energy=0.5)
+    for _ in range(20):
+        state.release_dopamine(0.25)
+
+    assert state.dopamine_phasic_peak <= 1.0
+    state.dopamine_phasic_at -= Config.DOPAMINE_PHASIC_HALFLIFE_S * 3
+    assert state.dopamine < 0.2
+
+
+# --------------------------------------------------------------------------
+# decay
+# --------------------------------------------------------------------------
+
+
+def test_burst_halves_after_one_half_life():
+    state = AgentState(mood=0.0, energy=0.5)  # tonic = 0.0, isolates the burst
+    state.release_dopamine(0.8)
+    peak = state.dopamine_phasic
+
+    state.dopamine_phasic_at -= Config.DOPAMINE_PHASIC_HALFLIFE_S
+
+    assert state.dopamine_phasic == pytest.approx(peak / 2, rel=1e-3)
+
+
+def test_burst_decays_toward_nothing():
+    state = AgentState(mood=0.0, energy=0.5)
+    state.release_dopamine(1.0)
+
+    state.dopamine_phasic_at -= Config.DOPAMINE_PHASIC_HALFLIFE_S * 20
+
+    assert state.dopamine_phasic == pytest.approx(0.0, abs=1e-5)
+    # approx(0.0) defaults to abs=1e-12, which a residual burst legitimately
+    # exceeds; the claim here is convergence to the tonic floor, not equality.
+    assert state.dopamine == pytest.approx(state.dopamine_tonic, abs=1e-5)
+
+
+def test_decay_is_time_based_not_tick_based():
+    """The level must be right even if system.tick never runs."""
+    state = AgentState(mood=0.0, energy=0.5)
+    state.release_dopamine(0.6)
+
+    elapsed = Config.DOPAMINE_PHASIC_HALFLIFE_S * 0.5
+    state.dopamine_phasic_at -= elapsed
+    expected = 0.6 * math.exp(
+        -math.log(2.0) * elapsed / Config.DOPAMINE_PHASIC_HALFLIFE_S
+    )
+
+    assert state.dopamine_phasic == pytest.approx(expected, rel=1e-3)
+
+
+def test_dopamine_never_falls_below_its_tonic_floor():
+    state = AgentState(mood=0.8, energy=0.7)  # tonic = 0.56
+    state.release_dopamine(0.3)
+    state.dopamine_phasic_at -= Config.DOPAMINE_PHASIC_HALFLIFE_S * 50
+
+    assert state.dopamine == pytest.approx(state.dopamine_tonic)
+    assert state.dopamine == pytest.approx(0.56, abs=0.01)
+
+
+def test_tonic_may_drift_under_a_live_burst_without_double_counting():
+    """The burst is stored relative to the tonic floor, so a later mood change
+    moves the floor rather than being folded into the burst."""
+    state = AgentState(mood=0.0, energy=0.5)  # tonic 0.0
+    state.release_dopamine(0.4)
+    assert state.dopamine == pytest.approx(0.4)
+
+    state.mood = 0.6  # tonic becomes 0.30
+    assert state.dopamine_tonic == pytest.approx(0.30, abs=0.01)
+    # 0.30 floor + the 0.40 burst still outstanding.
+    assert state.dopamine == pytest.approx(0.70, abs=0.01)
+
+
+def test_dopamine_stays_within_bounds_when_tonic_rises_under_a_burst():
+    state = AgentState(mood=0.0, energy=1.0)
+    state.release_dopamine(0.9)
+    state.mood = 1.0  # tonic jumps to 1.0 beneath a 0.9 burst
+
+    assert 0.0 <= state.dopamine <= 1.0
+
+
+# --------------------------------------------------------------------------
+# the behavioural payoff, through the somatic path
+# --------------------------------------------------------------------------
+
+
+def test_somatic_reward_outlives_the_valence_it_arrived_with():
+    """The point of the whole change. Previously, mood drifting back to neutral
+    erased the reward instantly, because dopamine was a pure function of it."""
+    service = _state_service()
+    service.current_state.mood = 0.0
+    service.current_state.energy = 0.5
+
+    asyncio.run(
+        service.apply_somatic_perception(
+            {"entities": ["chai"], "valence_spike": 0.15, "arousal_spike": 0.10}
+        )
+    )
+    spiked = service.current_state.dopamine
+
+    # The mood swing fades, as ALMA decay would eventually take it.
+    service.current_state.mood = 0.0
+    service.current_state.energy = 0.5
+
+    surviving = service.current_state.dopamine
+    assert service.current_state.dopamine_tonic == pytest.approx(0.0)
+    # The tonic contribution correctly leaves with the mood; the burst does not.
+    # Under the old derived-only dopamine this would now be exactly 0.0.
+    assert surviving > 0.0, "reward vanished with the mood"
+    assert surviving == pytest.approx(SOMATIC_DOPAMINE_SPIKE, abs=0.02)
+    assert surviving < spiked
+
+
+def test_somatic_perception_fires_a_burst_of_the_roadmap_size():
+    service = _state_service()
+    service.current_state.mood = 0.0
+    service.current_state.energy = 0.5
+
+    asyncio.run(
+        service.apply_somatic_perception(
+            {"entities": ["chai"], "valence_spike": 0.0, "arousal_spike": 0.0001}
+        )
+    )
+
+    assert service.current_state.dopamine_phasic == pytest.approx(
+        SOMATIC_DOPAMINE_SPIKE, abs=0.01
+    )
+
+
+def test_caller_may_override_the_burst_size():
+    service = _state_service()
+    service.current_state.mood = 0.0
+    service.current_state.energy = 0.5
+
+    asyncio.run(
+        service.apply_somatic_perception(
+            {
+                "entities": ["chai"],
+                "valence_spike": 0.1,
+                "arousal_spike": 0.0,
+                "dopamine_spike": 0.05,
+            }
+        )
+    )
+
+    assert service.current_state.dopamine_phasic == pytest.approx(0.05, abs=0.01)
+
+
+def test_a_non_match_fires_no_burst():
+    service = _state_service()
+    asyncio.run(service.apply_somatic_perception(None))
+    assert service.current_state.dopamine_phasic == 0.0
+
+
+def test_snapshot_reports_the_burst():
+    service = _state_service()
+    service.current_state.mood = 0.0
+    service.current_state.energy = 0.5
+    service.current_state.release_dopamine(0.4)
+
+    snapshot = service.get_context_snapshot()
+
+    assert snapshot["dopamine"] == pytest.approx(0.4, abs=0.01)
+
+
+def test_a_fresh_state_starts_with_no_outstanding_burst():
+    state = AgentState()
+    assert state.dopamine_phasic_peak == 0.0
+    assert state.dopamine_phasic == 0.0
+    assert state.dopamine_phasic_at <= time.time() + 1

--- a/backend/tests/test_phasic_dopamine.py
+++ b/backend/tests/test_phasic_dopamine.py
@@ -107,6 +107,31 @@ def test_a_non_positive_release_cannot_eat_an_outstanding_burst(amount):
     assert state.dopamine_phasic_peak == pytest.approx(peak)
 
 
+@pytest.mark.parametrize(
+    "amount", [float("nan"), float("inf"), float("-inf")]
+)
+def test_a_non_finite_release_is_ignored(amount):
+    """NaN survives float() and then defeats every comparison: `nan <= 0.0` is
+    False so it passes the guard, and `min(1.0, nan)` returns 1.0 -- so before
+    this check a NaN reward fired a *maximum* burst."""
+    state = AgentState(mood=0.0, energy=0.5)
+    before = state.dopamine
+
+    assert state.release_dopamine(amount) == pytest.approx(before)
+    assert state.dopamine_phasic_peak == 0.0
+
+
+@pytest.mark.parametrize("amount", [float("nan"), float("inf")])
+def test_a_non_finite_release_cannot_disturb_an_outstanding_burst(amount):
+    state = AgentState(mood=0.0, energy=0.5)
+    state.release_dopamine(0.4)
+    peak = state.dopamine_phasic_peak
+
+    state.release_dopamine(amount)
+
+    assert state.dopamine_phasic_peak == pytest.approx(peak)
+
+
 def test_repeated_releases_cannot_build_an_unboundedly_long_burst():
     """The cap belongs inside release, not only on the reported value. Storing
     an over-large peak would read as 1.0 after clamping while taking many extra


### PR DESCRIPTION
> Replaces #69, which GitHub auto-closed when its base branch `feat/somatic-vision-homeostasis` was deleted on merge of #68. Same commit (`53dbf34`), same content, now based on `main` — so this gets the full CI run and CodeRabbit review that #69 never received.


## Why

#68 had to document a deviation: the roadmap's `D_t = min(1.0, D_{t-1} + 0.25)` was **not implementable**, because `AgentState.dopamine` was a derived property — `max(0, valence) × arousal` — with no `D_{t-1}` to increment. The only way to move dopamine was to move mood itself.

This removes the constraint rather than continuing to work around it.

## Tonic + phasic

`dopamine` is now `dopamine_tonic + dopamine_phasic`, clamped:

- **Tonic** — the old formula, character-for-character. Tracks ongoing affect, no memory of its own.
- **Phasic** — a decaying burst, stored as a peak plus the timestamp it fired, 90s half-life.

This is the standard tonic/phasic split in dopamine signalling (Grace 1991; Schultz's reward-prediction-error work), and it buys what a derived value structurally cannot express: *"something good happened thirty seconds ago and I am still lit up."* Before, a reward evaporated the instant mood drifted back — because dopamine **was** mood.

### Backward compatibility is exact

With no burst outstanding, `dopamine` returns bit-for-bit what it always did. The entire pre-existing `test_endocrine.py` suite — which asserts the derived values directly (`V=0.8, Ar=0.7 → 0.56`) — **passes untouched**. A new parametrised test pins that equivalence against the old formula deliberately rather than by coincidence.

### Two design choices worth flagging

**Decay is computed from elapsed wall-clock time in the property**, not decremented on `system.tick`. The reading stays correct if ticks stall, there's no drift between a stored value and a computed one, and decay is testable by moving a timestamp rather than stubbing a clock.

**The burst is stored relative to the tonic floor**, so mood may drift underneath a live burst without being double-counted into it. `release_dopamine` applies the roadmap equation to the *total*, then derives the peak.

## Verification

`tests/test_phasic_dopamine.py` — 31 tests. Six mutations applied; **four caught on the first pass, two escaped — and both escapes were real gaps, not redundant code:**

- Removing `min(1.0, ...)` inside `release_dopamine` changed nothing observable, since the property clamps anyway — but an over-large stored peak reads as 1.0 while taking *many extra half-lives* to fall back, pinning the agent at peak reward. Now tested by firing twenty bursts and asserting decay.
- Removing the `amount <= 0.0` guard also changed nothing, because with no burst outstanding a negative amount clamps to zero regardless. The guard is load-bearing only once a burst exists — a bad caller must not be able to cancel a reward. Now tested against an outstanding burst.

Both fail against the mutated code and pass against the real code; 6/6 after the additions.

Suite **428 passed** (397 + 31). `ruff check .` clean.

## Not done

- **Cortisol is still derived** (`0.5 − V/2 + 0.3·fatigue`) and has the identical limitation: acute stress cannot outlive the valence dip that caused it. The symmetric fix is straightforward now the pattern exists, but no caller needs it yet.
- **The 90s half-life is a guess** — a conversational-timescale choice, not measured or tuned against anything.

## Test plan

- [x] `pytest` — 428 passed
- [x] `ruff check .` — clean
- [x] Existing `test_endocrine.py` passes unmodified (backward compat)
- [x] Mutation testing (6/6 after two additions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added phasic dopamine bursts that decay over time while preserving the existing tonic dopamine behavior.
  * Added dopamine release handling, including accumulation, bounds, and configurable burst half-life.
  * Somatic comfort recognition now triggers a dopamine burst, with support for custom burst amounts.
* **Tests**
  * Added coverage for dopamine decay, accumulation, clamping, tonic changes, and somatic reward behavior.
* **Documentation**
  * Updated documentation and inline guidance to describe the tonic-plus-phasic dopamine model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->