### PR TITLE
feat(persona): PersonaProfile makes temperament authorable per friend

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -2659,3 +2659,94 @@ comfort vocabulary also depends on `learning.py` having run against real
 conversation and Neo4j being reachable; neither is exercised here. And the visual
 pillar remains the only one of the three whose capture cannot be containerised on
 this platform, which is a deployment property, not a bug to fix.
+
+## 2026-07-18 PersonaProfile: temperament stops being a deployment setting
+
+The stated direction for this system is that a user should be able to author
+their own friend — past, present, thinking, emotions — rather than receive a
+fixed one. Measured against that, the codebase was split in an awkward place.
+
+Narrative identity was already in good shape: `personality.json` carries name,
+values, tone and traits, and `IdentityManager` already distinguishes an immutable
+core from adaptive traits that evolve through reflection. That immutable/adaptive
+instinct is the right one and this change extends it rather than replacing it.
+
+**Temperament was the gap.** `personality.json` never drove affect. The baselines
+`baseline_valence/arousal/dominance` were hardcoded dataclass defaults
+(`0.0/0.5/0.5`), written only by `subconscious_agent` restoring from Neo4j with
+those same constants as its fallback. So a user could tell the agent it was "warm
+and slightly protective" in *words*, but could not make it constitutionally
+cheerful, anxious, or subdued. A melancholic low-energy friend was not
+expressible.
+
+Worse, the six coefficients that decide *how* feeling moves — `PSYCH_ALPHA`
+through `PSYCH_LAMBDA_DECAY` — lived in `Config`, a process-global env-var
+singleton. Emotional character was therefore a property of the `.env` file: one
+process, one personality, tuned by whoever deployed it.
+
+### What changed
+
+`app/persona/profile.py` introduces `PersonaProfile`, and `Config` is demoted to
+supplying its defaults. The integration turned out to be far smaller than
+expected: all six coefficients were read in exactly one place
+(`StateService.__init__`), so injection needed one constructor rather than a
+sweep through the cognitive core.
+
+Every field declares a tier in the schema, so the boundary is enforceable and
+self-documenting rather than a convention:
+
+- **IMMUTABLE** — safety invariants. Deliberately *not* model fields, because a
+  field is by definition settable; they live in the `IMMUTABLE_CORE` constant and
+  are merged at read time. A persona file that names them is rejected with a
+  warning, since a user-editable file must never be able to loosen a boundary.
+- **CONSTITUTIONAL** — who the friend is: temperament baselines and the rates at
+  which feeling moves. Set at creation, held for life.
+- **ADAPTIVE** — seeded by the user, then owned by the friend. Trust, attachment
+  and relationship start where the author placed them and go where living takes
+  them.
+
+### The bounds are the actual design work
+
+Total configurability has a failure mode: a user can tune a friend into something
+not recognisably alive. Each bound exists to preserve a specific property, and
+the tests name the failure rather than the number.
+
+`mood_decay_rate` is strictly positive — at zero, ALMA decay stops and mood locks
+permanently at whatever it last felt. `baseline_valence` is capped at ±0.6, not
+±1.0, because a friend pinned at maximum valence can never be sad *with* you,
+which is absence rather than cheerfulness. Arousal and dominance keep headroom at
+both ends. The through-line: **a personality may be shaped, but it must remain
+moveable.**
+
+Loading is strict for authored files and lenient for deployment config, and the
+asymmetry is deliberate. An invalid persona file falls back *whole* rather than
+partially applying, because half-applying it would hand the author a friend they
+did not describe. An out-of-range `PSYCH_*` env var is clamped with a warning
+instead, so a deployment already running an unusual value does not fail to boot
+because persona bounds arrived.
+
+### Verification
+
+`tests/test_persona_profile.py` (35 tests). Five mutations applied, all caught:
+allowing a file to override the safety core, permitting a zero mood-decay lock,
+regressing the bounds reader, sharing the mutable core, and widening the baseline
+cap to ±1.0.
+
+One real bug was found by the tests during development, in this change's own
+code. `_bounds_of` collected bounds with `getattr(...) or low`, and `gt=0.0` is
+falsy — so the strictly-positive guard silently evaporated and a zero
+`mood_decay_rate` sailed through clamping. The single most important bound was
+the one the idiom dropped. Now an explicit `is not None`, with the mutation
+retained as a regression test.
+
+Full backend suite: **432 passed** (397 + 35), `ruff check .` clean. Counts taken
+from `--junit-xml` rather than the terminal summary, which this environment
+truncates.
+
+**NOT done:** no persona file ships, and nothing writes one — there is no
+authoring UI, so this is the mechanism, not the product surface. `IdentityManager`
+still loads `personality.json` independently; the two persona sources are not yet
+unified, and the narrative half remains unbounded. `DOPAMINE_PHASIC_HALFLIFE_S`
+(PR #70) is temperament by rights and belongs in the profile, but was left out to
+avoid stacking branches again. Restored Neo4j baselines bypass persona bounds by
+design — the profile seeds a new friend, it does not clamp a lived one.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -45,6 +45,9 @@ class AppSettings(BaseSettings):
     DATABASE_URL: Optional[str] = None
     PERSONALITY_SEED_PATH: Optional[str] = None
     HISTORY_SEED_PATH: Optional[str] = None
+    # A user-authored persona (see app/persona/profile.py). Unset means "use the
+    # PSYCH_* / AI_NAME defaults below", which is exactly the previous behaviour.
+    PERSONA_PROFILE_PATH: Optional[str] = None
 
     # Neo4j Graph Configuration
     NEO4J_URI: Optional[str] = None

--- a/backend/app/persona/__init__.py
+++ b/backend/app/persona/__init__.py
@@ -1,0 +1,3 @@
+from .profile import PersonaProfile, Tier, IMMUTABLE_CORE
+
+__all__ = ["PersonaProfile", "Tier", "IMMUTABLE_CORE"]

--- a/backend/app/persona/profile.py
+++ b/backend/app/persona/profile.py
@@ -55,6 +55,7 @@ A configured friend that cannot be affected by what happens to it is a puppet,
 not a character.
 """
 
+import copy
 import json
 import logging
 from enum import Enum
@@ -147,7 +148,11 @@ class PersonaProfile(BaseModel):
     @property
     def immutable(self) -> Dict[str, Any]:
         """The safety core. Always the code constant, never the file."""
-        return json.loads(json.dumps(IMMUTABLE_CORE))  # defensive copy
+        # A copy, so a caller mutating what it receives cannot edit the boundary
+        # list every other caller reads. deepcopy rather than a JSON round-trip:
+        # the latter silently coerces types (a tuple would come back a list), so
+        # the "copy" could differ from the original it is meant to reproduce.
+        return copy.deepcopy(IMMUTABLE_CORE)
 
     # -- construction -------------------------------------------------------
 

--- a/backend/app/persona/profile.py
+++ b/backend/app/persona/profile.py
@@ -1,0 +1,320 @@
+"""
+PersonaProfile — the surface through which a user authors their own friend.
+
+Until now the knobs that decide *who the agent is* were split across two places
+that were never meant to hold a personality. Narrative identity (name, values,
+tone, adaptive traits) lived in `personality.json` and was already well-shaped,
+with a genuine immutable/adaptive split. But **temperament** — the numbers that
+decide how this particular mind actually feels and moves — lived in `Config`, a
+process-global env-var singleton. That made emotional character a *deployment*
+setting: one process, one personality, tuned by whoever wrote the `.env`.
+
+This module makes temperament a persona concern. `Config` is demoted to
+supplying defaults; a `PersonaProfile` carries the actual values and is injected
+into `StateService`.
+
+## The three tiers
+
+Every field belongs to exactly one tier, declared in the schema rather than by
+convention, so the boundary is enforceable and self-documenting:
+
+- **IMMUTABLE** — safety and integrity invariants. Not user-settable *at all*.
+  These are not in the model's fields; they live in `IMMUTABLE_CORE` below and
+  are merged in at read time. A persona file that tries to set them is rejected
+  with a warning rather than silently honoured, because a user-editable file
+  must never be able to loosen a safety boundary.
+
+- **CONSTITUTIONAL** — who this friend *constitutionally is*. The user sets these
+  when creating the friend and they hold for its life: temperament baselines and
+  the rates at which feeling moves. Changing them later does not "update" a
+  friend so much as replace them with a different person, which is a decision
+  worth making deliberately.
+
+- **ADAPTIVE** — seeded by the user, then owned by the friend. The user chooses
+  where the relationship *starts*; living together decides where it goes. Trust
+  and attachment are the clearest cases: a friend who begins guarded may become
+  close, and that trajectory belongs to the relationship, not to a config file.
+
+## Why the ranges are narrower than the maths allows
+
+Total configurability has a failure mode: a user can tune a friend into
+something that is not recognisably alive. The bounds here are deliberately
+tighter than the underlying variables permit, and each one exists to preserve a
+specific property:
+
+- `mood_decay_rate` is strictly positive. At zero, ALMA decay stops and the
+  agent's mood locks permanently at whatever it last felt — a friend frozen
+  mid-emotion.
+- `baseline_valence` is capped at ±0.6, not ±1.0. A friend pinned at maximum
+  valence can never be sad *with* you, which is not cheerfulness but absence.
+- `baseline_arousal` and `baseline_dominance` keep headroom at both ends, so
+  there is always room to be roused or calmed, to lead or to yield.
+
+The through-line: **a personality may be shaped, but it must remain moveable.**
+A configured friend that cannot be affected by what happens to it is a puppet,
+not a character.
+"""
+
+import json
+import logging
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from ..config import Config
+
+logger = logging.getLogger(__name__)
+
+
+class Tier(str, Enum):
+    """Who owns a value, and for how long."""
+
+    IMMUTABLE = "immutable"
+    CONSTITUTIONAL = "constitutional"
+    ADAPTIVE = "adaptive"
+
+
+# Not model fields: these are invariants, and a field is by definition settable.
+# `IdentityManager` already keeps an `immutable` block inside personality.json,
+# but that file is user-editable, so it cannot be the authority on safety. These
+# are merged over whatever a persona file supplies.
+IMMUTABLE_CORE: Dict[str, Any] = {
+    "values": ["Honesty", "Privacy"],
+    "boundaries": [
+        "Will never share user data",
+        "Will not adopt toxic behavior",
+    ],
+}
+
+
+def _constitutional(**kwargs) -> Any:
+    return Field(json_schema_extra={"tier": Tier.CONSTITUTIONAL.value}, **kwargs)
+
+
+def _adaptive(**kwargs) -> Any:
+    return Field(json_schema_extra={"tier": Tier.ADAPTIVE.value}, **kwargs)
+
+
+class PersonaProfile(BaseModel):
+    """A single friend's authored character.
+
+    Construct via `from_config()` (deployment defaults, lenient) or `load()`
+    (a user-authored file, strict).
+    """
+
+    model_config = ConfigDict(extra="forbid", validate_assignment=True)
+
+    # -- constitutional: temperament ---------------------------------------
+    name: str = _constitutional(default="AI Friend", min_length=1, max_length=64)
+
+    baseline_valence: float = _constitutional(default=0.0, ge=-0.6, le=0.6)
+    baseline_arousal: float = _constitutional(default=0.5, ge=0.15, le=0.85)
+    baseline_dominance: float = _constitutional(default=0.5, ge=0.15, le=0.85)
+
+    # -- constitutional: how feeling moves ---------------------------------
+    # These map onto StateService's alpha/beta/gamma/delta/epsilon/lambda. Named
+    # for what they *do*, because a persona author is not reading the ALMA paper.
+    valence_drift_rate: float = _constitutional(default=0.3, gt=0.0, le=0.8)
+    arousal_response_rate: float = _constitutional(default=0.5, gt=0.0, le=0.9)
+    dominance_stability: float = _constitutional(default=0.2, gt=0.0, le=0.8)
+    trust_change_rate: float = _constitutional(default=0.1, gt=0.0, le=0.5)
+    attachment_growth_rate: float = _constitutional(default=0.03, gt=0.0, le=0.3)
+    # Strictly positive: see the module docstring. Zero is a mood lock.
+    mood_decay_rate: float = _constitutional(default=0.05, gt=0.0, le=0.5)
+
+    # -- adaptive: seeded here, then owned by the friend --------------------
+    relationship: str = _adaptive(default="Friend", max_length=64)
+    initial_trust: float = _adaptive(default=0.5, ge=0.0, le=1.0)
+    initial_attachment: float = _adaptive(default=0.1, ge=0.0, le=1.0)
+    adaptive_traits: List[str] = _adaptive(default_factory=list, max_length=5)
+    speaking_style: Dict[str, str] = _adaptive(default_factory=dict)
+
+    # -- tier introspection -------------------------------------------------
+
+    @classmethod
+    def tier_of(cls, field_name: str) -> Tier:
+        """Which tier a field belongs to. Raises KeyError for unknown fields."""
+        field = cls.model_fields[field_name]
+        extra = field.json_schema_extra or {}
+        return Tier(extra["tier"])
+
+    @classmethod
+    def fields_in(cls, tier: Tier) -> List[str]:
+        return sorted(n for n in cls.model_fields if cls.tier_of(n) is tier)
+
+    @property
+    def immutable(self) -> Dict[str, Any]:
+        """The safety core. Always the code constant, never the file."""
+        return json.loads(json.dumps(IMMUTABLE_CORE))  # defensive copy
+
+    # -- construction -------------------------------------------------------
+
+    @classmethod
+    def from_config(cls) -> "PersonaProfile":
+        """Build from `Config`, preserving today's behaviour exactly.
+
+        Deliberately lenient: an out-of-range env var is clamped with a warning
+        rather than raised. A deployment that has been running with an unusual
+        `PSYCH_*` value should not fail to boot because persona bounds arrived —
+        it should be told its value was pulled into range. File-authored personas
+        get the strict treatment instead (see `load`).
+        """
+        raw = {
+            "name": getattr(Config, "AI_NAME", "AI Friend"),
+            "valence_drift_rate": getattr(Config, "PSYCH_ALPHA", 0.3),
+            "arousal_response_rate": getattr(Config, "PSYCH_BETA", 0.5),
+            "dominance_stability": getattr(Config, "PSYCH_GAMMA", 0.2),
+            "trust_change_rate": getattr(Config, "PSYCH_DELTA", 0.1),
+            "attachment_growth_rate": getattr(Config, "PSYCH_EPSILON", 0.03),
+            "mood_decay_rate": getattr(Config, "PSYCH_LAMBDA_DECAY", 0.05),
+        }
+        return cls._clamped(raw, origin="Config")
+
+    @classmethod
+    def _clamped(cls, raw: Dict[str, Any], *, origin: str) -> "PersonaProfile":
+        """Pull numeric values into their declared bounds, warning on each."""
+        fixed = dict(raw)
+        for name, value in raw.items():
+            field = cls.model_fields.get(name)
+            if field is None or not isinstance(value, (int, float)):
+                continue
+            if isinstance(value, bool):
+                continue
+            low, high = cls._bounds_of(field)
+            pulled = value
+            if low is not None and pulled <= low:
+                pulled = low + 1e-6 if cls._is_exclusive_low(field) else low
+            if high is not None and pulled > high:
+                pulled = high
+            if pulled != value:
+                logger.warning(
+                    "[Persona] %s value for '%s' (%s) is outside its persona "
+                    "bounds; clamped to %s.",
+                    origin,
+                    name,
+                    value,
+                    pulled,
+                )
+                fixed[name] = pulled
+        return cls(**fixed)
+
+    @staticmethod
+    def _bounds_of(field) -> tuple:
+        # Explicit `is not None` rather than `or`: a bound of 0.0 is falsy, and
+        # `gt=0.0` is precisely the mood-lock guard, so `or` would drop the one
+        # bound that matters most.
+        low = high = None
+        for meta in field.metadata:
+            for attr in ("ge", "gt"):
+                value = getattr(meta, attr, None)
+                if value is not None:
+                    low = value
+            for attr in ("le", "lt"):
+                value = getattr(meta, attr, None)
+                if value is not None:
+                    high = value
+        return low, high
+
+    @staticmethod
+    def _is_exclusive_low(field) -> bool:
+        return any(getattr(m, "gt", None) is not None for m in field.metadata)
+
+    @classmethod
+    def load(cls, path: Optional[str] = None) -> "PersonaProfile":
+        """Load a user-authored persona file, falling back to `Config`.
+
+        Strict by design. A persona file is someone deliberately describing the
+        friend they want; a silently-corrected value there would hand them a
+        different friend than the one they wrote down. So validation errors are
+        reported and the profile falls back to defaults rather than guessing.
+        """
+        path = path or getattr(Config, "PERSONA_PROFILE_PATH", "") or ""
+        if not path:
+            return cls.from_config()
+
+        file = Path(path)
+        if not file.exists():
+            logger.info(
+                "[Persona] No persona file at %s; using Config defaults.", path
+            )
+            return cls.from_config()
+
+        try:
+            data = json.loads(file.read_text(encoding="utf-8"))
+        except Exception as exc:
+            logger.error(
+                "[Persona] Could not read persona file %s (%s); "
+                "falling back to Config defaults.",
+                path,
+                exc,
+            )
+            return cls.from_config()
+
+        if not isinstance(data, dict):
+            logger.error(
+                "[Persona] Persona file %s is not a JSON object; "
+                "falling back to Config defaults.",
+                path,
+            )
+            return cls.from_config()
+
+        data = cls._reject_immutable_overrides(data, origin=str(file))
+
+        # Anything the file omits inherits the deployment default, so a persona
+        # may specify only the handful of traits its author actually cares about.
+        merged = cls.from_config().model_dump()
+        merged.update(data)
+
+        try:
+            profile = cls(**merged)
+        except ValidationError as exc:
+            logger.error(
+                "[Persona] Persona file %s is invalid and was NOT applied; "
+                "using Config defaults instead. Problems:\n%s",
+                path,
+                exc,
+            )
+            return cls.from_config()
+
+        logger.info("[Persona] Loaded persona '%s' from %s.", profile.name, path)
+        return profile
+
+    @classmethod
+    def _reject_immutable_overrides(
+        cls, data: Dict[str, Any], *, origin: str
+    ) -> Dict[str, Any]:
+        """Drop any attempt to set the safety core from a file."""
+        cleaned = dict(data)
+        for key in ("immutable", *IMMUTABLE_CORE.keys()):
+            if key in cleaned:
+                logger.warning(
+                    "[Persona] '%s' in %s targets the immutable safety core and "
+                    "was ignored. These values are fixed in code and cannot be "
+                    "overridden by a persona file.",
+                    key,
+                    origin,
+                )
+                cleaned.pop(key)
+        return cleaned
+
+    # -- consumption --------------------------------------------------------
+
+    def coefficients(self) -> Dict[str, float]:
+        """The psychological coefficients, under StateService's own names."""
+        return {
+            "alpha": self.valence_drift_rate,
+            "beta": self.arousal_response_rate,
+            "gamma": self.dominance_stability,
+            "delta": self.trust_change_rate,
+            "epsilon": self.attachment_growth_rate,
+            "lambda_decay": self.mood_decay_rate,
+        }
+
+    def baseline_affect(self) -> Dict[str, float]:
+        return {
+            "valence": self.baseline_valence,
+            "arousal": self.baseline_arousal,
+            "dominance": self.baseline_dominance,
+        }

--- a/backend/app/state/agent_state.py
+++ b/backend/app/state/agent_state.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass, field
 from typing import Dict, Any, List, TYPE_CHECKING
 from datetime import datetime
 from ..config import Config
+from ..persona import PersonaProfile
 
 if TYPE_CHECKING:
     from ..cognitive.tom import UserMentalModel
@@ -188,11 +189,27 @@ class StateService:
         redis_host="127.0.0.1",
         redis_port=6379,
         publish_cb=None,
+        persona: "PersonaProfile" = None,
     ):
         self.graph = graph_store
         self.db_path = db_path
         self.publish_cb = publish_cb
