### PR TITLE
refactor(prosody): one source of truth; delete Python's dead divergent copy

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -2977,3 +2977,26 @@ a follow-up contract PR, gated on checking the frontend and any external
 consumer. `AgentVoiceModulation`/`ProsodyFrame` in `surfacing_agent` is a
 separate trajectory path and was not touched.
 
+### Review round (PR #74)
+
+CodeRabbit flagged the end-to-end test as under-asserting: it fed `trust`,
+`attachment` and `emotion` into the state snapshot and never checked they reached
+the wire, and it verified only two of the four deprecated prosody fields were
+inert. Correct on both counts. Mutation-tested before and after to be sure the
+gap was real rather than theoretical: dropping `trust`, `emotion`, or
+`attachment` from `brain_agent._publish_speech_chunk`, and repopulating
+`intensity`, all **survived** the old test and all fail the new one. Only the
+`speaking_rate` mutation had been caught. Four real gaps, not style.
+
+Chasing those mutations surfaced something the review did not mention:
+`brain_agent._publish_speech_chunk` builds its own `ChatOutput` rather than
+calling `SpeechCoordinator.create_chunk_payload`, so the affect vector is
+constructed twice from the same keys with the same defaults. That is the exact
+shape of the bug this PR removes for prosody — two implementations, one
+consumed — and it is why a mutation in `speech.py` left the end-to-end test
+green. It has not drifted yet. Left alone here deliberately: collapsing it
+touches the brain's streaming hot path and belongs in its own PR rather than
+riding along with a test fix.
+
+Full backend suite: **505 passed**, `ruff check .` clean.
+

