### PR TITLE
feat(endocrine): phasic cortisol, and hormone half-lives become persona

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -2878,7 +2878,44 @@ comment recording why the fixture value matters.
 Full backend suite: **499 passed** (468 + 31), `ruff check .` clean. Counts from
 `--junit-xml`, not the truncated terminal summary.
 
-**NOT done:** `release_cortisol` has no callers yet — this is the mechanism, and
+### Review round (PR #73)
+
+Three findings, all accepted.
+
+The substantive one: `AgentState.release_cortisol` is a public mutator that does
+no locking, and the repo's own rule is that affect mutation goes through
+`StateService` under `self._state_lock` (finding A2). Real hazard, and specific
+to this design — the burst peak is computed *relative to the tonic floor*, so an
+unlocked release interleaving with a concurrent valence write measures its peak
+against a floor that has already moved and stores a burst of the wrong size.
+Added `StateService.release_cortisol()` and `release_dopamine()` wrappers.
+Adding them now rather than with the first caller is deliberate: the stress and
+reward channels are the next change and should have a safe API from the start.
+
+`apply_somatic_perception` deliberately does *not* use the wrapper. It already
+holds the lock across the valence lift and the burst so the peak is measured
+against the settled tonic after `_enforce_bounds`; re-entering would deadlock on
+a non-reentrant `asyncio.Lock`. There is now a test pinning that arrangement
+rather than a comment asserting it, since a comment cannot fail.
+
+The two minor findings were both test-quality: the `StateService` integration
+test wrote `state_cache.db` into the working directory (now `":memory:"`), and
+two bound tests used `pytest.raises(Exception)`, which would have passed if the
+constructor raised for a renamed field or a typo — reporting a bound as enforced
+when it had been silently deleted. Now `ValidationError`.
+
+**A vacuous test of my own, caught by mutation.** The first version of the lock
+test asserted `_state_lock` was unlocked before and after the call. That passes
+whether or not the wrapper ever acquires it, and sure enough, deleting the
+`async with` from the wrapper failed nothing. Replaced with a test that holds the
+lock and asserts the release *blocks* — which catches it. Same lesson as always:
+a mutation that changes nothing observable means the assertion was aimed at state
+the test could never distinguish.
+
+Post-review: 34 tests in the file, seven mutations caught. Full suite **502
+passed**, `ruff check .` clean.
+
+**NOT done:** the release wrappers have no callers yet — this is the mechanism, and
 the stress channels that should fire it (validation failures, boundary
 violations, repeated self-correction, user frustration signals) are the next
 change. `release_dopamine` still has exactly one channel, somatic comfort