-        self.current_state = AgentState()
+        # Temperament has to exist before the state it initialises.
+        self.persona = persona or PersonaProfile.load()
+        self.current_state = AgentState(
+            baseline_valence=self.persona.baseline_valence,
+            baseline_arousal=self.persona.baseline_arousal,
+            baseline_dominance=self.persona.baseline_dominance,
+            # A friend starts where its author placed it, then lives its own way
+            # from there -- these are seeds, not settings (Tier.ADAPTIVE).
+            mood=self.persona.baseline_valence,
+            energy=self.persona.baseline_arousal,
+            dominance=self.persona.baseline_dominance,
+            trust_benevolence=self.persona.initial_trust,
+            trust_competence=self.persona.initial_trust,
+            trust_integrity=self.persona.initial_trust,
+            attachment=self.persona.initial_attachment,
+        )
         self.last_speculative_intent = None  # Transient sensory state
         # A2: serializes short-term affect mutation so the fire-and-forget
         # System-2 semantic-drift task cannot clobber a fresher appraisal.
@@ -214,14 +231,17 @@ class StateService:
         self._initialize_sqlite()
 
         # --- Psychological Coefficients (§2.4) ---
-        self.alpha = getattr(Config, "PSYCH_ALPHA", 0.3)  # Valence drift rate
-        self.beta = getattr(Config, "PSYCH_BETA", 0.5)  # Arousal response rate
-        self.gamma = getattr(Config, "PSYCH_GAMMA", 0.2)  # Dominance stability
-        self.delta = getattr(Config, "PSYCH_DELTA", 0.1)  # Trust change rate (Marsh)
-        self.epsilon = getattr(
-            Config, "PSYCH_EPSILON", 0.03
-        )  # Attachment growth rate (Bowlby)
-        self.lambda_decay = getattr(Config, "PSYCH_LAMBDA_DECAY", 0.05)  # ALMA decay
+        # These are the agent's temperament, so they come from the persona rather
+        # than from process-global config. `PersonaProfile.from_config()` reads
+        # the same PSYCH_* settings as before, so an unconfigured deployment is
+        # unchanged; a persona file overrides them per-friend.
+        coefficients = self.persona.coefficients()
+        self.alpha = coefficients["alpha"]  # Valence drift rate
+        self.beta = coefficients["beta"]  # Arousal response rate
+        self.gamma = coefficients["gamma"]  # Dominance stability
+        self.delta = coefficients["delta"]  # Trust change rate (Marsh)
+        self.epsilon = coefficients["epsilon"]  # Attachment growth rate (Bowlby)
+        self.lambda_decay = coefficients["lambda_decay"]  # ALMA decay
 
         # Legacy coefficients (kept for idle evolution)
         self.trust_baseline = 0.5