--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -2815,3 +2815,57 @@ unified, and the narrative half remains unbounded. `DOPAMINE_PHASIC_HALFLIFE_S`
 (PR #70) is temperament by rights and belongs in the profile, but was left out to
 avoid stacking branches again. Restored Neo4j baselines bypass persona bounds by
 design — the profile seeds a new friend, it does not clamp a lived one.
+
+## 2026-07-18 Prosody gets one source; Python's copy was dead and wrong
+
+`SpeechCoordinator.map_affect_to_prosody` computed speaking rate, intensity,
+pause bias and confidence, attached them to every `ChatOutput`, and shipped them
+across NATS. Nothing read them. The voice agent derives prosody itself from the
+`affect` vector via `contracts::vad_to_prosody` (Rust), and a grep of the crates
+for reads of `speaking_rate`, `pause_bias` or `intensity` returns nothing.
+
+The two implementations had also drifted, which is the part that mattered:
+
+- Python: `rate = 1.0 + 0.20*Ar - 0.10*V - 0.25*F` — linear.
+- Rust: `rate = 1.0 + tanh(0.20*Ar - 0.10*V - 0.25*F)` — saturated.
+
+Rust additionally models pitch, volume and user-distance adaptation (whisper
+under 0.6m, call-out over 1.5m) that had no Python counterpart at all. Both
+carried the same `Continuous formulas from CVS-3.5 Roadmap` comment, so the
+disagreement did not read as one. Anyone opening `speech.py` to learn how fast
+this agent talks got an answer that had never been true in production — the same
+class of problem as the `[TBP]` benchmark numbers, code that reads as
+authoritative and is not.
+
+Python now emits only the affect vector. The four `ChatOutput` prosody fields are
+kept at their defaults and marked deprecated in `contracts.py` rather than
+removed: removing them is a wire-contract change requiring
+`setup_nats_streams.py` to be re-run, and it is a separable decision. They are
+now inert rather than carrying a stale second opinion.
+
+### Verification
+
+`tests/test_phase4_features.py` rewritten (3 tests → 6). The old ones asserted
+Python's formulas to five decimal places, were green for the life of the project,
+and proved nothing about the running system; worse, they made the dead code look
+load-bearing. The new ones pin the contract that actually exists — a complete
+affect vector, no prosody — plus the legacy `mood`/`energy` key fallback and the
+absent-snapshot path.
+
+Four mutations applied, all caught: reintroducing a Python prosody implementation
+and repopulating the wire fields (2 failures), dropping `user_distance` from the
+affect vector (1), removing the legacy `mood`/`energy` fallback (1), and dropping
+`user_distance` in `brain_agent._publish_speech_chunk` (1).
+
+That last one initially reported as *surviving*. The mutation script's
+`str.replace(..., 1)` had not applied at all — a mutation that changes nothing is
+a failed edit, not a gap in the tests. Retargeted at the exact line, it fails as
+expected. Worth recording because "mutation survived" and "mutation never
+applied" look identical in a results table.
+
+Full backend suite: **471 passed** (468 - 3 + 6), `ruff check .` clean.
+
+**NOT done:** the four deprecated fields are still on the wire. Removing them is
+a follow-up contract PR, gated on checking the frontend and any external
+consumer. `AgentVoiceModulation`/`ProsodyFrame` in `surfacing_agent` is a
+separate trajectory path and was not touched.

--- a/backend/app/agents/brain_agent.py
+++ b/backend/app/agents/brain_agent.py
@@ -696,17 +696,14 @@ class BrainAgent(BaseAgent):
             return
 
         state_snap = self.cognitive_core.state.get_context_snapshot()
-        prosody = self.coordinator.map_affect_to_prosody(state_snap)
 
-        # Full §5.3 Affect Metadata Contract
+        # Full §5.3 Affect Metadata Contract. Prosody is not attached here: the
+        # voice agent derives it from `affect` via `contracts::vad_to_prosody`
+        # and never read what Python sent. See SpeechCoordinator's docstring.
         payload = ChatOutput(
             content=text,
             done=False,
             turn_id=turn_id,
-            confidence=prosody["confidence"],
-            intensity=prosody["intensity"],
-            speaking_rate=prosody["speaking_rate"],
-            pause_bias=prosody["pause_bias"],
             affect=ChatOutputAffect(
                 valence=state_snap.get("valence", state_snap.get("mood", 0.0)),
                 arousal=state_snap.get("arousal", state_snap.get("energy", 0.5)),

--- a/backend/app/contracts.py
+++ b/backend/app/contracts.py
@@ -94,6 +94,17 @@ class ChatOutput(BaseModel):
     affect: Optional[ChatOutputAffect] = None
 
     # Prosody & Signals
+    #
+    # DEPRECATED, and no longer written by any producer. Prosody has a single
+    # source: the voice agent computes it from `affect` above via
+    # `contracts::vad_to_prosody` (Rust). Python used to populate these too,
+    # with a formula that disagreed with the Rust one, and nothing ever read
+    # them -- see SpeechCoordinator's docstring.
+    #
+    # Retained at their defaults rather than removed, so an older consumer
+    # deserializing a new message still finds the fields it expects. They carry
+    # no information: do not read them, and do not repopulate them. Removing
+    # them is a wire-contract change and needs `setup_nats_streams.py` re-run.
     confidence: float = 1.0
     intensity: float = 0.0
     speaking_rate: float = 1.0

--- a/backend/app/utils/speech.py
+++ b/backend/app/utils/speech.py
@@ -4,34 +4,28 @@ from ..contracts import ChatOutput, ChatOutputAffect
 
 class SpeechCoordinator:
     """
-    Coordinates text-to-speech chunking and prosody mapping.
-    Maps emotional state to speaking rate, intensity, and pause bias.
+    Coordinates text-to-speech chunking and attaches the affect vector.
+
+    Prosody is deliberately *not* computed here. The voice agent derives it
+    from `affect` via `contracts::vad_to_prosody` (Rust) and has never read the
+    values this class used to attach, so the second implementation on this side
+    produced output that crossed the wire and went straight into the bin.
+
+    Worse, the two had drifted apart. This computed a *linear* speaking rate
+    (`1.0 + 0.20·Ar - 0.10·V - 0.25·F`) while Rust computes a `tanh`-saturated
+    one over the same terms, and Rust additionally models pitch, volume, and
+    user-distance adaptation that had no counterpart here at all. Both carried
+    the same "Continuous formulas from CVS-3.5 Roadmap" comment, so the
+    disagreement did not look like one. Anyone reading this file to learn how
+    fast the agent talks got an answer that had never been true in production.
+
+    The fix is one implementation, not a better second one: emit the affect
+    vector and let the single prosody mapping consume it.
     """
 
     def __init__(self, segmenter, formation_buffer_ms: float = 0.030):
         self.segmenter = segmenter
         self.formation_buffer_ms = formation_buffer_ms
-
-    def map_affect_to_prosody(self, state_snap: Dict[str, Any]) -> Dict[str, float]:
-        """§5.1: Continuous PAD-to-prosody formulas."""
-        V = state_snap.get("valence", state_snap.get("mood", 0.0))
-        Ar = state_snap.get("arousal", state_snap.get("energy", 0.5))
-        F = state_snap.get("fatigue", 0.0)
-
-        # Continuous formulas from CVS-3.5 Roadmap:
-        # Sr = 1.0 + (0.20 * arousal) - (0.10 * valence) - (0.25 * fatigue)
-        speaking_rate = max(0.6, min(1.8, 1.0 + (0.20 * Ar) - (0.10 * V) - (0.25 * F)))
-        confidence = 0.9  # Baseline
-        intensity = abs(V) * Ar
-        # pause_bias = 1.0 - arousal
-        pause_bias = max(0.0, min(1.0, 1.0 - Ar))
-
-        return {
-            "speaking_rate": round(speaking_rate, 3),
-            "intensity": round(intensity, 3),
-            "pause_bias": round(pause_bias, 3),
-            "confidence": confidence,
-        }
 
     def create_chunk_payload(
         self,
@@ -45,33 +39,23 @@ class SpeechCoordinator:
         user_distance: float = None,
     ) -> ChatOutput:
         text = " ".join(words).strip() if words else None
-        prosody = self.map_affect_to_prosody(state_snap or {})
+        state_snap = state_snap or {}
 
         return ChatOutput(
             content=text,
             done=done,
             turn_id=turn_id,
-            confidence=prosody["confidence"],
-            intensity=prosody["intensity"],
-            speaking_rate=prosody["speaking_rate"],
-            pause_bias=prosody["pause_bias"],
             full_response=full_response,
             generation_error=generation_error,
             proactive=proactive,
             affect=ChatOutputAffect(
-                valence=state_snap.get("valence", state_snap.get("mood", 0.0))
-                if state_snap
-                else 0.0,
-                arousal=state_snap.get("arousal", state_snap.get("energy", 0.5))
-                if state_snap
-                else 0.5,
-                dominance=state_snap.get("dominance", 0.5) if state_snap else 0.5,
-                trust=state_snap.get("trust", 0.5) if state_snap else 0.5,
-                attachment=state_snap.get("attachment", 0.1) if state_snap else 0.1,
-                emotion=state_snap.get("emotion", "neutral")
-                if state_snap
-                else "neutral",
-                fatigue=state_snap.get("fatigue", 0.0) if state_snap else 0.0,
+                valence=state_snap.get("valence", state_snap.get("mood", 0.0)),
+                arousal=state_snap.get("arousal", state_snap.get("energy", 0.5)),
+                dominance=state_snap.get("dominance", 0.5),
+                trust=state_snap.get("trust", 0.5),
+                attachment=state_snap.get("attachment", 0.1),
+                emotion=state_snap.get("emotion", "neutral"),
+                fatigue=state_snap.get("fatigue", 0.0),
                 user_distance=user_distance,
             ),
         )

--- a/backend/tests/test_phase4_features.py
+++ b/backend/tests/test_phase4_features.py
@@ -153,14 +153,25 @@ async def test_brain_agent_publishes_the_affect_vector_to_chat_output():
     assert parsed.done is False
     assert parsed.turn_id == "turn-5"
 
+    # Every field the snapshot supplied, because affect is now the whole
+    # contract: anything dropped between here and the wire is a change in how
+    # the agent sounds that nothing else would catch.
     assert parsed.affect.valence == -0.2
     assert parsed.affect.arousal == 0.6
     assert parsed.affect.dominance == 0.4
+    assert parsed.affect.trust == 0.7
+    assert parsed.affect.attachment == 0.2
+    assert parsed.affect.emotion == "sad"
     assert parsed.affect.fatigue == 0.4
     # Distance drives the whisper/call-out volume and pitch shift in Rust, so
     # losing it here silently flattens how the agent projects.
     assert parsed.affect.user_distance == 1.8
 
-    # The brain must not attach a second opinion on prosody.
-    assert parsed.speaking_rate == ChatOutput().speaking_rate
-    assert parsed.pause_bias == ChatOutput().pause_bias
+    # The brain must not attach a second opinion on prosody. All four, not the
+    # two that happen to be most visible — a repopulated `intensity` would be
+    # believed by a reader and disagree with what the voice agent computes.
+    defaults = ChatOutput()
+    assert parsed.speaking_rate == defaults.speaking_rate
+    assert parsed.pause_bias == defaults.pause_bias
+    assert parsed.intensity == defaults.intensity
+    assert parsed.confidence == defaults.confidence

--- a/backend/tests/test_phase4_features.py
+++ b/backend/tests/test_phase4_features.py
@@ -1,5 +1,18 @@
 """
-Comprehensive tests for Phase 4: Dynamic Continuous Prosody Mapping, verifying Python-side PAD formulas.
+The Brain→Voice affect contract, and prosody having exactly one source.
+
+This file used to assert Python's PAD-to-prosody formulas in fine numeric
+detail. Those assertions were green for the life of the project and proved
+nothing about the running system: the voice agent computes prosody itself from
+the `affect` vector via `contracts::vad_to_prosody` (Rust) and never read the
+values Python attached. The two implementations had also drifted — Python's
+speaking rate was linear where Rust's is `tanh`-saturated, and Rust models
+pitch, volume, and distance adaptation that Python did not have at all.
+
+So the tests here now pin the contract that actually exists: the brain emits a
+complete and accurate **affect vector**, and does not emit prosody. A test
+asserting a formula nobody consumes is worse than no test, because it makes
+dead code look load-bearing and dares the next reader to delete it.
 """
 
 import pytest
@@ -11,143 +24,34 @@ from app.contracts import ChatOutput, ChatOutputAffect
 from app.agents.brain_agent import BrainAgent
 
 
-def test_speech_coordinator_continuous_formulas():
-    """Verify that SpeechCoordinator computes correct continuous PAD formulas with fatigue slowdown."""
+def test_the_coordinator_no_longer_computes_prosody():
+    """Python must not grow a second prosody implementation again.
+
+    If this method returns, the system once more has two disagreeing answers to
+    "how fast does the agent talk", only one of which reaches the speaker.
+    """
+    assert not hasattr(SpeechCoordinator, "map_affect_to_prosody")
+
+
+def test_a_chunk_payload_carries_the_full_affect_vector():
+    """Affect is the real contract: it is the sole input to Rust prosody.
+
+    Every field here is read by `vad_to_prosody`, so a value silently dropped
+    or defaulted on this side changes how the agent sounds.
+    """
     coordinator = SpeechCoordinator(segmenter=HybridSegmenter(target_size=8))
-
-    # 1. Baseline/Neutral state
-    state_snap = {
-        "valence": 0.0,
-        "arousal": 0.5,
-        "dominance": 0.5,
-        "fatigue": 0.0,
-    }
-    prosody = coordinator.map_affect_to_prosody(state_snap)
-    # Sr = 1.0 + 0.20 * Ar - 0.10 * V - 0.25 * F = 1.0 + 0.20*0.5 - 0.0 - 0.0 = 1.10
-    assert abs(prosody["speaking_rate"] - 1.10) < 1e-5
-    assert abs(prosody["pause_bias"] - 0.5) < 1e-5
-    assert abs(prosody["intensity"] - 0.0) < 1e-5
-
-    # 2. Excited/Positive state
-    state_snap_excited = {
-        "valence": 0.8,
-        "arousal": 0.9,
-        "dominance": 0.7,
-        "fatigue": 0.0,
-    }
-    prosody_excited = coordinator.map_affect_to_prosody(state_snap_excited)
-    # Sr = 1.0 + 0.20 * 0.9 - 0.10 * 0.8 - 0.0 = 1.0 + 0.18 - 0.08 = 1.10
-    assert abs(prosody_excited["speaking_rate"] - 1.10) < 1e-5
-    assert abs(prosody_excited["pause_bias"] - 0.1) < 1e-5
-    assert abs(prosody_excited["intensity"] - 0.72) < 1e-5
-
-    # 3. Fatigued/Stressed state
-    state_snap_tired = {
-        "valence": -0.4,
-        "arousal": 0.8,
-        "dominance": 0.3,
-        "fatigue": 0.8,
-    }
-    prosody_tired = coordinator.map_affect_to_prosody(state_snap_tired)
-    # Sr = 1.0 + (0.20 * arousal) - (0.10 * valence) - (0.25 * fatigue) = 1.0 + 0.16 + 0.04 - 0.20 = 1.00
-    assert abs(prosody_tired["speaking_rate"] - 1.00) < 1e-5
-    assert abs(prosody_tired["pause_bias"] - 0.2) < 1e-5
-    assert abs(prosody_tired["intensity"] - 0.32) < 1e-5
-
-    # (1) Max fatigue (fatigue=1.0) with high arousal (arousal=0.9)
-    # Sr = 1.0 + 0.20 * Ar - 0.10 * V - 0.25 * F = 1.0 + 0.20 * 0.9 - 0.10 * 0.5 - 0.25 * 1.0 = 0.88
-    # Intensity = |V| * Ar = |0.5| * 0.9 = 0.45
-    # Pause Bias = clamp(1.0 - Ar, 0, 1) = clamp(1.0 - 0.9, 0, 1) = 0.10
-    state_snap_max_fatigue = {
-        "valence": 0.5,
-        "arousal": 0.9,
-        "dominance": 0.5,
-        "fatigue": 1.0,
-    }
-    prosody_fatigue = coordinator.map_affect_to_prosody(state_snap_max_fatigue)
-    assert abs(prosody_fatigue["speaking_rate"] - 0.880) < 1e-5
-    assert abs(prosody_fatigue["pause_bias"] - 0.100) < 1e-5
-    assert abs(prosody_fatigue["intensity"] - 0.450) < 1e-5
-
-    # (2) Zero arousal (arousal=0.0) combined with varying valence
-    # Case A: Positive valence (valence=0.5)
-    # Sr = 1.0 + 0.20 * 0.0 - 0.10 * 0.5 - 0.25 * 0.0 = 0.95
-    # Intensity = |V| * Ar = |0.5| * 0.0 = 0.00
-    # Pause Bias = clamp(1.0 - Ar, 0, 1) = clamp(1.0 - 0.0, 0, 1) = 1.00
-    state_snap_zero_arousal_pos = {
-        "valence": 0.5,
-        "arousal": 0.0,
-        "dominance": 0.5,
-        "fatigue": 0.0,
-    }
-    prosody_zero_ar_pos = coordinator.map_affect_to_prosody(state_snap_zero_arousal_pos)
-    assert abs(prosody_zero_ar_pos["speaking_rate"] - 0.950) < 1e-5
-    assert abs(prosody_zero_ar_pos["pause_bias"] - 1.000) < 1e-5
-    assert abs(prosody_zero_ar_pos["intensity"] - 0.000) < 1e-5
-
-    # Case B: Negative valence (valence=-0.8)
-    # Sr = 1.0 + 0.20 * 0.0 - 0.10 * -0.8 - 0.25 * 0.0 = 1.08
-    # Intensity = |V| * Ar = |-0.8| * 0.0 = 0.00
-    # Pause Bias = clamp(1.0 - Ar, 0, 1) = clamp(1.0 - 0.0, 0, 1) = 1.00
-    state_snap_zero_arousal_neg = {
-        "valence": -0.8,
-        "arousal": 0.0,
-        "dominance": 0.5,
-        "fatigue": 0.0,
-    }
-    prosody_zero_ar_neg = coordinator.map_affect_to_prosody(state_snap_zero_arousal_neg)
-    assert abs(prosody_zero_ar_neg["speaking_rate"] - 1.080) < 1e-5
-    assert abs(prosody_zero_ar_neg["pause_bias"] - 1.000) < 1e-5
-    assert abs(prosody_zero_ar_neg["intensity"] - 0.000) < 1e-5
-
-    # (3) Negative/edge dominance values (e.g. dominance=-1.0)
-    # Sr = 1.0 + 0.20 * 0.6 - 0.10 * 0.4 - 0.25 * 0.2 = 1.03
-    # Intensity = |V| * Ar = |0.4| * 0.6 = 0.24
-    # Pause Bias = clamp(1.0 - Ar, 0, 1) = clamp(1.0 - 0.6, 0, 1) = 0.40
-    state_snap_neg_dom = {
-        "valence": 0.4,
-        "arousal": 0.6,
-        "dominance": -1.0,
-        "fatigue": 0.2,
-    }
-    prosody_neg_dom = coordinator.map_affect_to_prosody(state_snap_neg_dom)
-    assert abs(prosody_neg_dom["speaking_rate"] - 1.030) < 1e-5
-    assert abs(prosody_neg_dom["pause_bias"] - 0.400) < 1e-5
-    assert abs(prosody_neg_dom["intensity"] - 0.240) < 1e-5
-
-    # (4) Out-of-range input (e.g., arousal=1.5, valence=-1.5)
-    # Sr = max(0.6, min(1.8, 1.0 + 0.20 * 1.5 - 0.10 * -1.5)) = max(0.6, min(1.8, 1.45)) = 1.45
-    # Intensity = |V| * Ar = |-1.5| * 1.5 = 2.25
-    # Pause Bias = clamp(1.0 - Ar, 0, 1) = clamp(1.0 - 1.5, 0, 1) = 0.00
-    state_snap_out_of_range = {
-        "valence": -1.5,
-        "arousal": 1.5,
-        "dominance": 0.5,
-        "fatigue": 0.0,
-    }
-    prosody_out_of_range = coordinator.map_affect_to_prosody(state_snap_out_of_range)
-    assert abs(prosody_out_of_range["speaking_rate"] - 1.450) < 1e-5
-    assert abs(prosody_out_of_range["pause_bias"] - 0.000) < 1e-5
-    assert abs(prosody_out_of_range["intensity"] - 2.250) < 1e-5
-
-
-def test_speech_coordinator_create_chunk_payload():
-    """Verify that SpeechCoordinator creates a fully compliant ChatOutput with affect fields."""
-    coordinator = SpeechCoordinator(segmenter=HybridSegmenter(target_size=8))
-
-    state_snap = {
-        "valence": 0.5,
-        "arousal": 0.7,
-        "dominance": 0.6,
-        "trust": 0.8,
-        "attachment": 0.4,
-        "emotion": "happy",
-        "fatigue": 0.2,
-    }
 
     payload = coordinator.create_chunk_payload(
         words=["hello", "there"],
-        state_snap=state_snap,
+        state_snap={
+            "valence": 0.5,
+            "arousal": 0.7,
+            "dominance": 0.6,
+            "trust": 0.8,
+            "attachment": 0.4,
+            "emotion": "happy",
+            "fatigue": 0.2,
+        },
         turn_id="turn-4",
         done=False,
         user_distance=1.2,
@@ -158,13 +62,6 @@ def test_speech_coordinator_create_chunk_payload():
     assert payload.turn_id == "turn-4"
     assert payload.done is False
 
-    # Check top-level prosody fields (rounded to 3 decimal places)
-    # Sr = 1.0 + 0.20*0.7 - 0.10*0.5 - 0.25*0.2 = 1.0 + 0.14 - 0.05 - 0.05 = 1.04
-    assert abs(payload.speaking_rate - 1.04) < 1e-5
-    assert abs(payload.pause_bias - 0.3) < 1e-5
-
-    # Check affect payload details
-    assert payload.affect is not None
     assert isinstance(payload.affect, ChatOutputAffect)
     assert payload.affect.valence == 0.5
     assert payload.affect.arousal == 0.7
@@ -176,10 +73,50 @@ def test_speech_coordinator_create_chunk_payload():
     assert payload.affect.user_distance == 1.2
 
 
+def test_the_legacy_mood_and_energy_keys_still_map_onto_affect():
+    """`get_context_snapshot` has emitted both namings historically.
+
+    Dropping the fallback would send valence 0.0 / arousal 0.5 — a flat,
+    neutral-sounding agent — rather than failing loudly.
+    """
+    coordinator = SpeechCoordinator(segmenter=HybridSegmenter(target_size=8))
+    payload = coordinator.create_chunk_payload(
+        words=["hi"], state_snap={"mood": -0.7, "energy": 0.9}, turn_id="t"
+    )
+    assert payload.affect.valence == -0.7
+    assert payload.affect.arousal == 0.9
+
+
+def test_an_absent_state_snapshot_produces_neutral_affect_not_a_crash():
+    """A chunk published before state exists must still be speakable."""
+    coordinator = SpeechCoordinator(segmenter=HybridSegmenter(target_size=8))
+    payload = coordinator.create_chunk_payload(words=["hi"], state_snap=None)
+    assert payload.affect.valence == 0.0
+    assert payload.affect.arousal == 0.5
+    assert payload.affect.emotion == "neutral"
+
+
+def test_prosody_fields_stay_at_their_defaults_on_the_wire():
+    """The deprecated fields must be inert, not carry a stale second opinion.
+
+    They are kept for deserialization compatibility with older consumers. If a
+    producer starts filling them again a reader could reasonably believe them,
+    and they would disagree with what the voice agent actually does.
+    """
+    coordinator = SpeechCoordinator(segmenter=HybridSegmenter(target_size=8))
+    payload = coordinator.create_chunk_payload(
+        words=["hi"], state_snap={"valence": 0.9, "arousal": 0.9, "fatigue": 0.9}
+    )
+    defaults = ChatOutput()
+    assert payload.speaking_rate == defaults.speaking_rate
+    assert payload.pause_bias == defaults.pause_bias
+    assert payload.intensity == defaults.intensity
+    assert payload.confidence == defaults.confidence
+
+
 @pytest.mark.asyncio
-async def test_brain_agent_prosody_calculation_publishing():
-    """Verify that BrainAgent correctly computes prosody and publishes compliant JSON to NATS."""
-    # Instantiating a mock/stub BrainAgent
+async def test_brain_agent_publishes_the_affect_vector_to_chat_output():
+    """The end-to-end Brain→Voice contract, as it is actually consumed."""
     agent = BrainAgent(
         ollama_url="http://127.0.0.1:11434",
         graph_db=MagicMock(),
@@ -187,7 +124,6 @@ async def test_brain_agent_prosody_calculation_publishing():
         conversation_store=MagicMock(),
     )
 
-    # Mock cognitive core context snapshot
     state_snap = {
         "valence": -0.2,
         "arousal": 0.6,
@@ -200,34 +136,31 @@ async def test_brain_agent_prosody_calculation_publishing():
     agent.cognitive_core = MagicMock()
     agent.cognitive_core.state.get_context_snapshot.return_value = state_snap
     agent.last_user_distance = 1.8
-
-    # Mock publish
     agent.publish = AsyncMock()
 
-    # Call the speech publishing method
     await agent._publish_speech_chunk(
         words=["testing", "continuous", "prosody"], turn_id="turn-5"
     )
 
-    # Assert publish was called once
     agent.publish.assert_called_once()
     nats_topic, nats_payload = agent.publish.call_args[0]
 
     assert nats_topic == "chat.output"
     assert isinstance(nats_payload, dict)
 
-    # Validate published payload
     parsed = ChatOutput.model_validate(nats_payload)
     assert parsed.content == "testing continuous prosody"
     assert parsed.done is False
     assert parsed.turn_id == "turn-5"
 
-    # Sr = 1.0 + 0.20*0.6 - 0.10*(-0.2) - 0.25*0.4 = 1.0 + 0.12 + 0.02 - 0.10 = 1.04
-    assert abs(parsed.speaking_rate - 1.04) < 1e-5
-    assert abs(parsed.pause_bias - 0.4) < 1e-5
-
     assert parsed.affect.valence == -0.2
     assert parsed.affect.arousal == 0.6
     assert parsed.affect.dominance == 0.4
     assert parsed.affect.fatigue == 0.4
+    # Distance drives the whisper/call-out volume and pitch shift in Rust, so
+    # losing it here silently flattens how the agent projects.
     assert parsed.affect.user_distance == 1.8
+
+    # The brain must not attach a second opinion on prosody.
+    assert parsed.speaking_rate == ChatOutput().speaking_rate
+    assert parsed.pause_bias == ChatOutput().pause_bias


### PR DESCRIPTION
The conservative half of the prosody de-duplication. Deletes the dead Python implementation; leaves the wire contract alone.

## The finding

`SpeechCoordinator.map_affect_to_prosody` computed speaking rate, intensity, pause bias and confidence, attached them to every `ChatOutput`, and shipped them across NATS. **Nothing reads them.** The voice agent derives prosody itself from the `affect` vector via `contracts::vad_to_prosody`, and grepping the crates for reads of `speaking_rate` / `pause_bias` / `intensity` returns nothing.

Dead code is cheap. The problem is that the two implementations had **drifted**:

| | speaking rate |
|---|---|
| Python | `1.0 + 0.20·Ar − 0.10·V − 0.25·F` — linear |
| Rust | `1.0 + tanh(0.20·Ar − 0.10·V − 0.25·F)` — saturated |

Rust additionally models pitch, volume, and user-distance adaptation (whisper under 0.6m, call-out over 1.5m) that had **no Python counterpart at all**. Both carried the identical comment `Continuous formulas from CVS-3.5 Roadmap`, so the disagreement did not read as one.

The cost isn't wasted cycles — it's that `speech.py` read as the authority on how fast this agent talks while describing behaviour that has never shipped. Same class of problem as the `[TBP]` benchmark figures: code that presents as authoritative and isn't.

## What changed

Python emits only the affect vector now. `map_affect_to_prosody` is gone, and neither `create_chunk_payload` nor `brain_agent._publish_speech_chunk` attaches prosody.

The four `ChatOutput` prosody fields are **kept at their defaults and marked deprecated** rather than removed. Removing them is a wire-contract change requiring `setup_nats_streams.py` to be re-run, and it needs the frontend and any external consumer checked first — a separable decision, deliberately not bundled here. The comment in `contracts.py` tells the next reader not to repopulate them and why.

## Verification

`tests/test_phase4_features.py` rewritten, 3 tests → 6.

The old tests asserted Python's formulas to five decimal places, passed for the life of the project, and proved nothing about the running system. Worse, they made the dead code look load-bearing — deleting it meant deleting a green test suite, which is exactly the friction that keeps this kind of thing alive. The new tests pin the contract that actually exists: a complete affect vector and no prosody, plus the legacy `mood`/`energy` key fallback and the absent-snapshot path.

Four mutations, all caught:

| Mutation | Failures |
|---|---|
| Python prosody reintroduced and wire fields repopulated | 2 |
| `user_distance` dropped from the affect vector | 1 |
| legacy `mood`/`energy` fallback removed | 1 |
| `user_distance` dropped in `_publish_speech_chunk` | 1 |

**The last one first reported as surviving, and that was my scripting bug, not a gap.** The mutation's `str.replace(..., 1)` had not applied at all — so the "mutation" changed nothing and of course nothing failed. Retargeted at the exact line, it fails as expected. Flagging it because *mutation survived* and *mutation never applied* look identical in a results table, and only one of them is good news.

Full backend suite: **471 passed, 0 failures** (468 − 3 + 6). `ruff check .` clean. No Rust changed.

## Not done

The four deprecated fields remain on the wire. Removing them is the follow-up contract PR. `AgentVoiceModulation` / `ProsodyFrame` in `surfacing_agent` is a separate trajectory path and was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat messages now publish a complete affect vector without conflicting, Python-generated prosody values.
  * Legacy prosody fields remain available for compatibility but stay at their default values.
  * Missing state snapshots now produce neutral affect data instead of causing errors.
  * Legacy mood and energy inputs continue to map correctly to affect data.

* **Tests**
  * Updated coverage verifies affect publishing, compatibility behavior, neutral defaults, and end-to-end chat output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->