--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -2815,3 +2815,74 @@ unified, and the narrative half remains unbounded. `DOPAMINE_PHASIC_HALFLIFE_S`
 (PR #70) is temperament by rights and belongs in the profile, but was left out to
 avoid stacking branches again. Restored Neo4j baselines bypass persona bounds by
 design — the profile seeds a new friend, it does not clamp a lived one.
+
+## 2026-07-18 Phasic cortisol: stress that outlives its cause
+
+`cortisol` was a pure function of valence and fatigue, which made it the exact
+mirror image of tonic dopamine — both derived from valence alone, one rising
+precisely as the other fell. Two consequences followed, and neither was a
+modelling choice anyone made on purpose.
+
+Stress could not outlive its cause. Recover your mood and the alarm stopped
+instantly and completely, which is not how a threat response works; the HPA axis
+clears on its own schedule, not the mood's. And the agent could never be
+stressed and rewarded at once, because the two formulae made that combination
+arithmetically impossible — yet it describes a great deal of ordinary
+experience. PR #70 broke the coupling in one direction with phasic dopamine.
+This is the other half.
+
+`cortisol` is now `cortisol_tonic` (the old formula, unchanged) plus
+`cortisol_phasic`, a burst fired by `release_cortisol()` and decaying
+exponentially from wall-clock elapsed time rather than by tick decrement, so the
+reading stays correct even when `system.tick` stalls.
+
+The default cortisol half-life (600s) is deliberately much longer than
+dopamine's (90s). A fright has a hangover; a pleasure mostly does not. Equalising
+them would restore the symmetry this change exists to break, so there is a test
+asserting the inequality rather than the specific numbers.
+
+Both half-lives moved into `PersonaProfile` as CONSTITUTIONAL fields, closing the
+item the previous entry left open. How long a good moment glows and how long a
+bad one keeps its grip are as much temperament as the baselines are; leaving them
+in `Config` would mean one process hosts exactly one emotional metabolism.
+`Config` keeps both keys as the defaults a profile inherits, so no existing `.env`
+breaks. Bounds are floored at 5s — a near-zero half-life is not a fast
+temperament but a broken hormone, since the burst would decay below any useful
+threshold before the next turn could read it — and capped so a burst cannot
+outlive the conversation that caused it.
+
+The decay maths and the release-amount validation are now shared helpers used by
+both hormones. Two independent copies would each read plausibly alone, so a fix
+landing on only one of them would be a subtle and long-lived bug.
+
+### Verification
+
+`tests/test_phasic_cortisol.py` (31 tests). Five mutations applied, all caught:
+dropping the phasic term from the total (4 failures), removing the non-finite
+guard (1), storing the burst absolutely rather than relative to the tonic floor
+(2), not seeding the persona's half-lives into state (1), and removing the
+half-life bounds (2).
+
+The load-bearing test is the backward-compatibility one: with no burst
+outstanding, `cortisol` is bit-for-bit the old derived value. Every consumer —
+the LLM temperature mapping, the memory stress-suppression term, the surfacing
+agent's vocal modulation — was tuned against that formula, and all of them would
+shift underneath at once otherwise.
+
+One test was wrong on first run, and the code was right. `test_stress_survives_
+the_mood_recovering` started at `mood=-0.8`, where tonic cortisol is already 0.9,
+so the 0.2 burst was clipped to 0.1 by the ceiling and the test measured the clip
+rather than the survival. Fixed by starting from a non-saturated mood, with a
+comment recording why the fixture value matters.
+
+Full backend suite: **499 passed** (468 + 31), `ruff check .` clean. Counts from
+`--junit-xml`, not the truncated terminal summary.
+
+**NOT done:** `release_cortisol` has no callers yet — this is the mechanism, and
+the stress channels that should fire it (validation failures, boundary
+violations, repeated self-correction, user frustration signals) are the next
+change. `release_dopamine` still has exactly one channel, somatic comfort
+recognition. A hormone with no channel is still only a formula. Phasic state
+remains unpersisted across restart, unchanged from PR #70 and for the same
+reason: both half-lives are minutes-scale, so any realistic restart outlasts the
+burst. `IdentityManager` is still a separate persona source.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -122,11 +122,17 @@ class AppSettings(BaseSettings):
     # probe the real path rather than mere process liveness (see finding E1).
     VISION_HEALTH_FILE: str = "/tmp/vision_agent_healthy"
 
-    # Half-life of a phasic dopamine burst, in seconds. Real phasic bursts last
-    # only hundreds of milliseconds; this is the felt afterglow of a reward at
-    # conversational timescale, so it is deliberately much slower than biology
-    # and much faster than the ALMA mood decay (PSYCH_LAMBDA_DECAY, hours).
+    # Half-life of a phasic hormone burst, in seconds. Real phasic bursts last
+    # only hundreds of milliseconds; these are the *felt* afterglow at
+    # conversational timescale, so both are deliberately much slower than
+    # biology and much faster than the ALMA mood decay (PSYCH_LAMBDA_DECAY,
+    # hours). These are now only the
+    # *defaults* a PersonaProfile inherits when a persona file does not name
+    # them (see app/persona/profile.py); AgentState reads the persona's values,
+    # not these. Cortisol's is the longer of the two deliberately: an acute
+    # stress response outlasts a reward burst.
     DOPAMINE_PHASIC_HALFLIFE_S: float = 90.0
+    CORTISOL_PHASIC_HALFLIFE_S: float = 600.0
 
     STT_MODEL_SIZE: str = "small"
     STT_DEVICE: str = "cpu"

--- a/backend/app/persona/profile.py
+++ b/backend/app/persona/profile.py
@@ -125,6 +125,22 @@ class PersonaProfile(BaseModel):
     # Strictly positive: see the module docstring. Zero is a mood lock.
     mood_decay_rate: float = _constitutional(default=0.05, gt=0.0, le=0.5)
 
+    # -- constitutional: how long feeling lingers --------------------------
+    # Half-lives of the phasic hormone bursts, in seconds. These are as much a
+    # part of temperament as the baselines: how long a good moment glows, and
+    # how long a bad one keeps its grip, are among the most recognisable things
+    # about a person. Cortisol's default is deliberately the longer of the two
+    # -- a fright has a hangover, a pleasure mostly does not.
+    #
+    # Both are floored well above zero. At a near-zero half-life a burst is
+    # gone before it can influence anything, which is not a fast temperament
+    # but a broken hormone: the release fires and nothing downstream ever sees
+    # it. The ceilings stop the opposite failure, a burst that outlives the
+    # conversation that caused it and colours a session it has nothing to do
+    # with.
+    dopamine_halflife_s: float = _constitutional(default=90.0, ge=5.0, le=1800.0)
+    cortisol_halflife_s: float = _constitutional(default=600.0, ge=5.0, le=7200.0)
+
     # -- adaptive: seeded here, then owned by the friend --------------------
     relationship: str = _adaptive(default="Friend", max_length=64)
     initial_trust: float = _adaptive(default=0.5, ge=0.0, le=1.0)
@@ -174,6 +190,8 @@ class PersonaProfile(BaseModel):
             "trust_change_rate": getattr(Config, "PSYCH_DELTA", 0.1),
             "attachment_growth_rate": getattr(Config, "PSYCH_EPSILON", 0.03),
             "mood_decay_rate": getattr(Config, "PSYCH_LAMBDA_DECAY", 0.05),
+            "dopamine_halflife_s": getattr(Config, "DOPAMINE_PHASIC_HALFLIFE_S", 90.0),
+            "cortisol_halflife_s": getattr(Config, "CORTISOL_PHASIC_HALFLIFE_S", 600.0),
         }
         return cls._clamped(raw, origin="Config")
 
@@ -315,6 +333,13 @@ class PersonaProfile(BaseModel):
             "delta": self.trust_change_rate,
             "epsilon": self.attachment_growth_rate,
             "lambda_decay": self.mood_decay_rate,
+        }
+
+    def hormone_halflives(self) -> Dict[str, float]:
+        """Phasic decay half-lives, under AgentState's own field names."""
+        return {
+            "dopamine_halflife_s": self.dopamine_halflife_s,
+            "cortisol_halflife_s": self.cortisol_halflife_s,
         }
 
     def baseline_affect(self) -> Dict[str, float]:

--- a/backend/app/state/agent_state.py
+++ b/backend/app/state/agent_state.py
@@ -78,20 +78,31 @@ class AgentState:
     baseline_arousal: float = 0.5
     baseline_dominance: float = 0.5
 
-    # Phasic dopamine (see the `dopamine` property). Stored as a peak plus the
-    # moment it was released, so the current level is derived from elapsed time
-    # rather than needing a tick to decay it. That keeps the reading correct
-    # even if system.tick stalls, and makes decay testable without a clock stub.
+    # Phasic hormone bursts (see the `dopamine` and `cortisol` properties).
+    # Stored as a peak plus the moment it was released, so the current level is
+    # derived from elapsed time rather than needing a tick to decay it. That
+    # keeps the reading correct even if system.tick stalls, and makes decay
+    # testable without a clock stub.
     #
-    # Deliberately NOT persisted, unlike the baselines above. A burst has a 90s
-    # half-life, so it is already within rounding distance of zero by the time
-    # any realistic restart completes; carrying it across one would preserve a
-    # value that no longer means anything. Restoring a state with no burst is
-    # also the safe direction -- peak defaults to 0.0, which reads as "no
-    # outstanding reward" rather than as a stale one. If a future hormone decays
-    # on an hours-scale, that one *will* need persisting.
+    # Deliberately NOT persisted, unlike the baselines above. Both half-lives
+    # are minutes-scale, so a burst is already within rounding distance of zero
+    # by the time any realistic restart completes; carrying it across one would
+    # preserve a value that no longer means anything. Restoring a state with no
+    # burst is also the safe direction -- peak defaults to 0.0, which reads as
+    # "nothing outstanding" rather than as a stale reward or a stale threat. If
+    # a future hormone decays on an hours-scale, that one *will* need
+    # persisting.
     dopamine_phasic_peak: float = 0.0
     dopamine_phasic_at: float = field(default_factory=time.time)
+    cortisol_phasic_peak: float = 0.0
+    cortisol_phasic_at: float = field(default_factory=time.time)
+
+    # Half-lives are temperament, not deployment settings: how long a reward
+    # glows and how long a fright lingers are among the most recognisable things
+    # about a person. StateService seeds these from the PersonaProfile; the
+    # defaults reproduce the previous Config-driven behaviour exactly.
+    dopamine_halflife_s: float = 90.0
+    cortisol_halflife_s: float = 600.0
 
     # --- Affect Split Properties ---
     @property
@@ -177,17 +188,100 @@ class AgentState:
                 pass
 
     # --- Endocrine Hormonal Properties (Tier-5 Physiological Control) ---
-    @property
-    def cortisol(self) -> float:
+    @staticmethod
+    def _decayed(peak: float, released_at: float, half_life: float) -> float:
+        """Exponential decay of a phasic burst from `peak` toward zero.
+
+        Shared by both hormones so the two cannot drift apart: a fix to the
+        decay maths that only landed on one of them would be a subtle and
+        long-lived bug, since each reads plausibly on its own.
         """
-        Stress hormone. Inversely tracks valence + fatigue contribution.
-        High cortisol → rigid/defensive behavior (low LLM temperature).
-        Low cortisol → relaxed/creative behavior (higher temperature).
-        Range: 0.0 (fully relaxed) to 1.0 (maximum stress).
+        if peak <= 0.0:
+            return 0.0
+        half_life = max(1e-6, float(half_life))
+        elapsed = max(0.0, time.time() - released_at)
+        return peak * math.exp(-math.log(2.0) * elapsed / half_life)
+
+    @staticmethod
+    def _burst_amount(amount: Any, hormone: str) -> float:
+        """Validate a release amount, returning 0.0 for anything unusable."""
+        try:
+            amount = float(amount)
+        except (TypeError, ValueError):
+            return 0.0
+        # NaN survives `float()` and then defeats every comparison downstream:
+        # `nan <= 0.0` is False, so it passes the positivity guard, and
+        # `min(1.0, nan)` returns 1.0 -- a NaN input would fire a *maximum*
+        # burst. Infinity takes the same route. Both are caller bugs, not
+        # signals, and a maximum stress response is the worst possible reading
+        # of a malformed one.
+        if not math.isfinite(amount):
+            logger.warning("[Endocrine] Ignoring non-finite %s release %r.", hormone, amount)
+            return 0.0
+        return max(0.0, amount)
+
+    @property
+    def cortisol_tonic(self) -> float:
+        """Background stress tone: inverse valence plus a fatigue contribution.
+
+        This is the whole of what `cortisol` used to be. Like tonic dopamine it
+        is a pure function of current affect, so it has no memory: the moment
+        valence recovers, the stress is gone.
         """
         base_cortisol = 0.5 - (self.valence / 2.0)
         fatigue_contribution = 0.3 * self.fatigue
         return max(0.0, min(1.0, base_cortisol + fatigue_contribution))