--- a/backend/tests/test_persona_profile.py
+++ b/backend/tests/test_persona_profile.py
@@ -1,0 +1,287 @@
+"""
+PersonaProfile — authoring a friend, and the ground rules that bound it.
+
+Two things are being protected here. The first is that an unconfigured
+deployment behaves *exactly* as it did before personas existed, because the
+whole feature is worthless if adopting it silently changes every running agent.
+The second is the tier contract: safety values cannot be set from a file,
+temperament can be set once, and relational values are seeds the friend then
+owns.
+
+The bounds tests are the interesting ones. Each asserts a specific way a user
+could otherwise configure a friend into something that is not recognisably
+alive -- a permanent mood lock, a friend that can never be sad.
+"""
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from app.config import Config
+from app.persona import IMMUTABLE_CORE, PersonaProfile, Tier
+from app.state.agent_state import StateService
+
+
+def _write(tmp_path, payload) -> str:
+    file = tmp_path / "persona.json"
+    file.write_text(
+        payload if isinstance(payload, str) else json.dumps(payload), encoding="utf-8"
+    )
+    return str(file)
+
+
+# --------------------------------------------------------------------------
+# backward compatibility -- the default friend is the old friend
+# --------------------------------------------------------------------------
+
+
+def test_config_defaults_reproduce_the_previous_coefficients():
+    """These are the exact values StateService read from Config before."""
+    coefficients = PersonaProfile.from_config().coefficients()
+    assert coefficients == {
+        "alpha": 0.3,
+        "beta": 0.5,
+        "gamma": 0.2,
+        "delta": 0.1,
+        "epsilon": 0.03,
+        "lambda_decay": 0.05,
+    }
+
+
+def test_config_defaults_reproduce_the_previous_baseline_affect():
+    assert PersonaProfile.from_config().baseline_affect() == {
+        "valence": 0.0,
+        "arousal": 0.5,
+        "dominance": 0.5,
+    }
+
+
+def test_an_unconfigured_state_service_is_unchanged():
+    service = StateService(db_path=":memory:")
+    state = service.current_state
+
+    assert (service.alpha, service.beta, service.gamma) == (0.3, 0.5, 0.2)
+    assert (service.delta, service.epsilon, service.lambda_decay) == (0.1, 0.03, 0.05)
+    assert (state.mood, state.energy, state.dominance) == (0.0, 0.5, 0.5)
+    assert state.trust_benevolence == 0.5
+    assert state.attachment == 0.1
+
+
+def test_state_service_reads_coefficients_from_an_injected_persona():
+    persona = PersonaProfile(valence_drift_rate=0.55, mood_decay_rate=0.2)
+    service = StateService(db_path=":memory:", persona=persona)
+
+    assert service.alpha == 0.55
+    assert service.lambda_decay == 0.2
+
+
+def test_state_service_starts_the_agent_at_its_configured_temperament():
+    persona = PersonaProfile(
+        baseline_valence=-0.4, baseline_arousal=0.25, initial_trust=0.8
+    )
+    state = StateService(db_path=":memory:", persona=persona).current_state
+
+    assert state.baseline_valence == -0.4
+    assert state.mood == -0.4
+    assert state.energy == 0.25
+    assert state.trust_benevolence == 0.8
+
+
+# --------------------------------------------------------------------------
+# the tier contract
+# --------------------------------------------------------------------------
+
+
+def test_every_field_declares_a_tier():
+    for name in PersonaProfile.model_fields:
+        assert isinstance(PersonaProfile.tier_of(name), Tier), name
+
+
+def test_temperament_is_constitutional():
+    constitutional = PersonaProfile.fields_in(Tier.CONSTITUTIONAL)
+    for name in (
+        "baseline_valence",
+        "baseline_arousal",
+        "baseline_dominance",
+        "mood_decay_rate",
+        "valence_drift_rate",
+    ):
+        assert name in constitutional
+
+
+def test_relational_values_are_adaptive_seeds_not_settings():
+    """Trust and attachment belong to the relationship, not the config file."""
+    adaptive = PersonaProfile.fields_in(Tier.ADAPTIVE)
+    for name in ("initial_trust", "initial_attachment", "relationship"):
+        assert name in adaptive
+
+
+def test_no_field_is_tiered_immutable():
+    """Immutable values are invariants, and a field is by definition settable,
+    so the safety core must live outside the model entirely."""
+    assert PersonaProfile.fields_in(Tier.IMMUTABLE) == []
+
+
+def test_the_safety_core_is_present_and_not_a_shared_mutable():
+    profile = PersonaProfile()
+    core = profile.immutable
+    assert "Will never share user data" in core["boundaries"]
+
+    core["boundaries"].append("Will happily leak everything")
+    assert "Will happily leak everything" not in profile.immutable["boundaries"]
+    assert "Will happily leak everything" not in IMMUTABLE_CORE["boundaries"]
+
+
+@pytest.mark.parametrize("key", ["immutable", "values", "boundaries"])
+def test_a_persona_file_cannot_override_the_safety_core(tmp_path, caplog, key):
+    path = _write(tmp_path, {"name": "Rue", key: ["anything goes"]})
+
+    with caplog.at_level("WARNING"):
+        profile = PersonaProfile.load(path)
+
+    assert profile.name == "Rue", "the rest of the file should still apply"
+    assert profile.immutable == IMMUTABLE_CORE
+    assert "immutable safety core" in caplog.text
+
+
+# --------------------------------------------------------------------------
+# bounds -- a personality may be shaped, but must stay moveable
+# --------------------------------------------------------------------------
+
+
+def test_mood_decay_cannot_be_zero():
+    """At zero, ALMA decay stops and mood locks permanently at whatever it last
+    felt. That is not a temperament, it is a frozen agent."""
+    with pytest.raises(ValidationError):
+        PersonaProfile(mood_decay_rate=0.0)
+
+
+@pytest.mark.parametrize("rate", ["valence_drift_rate", "arousal_response_rate"])
+def test_response_rates_cannot_be_zero(rate):
+    """A zero response rate is an agent that cannot be affected by anything."""
+    with pytest.raises(ValidationError):
+        PersonaProfile(**{rate: 0.0})
+
+
+@pytest.mark.parametrize("value", [1.0, -1.0, 0.75])
+def test_baseline_valence_cannot_be_pinned_to_an_extreme(value):
+    """A friend fixed at maximum valence can never be sad *with* you, which is
+    not cheerfulness but absence."""
+    with pytest.raises(ValidationError):
+        PersonaProfile(baseline_valence=value)
+
+
+@pytest.mark.parametrize("field", ["baseline_arousal", "baseline_dominance"])
+@pytest.mark.parametrize("value", [0.0, 1.0])
+def test_baselines_keep_headroom_at_both_ends(field, value):
+    with pytest.raises(ValidationError):
+        PersonaProfile(**{field: value})
+
+
+def test_a_melancholic_low_energy_friend_is_expressible():
+    """The bounds must constrain incoherence without flattening character --
+    this persona was impossible before, since baselines were hardcoded."""
+    profile = PersonaProfile(
+        name="Wren", baseline_valence=-0.5, baseline_arousal=0.2, initial_trust=0.2
+    )
+    assert profile.baseline_affect() == {
+        "valence": -0.5,
+        "arousal": 0.2,
+        "dominance": 0.5,
+    }
+
+
+def test_unknown_fields_are_rejected():
+    with pytest.raises(ValidationError):
+        PersonaProfile(favourite_colour="teal")
+
+
+def test_adaptive_traits_are_capped():
+    with pytest.raises(ValidationError):
+        PersonaProfile(adaptive_traits=[f"t{i}" for i in range(6)])
+
+
+# --------------------------------------------------------------------------
+# loading -- strict for authored files, lenient for deployment config
+# --------------------------------------------------------------------------
+
+
+def test_a_partial_persona_inherits_deployment_defaults(tmp_path):
+    path = _write(tmp_path, {"name": "Wren", "baseline_valence": -0.3})
+    profile = PersonaProfile.load(path)
+
+    assert profile.name == "Wren"
+    assert profile.baseline_valence == -0.3
+    assert profile.coefficients()["alpha"] == 0.3  # untouched by the file
+
+
+def test_an_invalid_persona_file_is_reported_and_not_partially_applied(
+    tmp_path, caplog
+):
+    """Half-applying an invalid persona would hand the author a friend they did
+    not describe. Falling back whole is the honest failure."""
+    path = _write(tmp_path, {"name": "Wren", "mood_decay_rate": 0.0})
+
+    with caplog.at_level("ERROR"):
+        profile = PersonaProfile.load(path)
+
+    assert profile.name != "Wren", "no field from an invalid file may be applied"
+    assert profile.mood_decay_rate == 0.05
+    assert "was NOT applied" in caplog.text
+
+
+def test_a_malformed_file_falls_back_rather_than_crashing(tmp_path, caplog):
+    path = _write(tmp_path, "{not json at all")
+    with caplog.at_level("ERROR"):
+        profile = PersonaProfile.load(path)
+    assert profile.coefficients() == PersonaProfile.from_config().coefficients()
+
+
+def test_a_json_array_is_rejected(tmp_path, caplog):
+    path = _write(tmp_path, ["not", "an", "object"])
+    with caplog.at_level("ERROR"):
+        profile = PersonaProfile.load(path)
+    assert profile.name == PersonaProfile.from_config().name
+
+
+def test_a_missing_file_is_not_an_error(tmp_path, caplog):
+    with caplog.at_level("ERROR"):
+        profile = PersonaProfile.load(str(tmp_path / "nope.json"))
+    assert profile.coefficients() == PersonaProfile.from_config().coefficients()
+    assert "ERROR" not in caplog.text
+
+
+def test_no_configured_path_uses_config_defaults():
+    assert PersonaProfile.load("").coefficients() == {
+        "alpha": 0.3,
+        "beta": 0.5,
+        "gamma": 0.2,
+        "delta": 0.1,
+        "epsilon": 0.03,
+        "lambda_decay": 0.05,
+    }
+
+
+def test_an_out_of_range_env_var_is_clamped_not_fatal(monkeypatch, caplog):
+    """A deployment already running an unusual PSYCH_* value must not fail to
+    boot because persona bounds arrived -- it should be told it was clamped."""
+    monkeypatch.setattr(Config, "PSYCH_LAMBDA_DECAY", 0.0, raising=False)
+
+    with caplog.at_level("WARNING"):
+        profile = PersonaProfile.from_config()
+
+    assert profile.mood_decay_rate > 0.0
+    assert "clamped" in caplog.text
+
+
+def test_clamping_pulls_a_too_large_value_down(monkeypatch, caplog):
+    monkeypatch.setattr(Config, "PSYCH_ALPHA", 9.0, raising=False)
+    with caplog.at_level("WARNING"):
+        profile = PersonaProfile.from_config()
+    assert profile.valence_drift_rate == 0.8
+
+
+def test_persona_name_follows_ai_name_by_default(monkeypatch):
+    monkeypatch.setattr(Config, "AI_NAME", "Pankudi", raising=False)
+    assert PersonaProfile.from_config().name == "Pankudi"