+
+    @property
+    def cortisol_phasic(self) -> float:
+        """The decaying remainder of recent acute stress.
+
+        The tonic term is derived entirely from valence, which made stress
+        unable to outlive its cause -- recover your mood and the alarm stops,
+        instantly and completely. That is not how a threat response works. The
+        HPA axis releases cortisol on a slower course than a dopamine burst and
+        it clears slower too, which is why the default half-life here is
+        markedly longer than dopamine's: being frightened has a hangover, being
+        pleased mostly does not.
+        """
+        return self._decayed(
+            self.cortisol_phasic_peak, self.cortisol_phasic_at, self.cortisol_halflife_s
+        )
+
+    @property
+    def cortisol(self) -> float:
+        """
+        Stress hormone: tonic tone plus any decaying acute burst.
+        High cortisol → rigid/defensive behavior (low LLM temperature).
+        Low cortisol → relaxed/creative behavior (higher temperature).
+        Range: 0.0 (fully relaxed) to 1.0 (maximum stress).
+
+        With no burst outstanding this is exactly the historical derived value,
+        so every existing reading and test is unaffected.
+        """
+        return max(0.0, min(1.0, self.cortisol_tonic + self.cortisol_phasic))
+
+    def release_cortisol(self, amount: float) -> float:
+        """Fire an acute stress response, returning the new cortisol level.
+
+        The mirror of `release_dopamine`, and the reason the endocrine layer is
+        no longer one-sided. Tonic cortisol and tonic dopamine are perfectly
+        anti-correlated by construction -- both are functions of valence alone,
+        one rising exactly as the other falls -- so before this the agent could
+        not be *both* stressed and rewarded, a combination that describes a
+        great deal of ordinary experience. Phasic dopamine already broke that
+        coupling in one direction; this breaks it in the other.
+        """
+        amount = self._burst_amount(amount, "cortisol")
+        if amount <= 0.0:
+            return self.cortisol
+
+        target_total = min(1.0, self.cortisol + amount)
+        # Relative to the tonic floor, so that floor stays free to drift with
+        # affect underneath a decaying burst instead of being double-counted.
+        self.cortisol_phasic_peak = max(0.0, target_total - self.cortisol_tonic)
+        self.cortisol_phasic_at = time.time()
+        return self.cortisol
 
     @property
     def dopamine_tonic(self) -> float:
@@ -209,11 +303,9 @@ class AgentState:
         valence and arousal, it forgets instantly. This is that memory, decaying
         exponentially from the peak toward zero.
         """
-        if self.dopamine_phasic_peak <= 0.0:
-            return 0.0
-        half_life = max(1e-6, float(getattr(Config, "DOPAMINE_PHASIC_HALFLIFE_S", 90.0)))
-        elapsed = max(0.0, time.time() - self.dopamine_phasic_at)
-        return self.dopamine_phasic_peak * math.exp(-math.log(2.0) * elapsed / half_life)
+        return self._decayed(
+            self.dopamine_phasic_peak, self.dopamine_phasic_at, self.dopamine_halflife_s
+        )
 
     @property
     def dopamine(self) -> float:
@@ -241,17 +333,7 @@ class AgentState:
         free to drift with affect underneath a decaying burst instead of being
         double-counted into it.
         """
-        try:
-            amount = float(amount)
-        except (TypeError, ValueError):
-            return self.dopamine
-        # NaN survives `float()` and then defeats every comparison below:
-        # `nan <= 0.0` is False, so it passes the guard, and `min(1.0, nan)`
-        # returns 1.0 -- a NaN reward would fire a *maximum* burst. Infinity
-        # takes the same route. Both are caller bugs, not rewards.
-        if not math.isfinite(amount):
-            logger.warning("[Endocrine] Ignoring non-finite dopamine release %r.", amount)
-            return self.dopamine
+        amount = self._burst_amount(amount, "dopamine")
         if amount <= 0.0:
             return self.dopamine
 
@@ -291,6 +373,7 @@ class StateService:
             trust_competence=self.persona.initial_trust,
             trust_integrity=self.persona.initial_trust,
             attachment=self.persona.initial_attachment,
+            **self.persona.hormone_halflives(),
         )
         self.last_speculative_intent = None  # Transient sensory state
         # A2: serializes short-term affect mutation so the fire-and-forget

--- a/backend/app/state/agent_state.py
+++ b/backend/app/state/agent_state.py
@@ -1025,6 +1025,43 @@ class StateService:
         )
         await self._persist_sensory_state_if_due()
 
+    async def release_cortisol(self, amount: float, *, reason: str = "") -> float:
+        """Fire an acute stress response under the state lock.
+
+        `AgentState.release_cortisol` is the primitive and does no locking. A
+        fire-and-forget System-2 appraisal writes affect concurrently with the
+        synchronous path (finding A2), and the burst peak is computed *relative
+        to the tonic floor* — so an unlocked release that interleaves with a
+        valence write can measure its peak against a floor that no longer
+        exists and store a burst of the wrong size.
+
+        This is the API stress channels should call. The dopamine equivalent
+        below exists for the same reason.
+        """
+        async with self._state_lock:
+            level = self.current_state.release_cortisol(amount)
+        if reason:
+            logger.info(
+                "[Endocrine] Cortisol released (%s) — now %.2f.", reason, level
+            )
+        return level
+
+    async def release_dopamine(self, amount: float, *, reason: str = "") -> float:
+        """Fire a reward burst under the state lock. See `release_cortisol`.
+
+        `apply_somatic_perception` does not call this: it is already inside the
+        lock and holds it across the valence lift and the burst deliberately,
+        so the peak is measured against the settled tonic. Re-entering here
+        would deadlock on a non-reentrant `asyncio.Lock`.
+        """
+        async with self._state_lock:
+            level = self.current_state.release_dopamine(amount)
+        if reason:
+            logger.info(
+                "[Endocrine] Dopamine released (%s) — now %.2f.", reason, level
+            )
+        return level
+
     async def handle_system_tick(self, tick_metadata: Dict[str, Any]):
         """
         Idle evolution triggered by NATS system.tick.

--- a/backend/tests/test_phasic_cortisol.py
+++ b/backend/tests/test_phasic_cortisol.py
@@ -18,10 +18,13 @@ The first test below is the load-bearing one: with no burst outstanding the
 value is bit-for-bit what it always was, so nothing downstream shifts.
 """
 
+import asyncio
 import math
 import time
+from unittest.mock import AsyncMock
 
 import pytest
+from pydantic import ValidationError
 
 from app.persona import PersonaProfile, Tier
 from app.state.agent_state import AgentState, StateService
@@ -237,7 +240,10 @@ def test_both_half_lives_are_constitutional_persona_fields():
 def test_state_service_seeds_state_half_lives_from_the_persona():
     """The persona's values must actually reach the state that decays."""
     persona = PersonaProfile(dopamine_halflife_s=45.0, cortisol_halflife_s=1200.0)
-    service = StateService(graph_store=None, persona=persona)
+    # ":memory:" so the default constructor does not write state_cache.db into
+    # the working directory, which leaves an artifact and fails outright in a
+    # read-only workspace.
+    service = StateService(graph_store=None, persona=persona, db_path=":memory:")
     assert service.current_state.dopamine_halflife_s == 45.0
     assert service.current_state.cortisol_halflife_s == 1200.0
 
@@ -247,21 +253,107 @@ def test_a_persona_cannot_set_a_half_life_so_short_the_burst_is_never_seen():
 
     The release would fire and decay below any useful threshold before the next
     turn could read it — indistinguishable from the hormone not existing.
+
+    `ValidationError` specifically, not bare `Exception`: a broad catch would
+    also pass if the constructor raised for an unrelated reason — a renamed
+    field, a typo in the keyword — and the test would report the bound as
+    enforced when it had been silently deleted.
     """
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         PersonaProfile(cortisol_halflife_s=0.0)
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         PersonaProfile(dopamine_halflife_s=0.001)
 
 
 def test_a_persona_cannot_set_a_half_life_that_outlives_the_conversation():
     """A burst lasting hours would colour sessions it has nothing to do with."""
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         PersonaProfile(dopamine_halflife_s=99_999.0)
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         PersonaProfile(cortisol_halflife_s=99_999.0)
 
 
 def test_an_unconfigured_deployment_keeps_the_previous_half_life():
     """The dopamine default must not move; it was tuned before this change."""
     assert PersonaProfile.from_config().dopamine_halflife_s == 90.0
+
+
+# --------------------------------------------------------------------------
+# the locked service API
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_service_releases_both_hormones_under_the_state_lock():
+    """Affect mutation must go through StateService, holding `_state_lock`.
+
+    The burst peak is computed *relative to the tonic floor*. A fire-and-forget
+    System-2 appraisal writes valence concurrently with the synchronous path
+    (finding A2), so an unlocked release that interleaves with a valence write
+    measures its peak against a floor that has already moved and stores a burst
+    of the wrong size. These wrappers are the API the stress and reward
+    channels will call.
+    """
+    service = StateService(graph_store=None, db_path=":memory:")
+    service.current_state.mood = 0.0
+
+    assert not service._state_lock.locked()
+    level = await service.release_cortisol(0.3, reason="test")
+    assert level > service.current_state.cortisol_tonic
+    # Released, not merely computed: the burst is outstanding on the state.
+    assert service.current_state.cortisol_phasic_peak > 0.0
+    # And the lock was given back, or every later turn would hang on it.
+    assert not service._state_lock.locked()
+
+    await service.release_dopamine(0.3, reason="test")
+    assert service.current_state.dopamine_phasic_peak > 0.0
+    assert not service._state_lock.locked()
+
+
+@pytest.mark.asyncio
+async def test_somatic_perception_does_not_deadlock_on_the_release_wrapper():
+    """`apply_somatic_perception` already holds the lock across its burst.
+
+    It calls the unlocked `AgentState` primitive on purpose, so the peak is
+    measured against the settled tonic after `_enforce_bounds`. If it were ever
+    switched to the service wrapper, this would hang forever — `asyncio.Lock`
+    is not reentrant — so the test pins the arrangement rather than the comment.
+    """
+    service = StateService(graph_store=None, db_path=":memory:")
+    service._persist_sensory_state_if_due = AsyncMock(return_value=None)
+
+    await asyncio.wait_for(
+        service.apply_somatic_perception(
+            {"valence_spike": 0.2, "arousal_spike": 0.1, "entities": ["mug"]}
+        ),
+        timeout=5.0,
+    )
+    assert service.current_state.dopamine_phasic_peak > 0.0
+    assert not service._state_lock.locked()
+
+
+@pytest.mark.asyncio
+async def test_a_release_waits_for_a_held_state_lock():
+    """Proves the wrapper actually acquires the lock, rather than merely
+    leaving it free.
+
+    The obvious assertion — that `_state_lock` is unlocked after the call —
+    passes whether or not the wrapper ever took it, so it cannot detect the
+    lock being dropped. Holding the lock and showing the release *blocks* is
+    the only version of this test with any detection power.
+    """
+    service = StateService(graph_store=None, db_path=":memory:")
+
+    async with service._state_lock:
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(service.release_cortisol(0.3), timeout=0.25)
+        # Blocked, so nothing was written while another writer held the lock.
+        assert service.current_state.cortisol_phasic_peak == 0.0
+
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(service.release_dopamine(0.3), timeout=0.25)
+        assert service.current_state.dopamine_phasic_peak == 0.0
+
+    # Released once the lock is free again.
+    assert await service.release_cortisol(0.3) > 0.0
+    assert service.current_state.cortisol_phasic_peak > 0.0

--- a/backend/tests/test_phasic_cortisol.py
+++ b/backend/tests/test_phasic_cortisol.py
@@ -1,0 +1,267 @@
+"""
+Phasic cortisol — stress that outlives the thing that caused it.
+
+`cortisol` was a pure function of valence and fatigue, which made it the exact
+mirror image of tonic dopamine: both derived from valence alone, one rising
+precisely as the other fell. Two consequences, both wrong.
+
+First, stress could not outlive its cause. Recover your mood and the alarm
+stopped instantly and completely, which is not how a threat response works —
+the HPA axis clears on its own schedule, not the mood's.
+
+Second, the agent could never be stressed and rewarded at once, because the
+formulae made that arithmetically impossible. Plenty of ordinary experience is
+exactly that combination. Phasic dopamine broke the coupling in one direction;
+this is the other half.
+
+The first test below is the load-bearing one: with no burst outstanding the
+value is bit-for-bit what it always was, so nothing downstream shifts.
+"""
+
+import math
+import time
+
+import pytest
+
+from app.persona import PersonaProfile, Tier
+from app.state.agent_state import AgentState, StateService
+
+
+def _old_derived_cortisol(state: AgentState) -> float:
+    """The formula exactly as it stood before phasic cortisol existed."""
+    base = 0.5 - (state.valence / 2.0)
+    return max(0.0, min(1.0, base + 0.3 * state.fatigue))
+
+
+# --------------------------------------------------------------------------
+# backward compatibility
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "mood,fatigue",
+    [(0.8, 0.0), (-0.5, 0.4), (1.0, 1.0), (-1.0, 0.0), (0.0, 0.5), (0.33, 0.66)],
+)
+def test_without_a_burst_cortisol_is_exactly_the_old_derived_value(mood, fatigue):
+    """No burst outstanding must be indistinguishable from the old behaviour.
+
+    Every consumer of `cortisol` — the LLM temperature mapping, the memory
+    stress-suppression term, the surfacing agent's vocal modulation — was
+    tuned against the derived formula. If an unstressed agent reads even
+    slightly differently now, all of them shift underneath at once.
+    """
+    state = AgentState(mood=mood, fatigue=fatigue)
+    assert state.cortisol_phasic == 0.0
+    assert state.cortisol == pytest.approx(_old_derived_cortisol(state))
+
+
+def test_a_fresh_state_carries_no_outstanding_stress():
+    """A restored or newly constructed agent must not start out alarmed."""
+    assert AgentState().cortisol_phasic_peak == 0.0
+    assert AgentState().cortisol_phasic == 0.0
+
+
+# --------------------------------------------------------------------------
+# release
+# --------------------------------------------------------------------------
+
+
+def test_releasing_cortisol_raises_the_level_by_the_requested_amount():
+    """A stress event must actually move the hormone, not just the mood."""
+    state = AgentState(mood=0.0, fatigue=0.0)
+    before = state.cortisol
+    after = state.release_cortisol(0.3)
+    assert after == pytest.approx(before + 0.3)
+
+
+def test_cortisol_cannot_be_driven_above_one():
+    """Saturation is the ceiling of the range, not an unbounded accumulator."""
+    state = AgentState(mood=-1.0, fatigue=1.0)
+    assert state.release_cortisol(0.9) == pytest.approx(1.0)
+
+
+def test_stress_survives_the_mood_recovering():
+    """The whole point: cortisol must not vanish the moment valence returns.
+
+    This is the failure the tonic-only formula had. If this regresses, an agent
+    that was just frightened reads as perfectly calm the instant its mood
+    drifts back up, and nothing downstream can tell the difference.
+    """
+    # Deliberately not starting at maximum stress: a burst on top of an
+    # already-saturated tonic is clipped by the 1.0 ceiling, which would make
+    # this test measure the clip rather than the survival.
+    state = AgentState(mood=-0.3, fatigue=0.0)
+    state.release_cortisol(0.2)
+    state.mood = 0.9  # the cause is gone
+    assert state.cortisol_tonic == pytest.approx(0.05)
+    assert state.cortisol_phasic > 0.15
+    assert state.cortisol > state.cortisol_tonic
+
+
+def test_an_agent_can_be_stressed_and_rewarded_at_the_same_time():
+    """Tonic dopamine and tonic cortisol are anti-correlated by construction.
+
+    Before the phasic terms, high cortisol *entailed* low dopamine and vice
+    versa, so a state like "this is going well and I am also on edge" was not
+    representable at all. Both bursts outstanding must produce it.
+    """
+    state = AgentState(mood=0.0, energy=0.5, fatigue=0.0)
+    state.release_dopamine(0.4)
+    state.release_cortisol(0.4)
+    assert state.dopamine > 0.35
+    assert state.cortisol > 0.85
+
+
+# --------------------------------------------------------------------------
+# rejection of unusable amounts
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("amount", [0.0, -0.1, -5.0])
+def test_a_non_positive_release_is_ignored(amount):
+    """`release_cortisol` fires stress; it is not a way to remove it."""
+    state = AgentState(mood=0.2)
+    before = state.cortisol
+    assert state.release_cortisol(amount) == pytest.approx(before)
+    assert state.cortisol_phasic_peak == 0.0
+
+
+@pytest.mark.parametrize("amount", [float("nan"), float("inf"), float("-inf")])
+def test_a_non_finite_release_cannot_fire_a_maximum_stress_response(amount):
+    """NaN defeats every guard downstream and would saturate the hormone.
+
+    `nan <= 0.0` is False so it passes the positivity check, and
+    `min(1.0, nan)` returns 1.0 — so without an explicit finiteness guard a
+    malformed stress signal produces the *maximum possible* stress response,
+    the worst available reading of a caller bug. It would then pin the LLM
+    temperature to its floor for the whole half-life.
+    """
+    state = AgentState(mood=0.2)
+    assert not math.isnan(state.release_cortisol(amount))
+    assert state.cortisol_phasic_peak == 0.0
+
+
+@pytest.mark.parametrize("amount", ["a lot", None, object()])
+def test_a_non_numeric_release_is_ignored(amount):
+    """A malformed payload must not crash the cognitive turn."""
+    state = AgentState(mood=0.2)
+    before = state.cortisol
+    assert state.release_cortisol(amount) == pytest.approx(before)
+    assert state.cortisol_phasic_peak == 0.0
+
+
+def test_a_non_finite_release_does_not_clear_an_existing_burst():
+    """A bad signal must leave real outstanding stress untouched."""
+    state = AgentState(mood=0.0)
+    state.release_cortisol(0.5)
+    peak = state.cortisol_phasic_peak
+    state.release_cortisol(float("nan"))
+    assert state.cortisol_phasic_peak == pytest.approx(peak)
+
+
+# --------------------------------------------------------------------------
+# decay
+# --------------------------------------------------------------------------
+
+
+def test_stress_halves_after_exactly_one_half_life():
+    """Decay is computed from wall-clock, so it is correct even if ticks stall."""
+    state = AgentState(mood=0.0, cortisol_halflife_s=100.0)
+    state.release_cortisol(0.4)
+    peak = state.cortisol_phasic_peak
+    state.cortisol_phasic_at = time.time() - 100.0
+    assert state.cortisol_phasic == pytest.approx(peak / 2.0, abs=1e-3)
+
+
+def test_stress_decays_toward_zero_and_not_below():
+    """A long-past burst must leave the tonic reading, not a negative one."""
+    state = AgentState(mood=0.0, cortisol_halflife_s=10.0)
+    state.release_cortisol(0.5)
+    state.cortisol_phasic_at = time.time() - 10_000.0
+    assert state.cortisol_phasic == pytest.approx(0.0, abs=1e-6)
+    assert state.cortisol == pytest.approx(state.cortisol_tonic)
+
+
+def test_a_longer_half_life_holds_stress_longer():
+    """Half-life is the knob that makes one temperament slower to settle."""
+    elapsed = 60.0
+    quick = AgentState(mood=0.0, cortisol_halflife_s=30.0)
+    slow = AgentState(mood=0.0, cortisol_halflife_s=600.0)
+    for state in (quick, slow):
+        state.release_cortisol(0.5)
+        state.cortisol_phasic_at = time.time() - elapsed
+    assert slow.cortisol_phasic > quick.cortisol_phasic
+
+
+def test_cortisol_clears_slower_than_dopamine_by_default():
+    """A fright has a hangover; a pleasure mostly does not.
+
+    If these defaults were ever equalised the endocrine layer would go back to
+    describing a creature whose good and bad moments fade at identical rates,
+    which is the symmetry the split exists to break.
+    """
+    assert AgentState().cortisol_halflife_s > AgentState().dopamine_halflife_s
+
+
+def test_the_tonic_floor_drifts_underneath_an_outstanding_burst():
+    """The burst is stored relative to tonic, not absolutely.
+
+    If it were absolute, mood movement during a burst would be double-counted
+    into the total and the agent would read as far more stressed than either
+    the mood or the event alone warrants.
+    """
+    state = AgentState(mood=0.0, fatigue=0.0)
+    state.release_cortisol(0.2)
+    peak = state.cortisol_phasic_peak
+    state.mood = -0.6  # tonic rises on its own
+    assert state.cortisol_phasic_peak == pytest.approx(peak)
+    assert state.cortisol == pytest.approx(state.cortisol_tonic + state.cortisol_phasic)
+
+
+# --------------------------------------------------------------------------
+# half-lives are persona, not deployment config
+# --------------------------------------------------------------------------
+
+
+def test_both_half_lives_are_constitutional_persona_fields():
+    """How long feeling lingers is temperament, not an env var.
+
+    Leaving these in Config would mean one process can host exactly one
+    emotional metabolism, which is the constraint PersonaProfile exists to
+    remove.
+    """
+    assert PersonaProfile.tier_of("dopamine_halflife_s") is Tier.CONSTITUTIONAL
+    assert PersonaProfile.tier_of("cortisol_halflife_s") is Tier.CONSTITUTIONAL
+
+
+def test_state_service_seeds_state_half_lives_from_the_persona():
+    """The persona's values must actually reach the state that decays."""
+    persona = PersonaProfile(dopamine_halflife_s=45.0, cortisol_halflife_s=1200.0)
+    service = StateService(graph_store=None, persona=persona)
+    assert service.current_state.dopamine_halflife_s == 45.0
+    assert service.current_state.cortisol_halflife_s == 1200.0
+
+
+def test_a_persona_cannot_set_a_half_life_so_short_the_burst_is_never_seen():
+    """A near-zero half-life is a broken hormone, not a fast temperament.
+
+    The release would fire and decay below any useful threshold before the next
+    turn could read it — indistinguishable from the hormone not existing.
+    """
+    with pytest.raises(Exception):
+        PersonaProfile(cortisol_halflife_s=0.0)
+    with pytest.raises(Exception):
+        PersonaProfile(dopamine_halflife_s=0.001)
+
+
+def test_a_persona_cannot_set_a_half_life_that_outlives_the_conversation():
+    """A burst lasting hours would colour sessions it has nothing to do with."""
+    with pytest.raises(Exception):
+        PersonaProfile(dopamine_halflife_s=99_999.0)
+    with pytest.raises(Exception):
+        PersonaProfile(cortisol_halflife_s=99_999.0)
+
+
+def test_an_unconfigured_deployment_keeps_the_previous_half_life():
+    """The dopamine default must not move; it was tuned before this change."""
+    assert PersonaProfile.from_config().dopamine_halflife_s == 90.0