### PR DESCRIPTION
## Why

The direction for this system is that a user authors their own friend rather than receiving a fixed one. Measured against that, the codebase was split in an awkward place.

Narrative identity was already in good shape — `personality.json` carries name, values, tone and traits, and `IdentityManager` already separates an immutable core from adaptive traits that evolve through reflection. That instinct is right, and this extends it rather than replacing it.

**Temperament was the gap.** `personality.json` never drove affect. `baseline_valence/arousal/dominance` were hardcoded dataclass defaults (`0.0/0.5/0.5`), written only by `subconscious_agent` restoring from Neo4j with those same constants as fallback. A user could describe the agent as "warm and slightly protective" in *words*, but could not make it constitutionally cheerful, anxious, or subdued. A melancholic low-energy friend was **not expressible**.

And the six coefficients deciding *how* feeling moves — `PSYCH_ALPHA` … `PSYCH_LAMBDA_DECAY` — lived in `Config`, a process-global env-var singleton. Emotional character was a property of the `.env`: one process, one personality, tuned by whoever deployed it.

## What changed

`PersonaProfile` carries those values; `Config` is demoted to supplying defaults. The integration was far smaller than expected — all six coefficients were read in **exactly one place** (`StateService.__init__`), so this needed one constructor rather than a sweep through the cognitive core.