### PR DESCRIPTION
Steps 2 and 3 of the agreed sequence, deliberately combined. Keeping them apart would have put `CORTISOL_PHASIC_HALFLIFE_S` into `Config` in one PR only to move it out in the next — shipping debt in order to pay it off immediately. Together, the rule "hormone half-lives live in the persona" arrives whole rather than as a half-rule with an exception.

## The problem

`cortisol` was `0.5 - valence/2 + 0.3*fatigue` — a pure function of current affect, exactly like tonic dopamine, and derived from the same variable in the opposite direction. Two things followed that nobody chose:

1. **Stress could not outlive its cause.** Recover your mood and the alarm stopped instantly and completely. The HPA axis clears on its own schedule, not the mood's.
2. **The agent could never be stressed and rewarded at once.** The two formulae made it arithmetically impossible — one rose exactly as the other fell. "This is going well and I am also on edge" was not a representable state, despite describing a great deal of ordinary experience.

PR #70 broke the coupling in one direction by giving dopamine a phasic term. This is the symmetric half.

## What changed

`cortisol` = `cortisol_tonic` (the old formula, untouched) + `cortisol_phasic`, a burst fired by `release_cortisol()` and decaying exponentially from **wall-clock elapsed time** rather than tick decrement, so the reading stays correct when `system.tick` stalls and decay is testable without a clock stub.