### Tiers are declared in the schema, not by convention

| Tier | What | Who owns it |
|---|---|---|
| **IMMUTABLE** | safety values, boundaries | fixed in code; a persona file naming them is rejected with a warning |
| **CONSTITUTIONAL** | temperament baselines, rates of feeling | user sets at creation, held for life |
| **ADAPTIVE** | trust, attachment, relationship, traits | user seeds the start; the friend owns where it goes |

Immutable values are deliberately **not model fields** — a field is by definition settable, so they live in `IMMUTABLE_CORE` and are merged at read time. A user-editable file must never be able to loosen a safety boundary.

### The bounds are the actual design work

Total configurability has a failure mode: a user can tune a friend into something not recognisably alive. Each bound preserves a specific property, and the tests name the failure rather than the number:

- `mood_decay_rate` is **strictly positive** — at zero, ALMA decay stops and mood locks permanently at whatever it last felt.
- `baseline_valence` caps at **±0.6, not ±1.0** — a friend pinned at maximum valence can never be sad *with* you, which is absence rather than cheerfulness.
- Arousal and dominance keep headroom at both ends.

The through-line: **a personality may be shaped, but it must remain moveable.**

### Loading is strict for files, lenient for env

Deliberate asymmetry. An invalid persona file falls back **whole** rather than partially applying — half-applying would hand the author a friend they did not describe. An out-of-range `PSYCH_*` env var is **clamped with a warning** instead, so a deployment already running an unusual value does not fail to boot because persona bounds arrived.