The burst is stored relative to the tonic floor, so that floor stays free to drift with affect underneath a decaying burst instead of being double-counted into it.

**Both half-lives moved into `PersonaProfile`** as CONSTITUTIONAL fields, closing the open item from #71. `Config` keeps both keys as the defaults a profile inherits, so no existing `.env` breaks — the same pattern #71 used for the `PSYCH_*` coefficients.

Cortisol's default (600s) is much longer than dopamine's (90s), deliberately: a fright has a hangover, a pleasure mostly does not. There is a test on the *inequality* rather than the numbers, since equalising them would silently restore the symmetry this change exists to break.

Bounds are floored at 5s — a near-zero half-life is not a fast temperament but a broken hormone, since the burst would decay below any readable threshold before the next turn — and capped so a burst cannot outlive the conversation that caused it.

Decay and release-amount validation are now **shared helpers** used by both hormones. Two independent copies would each read plausibly on its own, so a fix landing on only one would be subtle and long-lived. The non-finite guard from #70 is preserved through the refactor: NaN passes `<= 0.0` and `min(1.0, nan)` returns 1.0, so without it a malformed signal fires a *maximum* stress response and pins the LLM temperature to its floor for a full half-life.

## Verification

`tests/test_phasic_cortisol.py`, **31 tests**. Five mutations applied, all caught:

| Mutation | Failures |
|---|---|
| `cortisol` drops the phasic term (regress to tonic-only) | 4 |
| non-finite guard removed | 1 |
| burst stored absolutely, not relative to tonic | 2 |
| persona half-lives not seeded into state | 1 |
| cortisol half-life bounds removed | 2 |

The load-bearing test is the backward-compatibility one: with no burst outstanding, `cortisol` is bit-for-bit the old derived value across a parametrized sweep. Every consumer was tuned against that formula and they would all shift underneath at once otherwise.

**One test was wrong on first run and the code was right** — worth stating explicitly. `test_stress_survives_the_mood_recovering` started at `mood=-0.8`, where tonic is already 0.9, so the 0.2 burst was clipped to 0.1 by the ceiling and the test measured the clip rather than the survival. Fixed by starting from a non-saturated mood, with a comment recording why the fixture value carries weight.

Full backend suite: **499 passed, 0 failures** (468 + 31). `ruff check .` clean. Counts taken from `--junit-xml`; this environment truncates pytest's terminal summary.

## Not done

`release_cortisol` **has no callers yet** — this is the mechanism, not the behaviour. The stress channels that should fire it (validation failures, boundary violations, repeated self-correction, user frustration) are the next change in the sequence, and `release_dopamine` still has exactly one channel. A hormone with no channel is still only a formula, and this PR does not pretend otherwise.

Phasic state remains unpersisted across restart, unchanged from #70 and for the same reason: both half-lives are minutes-scale, so any realistic restart outlasts the burst, and `peak=0.0` restores as "nothing outstanding" rather than as a stale threat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added phasic cortisol dynamics, including stress-triggered release and gradual decay over time.
  * Added configurable dopamine and cortisol half-life settings to persona profiles.
  * Cortisol now combines baseline and phasic levels while remaining within safe bounds.

* **Bug Fixes**
  * Improved handling of invalid or non-finite hormone release values.
  * Ensured hormone decay remains accurate even when regular updates are delayed.

* **Tests**
  * Added comprehensive coverage for cortisol release, decay, limits, validation, compatibility, and concurrent dopamine activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->