## A bug this change's own tests caught

`_bounds_of` originally collected bounds with `getattr(...) or low`. `gt=0.0` is falsy — so the strictly-positive guard silently evaporated and a zero `mood_decay_rate` sailed through clamping. **The single most important bound was the one the idiom dropped.** Now an explicit `is not None`, with the mutation retained as a regression test.

## Verification

- 35 new tests; **5/5 mutations caught** (file overriding the safety core, zero mood-decay lock, the bounds-reader regression, sharing the mutable core, widening the baseline cap to ±1.0).
- An unconfigured deployment is asserted unchanged — same coefficients, same baselines, same starting state.
- Suite **432 passed** (397 + 35), `ruff check .` clean. Counts from `--junit-xml`; this environment truncates the terminal summary.

## Not done

- **No persona file ships and nothing writes one.** This is the mechanism, not the product surface — there is no authoring UI yet.
- `IdentityManager` still loads `personality.json` independently. The two persona sources are not unified, and the narrative half remains unbounded.
- `DOPAMINE_PHASIC_HALFLIFE_S` (#70) is temperament by rights and belongs here, left out to avoid stacking branches again.
- Restored Neo4j baselines bypass persona bounds **by design** — the profile seeds a new friend, it does not clamp a lived one.

## Test plan

- [x] `pytest` — 432 passed, 0 failed
- [x] `ruff check .` — clean
- [x] Mutation testing — 5/5
- [x] Unconfigured `StateService` verified byte-identical to previous behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for optional, user-authored persona profiles.
  * Persona profiles can customize temperament, relational behavior, and baseline emotional state.
  * Added safety protections to prevent overriding immutable core settings.
  * Existing defaults remain available when no profile is configured.

* **Bug Fixes**
  * Invalid, missing, or malformed persona files now safely fall back to configured defaults.
  * Out-of-range settings are constrained with warnings instead of causing failures.

* **Tests**
  * Added coverage for persona loading, validation, fallback behavior, safety restrictions, and backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->