### PR TITLE
feat(endocrine): give the hormones channels — reward prediction error and self-correction

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -2923,3 +2923,84 @@ recognition. A hormone with no channel is still only a formula. Phasic state
 remains unpersisted across restart, unchanged from PR #70 and for the same
 reason: both half-lives are minutes-scale, so any realistic restart outlasts the
 burst. `IdentityManager` is still a separate persona source.
+
+## 2026-07-18 The hormones get channels: reward prediction error and self-correction
+
+Both hormones had a release API and almost nothing calling it -- one channel for
+dopamine (somatic comfort recognition) and none at all for cortisol. An agent
+with no camera had a reward hormone that had never once fired. A hormone with no
+channel is only a formula, and the previous two entries said so in their own
+"NOT done" sections. This closes it.
+
+**Reward channel: prediction error, not outcome.** Firing a burst on any good
+turn would double-count what tonic dopamine already tracks -- the tonic term is
+valence x arousal, and a good turn raises valence by itself, so the burst would
+be the same signal counted twice. Phasic dopamine is supposed to mean *better
+than expected* (Schultz, cited in `dopamine_phasic`'s own docstring). The
+reappraisal engine was already computing exactly that quantity, using it to tune
+appraisal weights, and throwing it away. `evaluate_outcome` now returns it.
+
+The sign is flipped on the way out. Internally reappraisal uses
+`delta = expected - actual` for weight updates; returning that raw would invert
+the endocrine channel, firing cortisol on every pleasant surprise and dopamine
+on every disappointment. The returned value is `actual - expected`, matching the
+sign convention of the literature.
+
+`None` and `0.0` are deliberately different answers -- "no comparison was made"
+versus "exactly as expected". Reappraisal returns `None` when disabled, when no
+expectation was recorded, when rate-limited, and when the outcome landed within
+its existing 0.1 tolerance. The pipeline's deadband reuses that same 0.1 rather
+than introducing a second definition of "significant" that could drift.
+
+**Stress channel: self-correction.** Catching yourself mid-sentence about to
+violate your own identity constraints is the clearest stressor the agent has.
+`ActionService` yields a `self_correction` chunk; the pipeline consumes it and
+fires cortisol. Deliberately *reported* rather than acted on at the action layer,
+which has no `StateService` -- giving it one to fire a hormone would invert the
+dependency. Action reports what happened; state decides the physiological
+response. The chunk is consumed, not forwarded: downstream consumers switch on a
+small set of chunk types and an unrecognised one reaches the transport as a
+malformed message.
+
+Gains are asymmetric (stress 0.45, reward 0.35). Standard negativity bias, and
+also the safer failure direction: cortisol narrows the agent's own sampling
+temperature, so over-reacting to a bad turn degrades gracefully while
+over-reacting to a good one makes it erratic exactly when things are going well.
+
+### Verification
+
+`tests/test_endocrine_channels.py` (21 tests). Eight mutations applied, seven
+caught: deadband removed (3 failures), finiteness guard removed (3), reward and
+stress polarity swapped (3), self-correction firing no cortisol (1), the
+`self_correction` chunk being forwarded downstream (1), reappraisal returning the
+unflipped sign (1), and the tolerance path returning `0.0` instead of `None` (1).
+
+**One mutation survived, and it was right to.** Deleting the explicit
+`if prediction_error is None: return` changed nothing, because `float(None)`
+raises `TypeError` and the conversion guard below already catches it. The check
+is defence in depth and documentation of intent, not independently load-bearing.
+Recorded rather than papered over: the honest count is seven of eight, and a
+test contorted into detecting a redundant branch would be testing the branch
+rather than the behaviour.
+
+A weak test was caught during development. The first version of the
+chunk-routing test reimplemented the pipeline's loop inside the test and asserted
+against its own copy -- it would have passed with the real routing deleted. The
+routing was extracted into `_consume_internal_chunk` so the test drives the real
+method.
+
+**Line endings.** This repo has no `.gitattributes` and `core.autocrlf=false`, so
+files carry mixed conventions: `pipeline.py` and `reappraisal.py` are LF while
+`action.py` is CRLF. Editing via Python's text mode rewrote whole files and
+produced a 1800-line diff for a five-line change. Each file was restored to its
+own committed convention. Worth knowing before scripting an edit here.
+
+Full backend suite: **523 passed** (502 + 21), `ruff check .` clean.
+
+**NOT done:** the reward channel depends on `ReappraisalEngine` being enabled
+(`REAPPRAISAL_ENABLED`); with it off, phasic dopamine falls back to the somatic
+path alone. Grounding failures and generation errors are plausible additional
+stressors and are not wired. The gains are reasoned, not measured -- no
+calibration against real conversation has been done, and they should be treated
+as starting points rather than tuned values. Cortisol still has no channel for
+user-expressed frustration, which is probably the most obvious missing one.

--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -3080,3 +3080,68 @@ riding along with a test fix.
 
 Full backend suite: **505 passed**, `ruff check .` clean.
 
+### Review round (PR #75)
+
+Three comments, all three valid, and the first was a real bug rather than a
+style note.
+
+**The retry loop leaked the internal signal.** Stage 9 re-runs
+`action.execute(plan)` after an identity-validation failure, and that second
+loop yielded chunks without passing them through `_consume_internal_chunk`. So a
+`self_correction` emitted on the *retry* both reached the transport as an
+unrecognised chunk type and failed to release cortisol. The retry is the worst
+place for that gap: it runs only after a response was already rejected, with a
+hardened prompt, so it is the likeliest path to trip a second metacognitive
+violation. Fixed by filtering both loops.
+
+The bug existed because the test drove `_consume_internal_chunk` directly and
+never the loops that call it — the method was correct and unreachable-from-test
+on one of its two call sites. Added
+`test_the_self_correction_signal_is_consumed_on_the_retry_pass_too`, which runs
+the whole pipeline through `execute()` with `validate_response` rejecting once
+and accepting the second time, and asserts the retry branch was actually entered
+rather than trusting that it was.
+
+**Two vacuous assertions.** `cortisol <= 1.0` passed with the release deleted
+entirely, since the hormone sits at a 0.5 tonic baseline anyway; it now asserts
+the burst landed and stopped at the ceiling. `error is None or abs(error) >=
+DEADBAND` accepted exactly the regression it was meant to catch; it now asserts
+`is None` flatly.
+
+The ceiling assertion is `pytest.approx(1.0)`, not `== 1.0`, and deliberately:
+the phasic term starts decaying the instant it is recorded, so the total is
+asymptotically 1.0 (measured 0.99999998) and never precisely it. An exact
+comparison would pass or fail on scheduling luck.
+
+### Verification
+
+Five mutations. Reverting the retry-loop fix fails the new test. The tolerance
+branch returning `0.0` instead of `None` fails the tightened assertion.
+
+Removing the clamp inside `release_cortisol` **survived**, correctly: the
+`cortisol` property carries its own `min(1.0, ...)`, so either clamp alone
+suffices for that input. Removing the *property* clamp also survived at first —
+and that one was a genuine hole. The two clamps are not redundant: the phasic
+peak is stored relative to the tonic floor at release time, so a mood collapse
+afterwards lifts tonic underneath a burst already at the ceiling (0.5 + 0.5
+becomes ~0.9 + 0.5) and only the property clamp catches it. That matters because
+`_compute_endocrine_options` maps cortisol onto sampling temperature, and a
+value above 1.0 leaves the intended range. Added
+`test_a_mood_collapse_after_a_burst_cannot_push_cortisol_over_one`, which
+asserts its own fixture actually exceeds 1.0 before asserting the clamp holds;
+the property mutation is now caught.
+
+One mutation initially reported as surviving had been applied to the wrong line:
+`reappraisal.py` has four `return None` statements and a `replace(..., 1)` hit
+the *disabled* branch, which never executes when reappraisal is enabled.
+Retargeted by searching for the tolerance comment rather than by ordinal
+position. This is the second time this exact mistake has appeared in this
+ledger, which is itself the argument for anchoring mutations to surrounding text.
+
+Full backend suite: **528 passed**, `ruff check .` clean.
+
+**NOT done:** the two `action.execute` loops in stage 9 are now near-identical
+four-line bodies differing only in the speculative flag. Collapsing them into one
+drained helper would make this class of bug unrepresentable rather than merely
+fixed, but it touches the streaming hot path and belongs in its own PR.
+

--- a/backend/app/cognitive/action.py
+++ b/backend/app/cognitive/action.py
@@ -810,6 +810,11 @@ class ActionService:
                 )
                 await self._announce_self_correction(me.reason)
 
+                # Reported, not acted on: this layer has no StateService, and
+                # giving it one to fire a hormone would invert the dependency.
+                # The pipeline owns state and decides the response.
+                yield {"type": "self_correction", "data": me.reason}
+
                 yield {"type": "content", "data": " Wait, let me rephrase that... "}
                 if endocrine_options is None:
                     endocrine_options = {}

--- a/backend/app/cognitive/pipeline.py
+++ b/backend/app/cognitive/pipeline.py
@@ -1,7 +1,39 @@
 import logging
+import math
 from typing import Dict, Any, AsyncGenerator, List
 
 logger = logging.getLogger(__name__)
+
+# --- Endocrine channels ---------------------------------------------------
+# Until now both hormones had a release API and almost nothing calling it: one
+# channel (somatic comfort recognition) for dopamine and none at all for
+# cortisol. A hormone with no channel is only a formula, so these are the
+# events that actually move them.
+#
+# The reward channel is *prediction error*, not outcome. Firing a burst on any
+# good turn would double-count what tonic dopamine already tracks -- the tonic
+# term is valence x arousal, and a good turn raises valence by itself. Phasic
+# dopamine is supposed to signal "better than I expected", per the Schultz
+# reward-prediction-error work the `dopamine_phasic` docstring cites. The
+# reappraisal module was already computing exactly that quantity and throwing
+# it away after using it to tune weights.
+#
+# Scaled well below 1.0: a single surprising turn should colour the next few
+# minutes, not saturate the hormone. Deliberately asymmetric -- the stress
+# response to a turn going badly is stronger than the reward for one going
+# well, which is the standard negativity bias and also the safer failure mode
+# for a system whose cortisol narrows its own sampling temperature.
+REWARD_PREDICTION_GAIN = 0.35
+STRESS_PREDICTION_GAIN = 0.45
+# Below this, a prediction error is noise rather than surprise. Reappraisal
+# already ignores |delta| < 0.1 for weight updates; matching that keeps one
+# definition of "significant" instead of two that can drift apart.
+PREDICTION_ERROR_DEADBAND = 0.1
+# A self-correction means the agent caught itself about to violate its own
+# identity constraints mid-sentence. Fixed rather than scaled: the severity of
+# a violation is not something the metacognitive check reports, and inventing a
+# magnitude for it would be false precision.
+SELF_CORRECTION_STRESS = 0.3
 
 
 class CognitivePipeline:
@@ -188,11 +220,12 @@ class CognitivePipeline:
                 if isinstance(tom, dict) and "inferred_valence" in tom:
                     actual_text_valence = tom["inferred_valence"]
 
-                await self.reappraisal.evaluate_outcome(
+                prediction_error = await self.reappraisal.evaluate_outcome(
                     actual_text_valence=actual_text_valence,
                     acoustic_delta=acoustic_delta,
                     behavioral_signal=0.5,
                 )
+                await self._apply_reward_prediction_error(prediction_error)
 
             # Pre-Decision Vocabulary Update (zero LLM overhead concepts indexing)
             await self.state.update_theory_of_mind(event.raw_content)
@@ -331,6 +364,8 @@ class CognitivePipeline:
             if chunk["type"] == "done":
                 done_chunk = chunk
                 continue
+            if await self._consume_internal_chunk(chunk):
+                continue
             yield chunk
         stage_times["stage_8_action_execution_ms"] = (
             time.perf_counter() - t_start
@@ -393,6 +428,70 @@ class CognitivePipeline:
             yield done_chunk
         else:
             yield {"type": "done", "data": "finished", "speculative": is_spec}
+
+    async def _consume_internal_chunk(self, chunk) -> bool:
+        """Handle chunks meant for the pipeline itself. True = do not forward.
+
+        Downstream consumers switch on a small set of chunk types, and an
+        unrecognised one reaches the transport as a malformed message. These
+        are internal signals from the action layer, not output.
+        """
+        if chunk.get("type") == "self_correction":
+            await self._apply_self_correction_stress(chunk.get("data", ""))
+            return True
+        return False
+
+    async def _apply_reward_prediction_error(self, prediction_error):
+        """Turn a reward prediction error into a hormone burst.
+
+        `None` means no comparison was made (reappraisal disabled, no recorded
+        expectation, rate limited, or within tolerance) and is *not* the same as
+        `0.0`. Treating them alike would fire a burst of zero on every turn the
+        module declined to evaluate, which is harmless today only because the
+        release methods reject non-positive amounts -- a coincidence, not a
+        guarantee, so the distinction is made explicitly here.
+        """
+        if prediction_error is None:
+            return
+        try:
+            prediction_error = float(prediction_error)
+        except (TypeError, ValueError):
+            return
+        if not math.isfinite(prediction_error):
+            return
+        if abs(prediction_error) < PREDICTION_ERROR_DEADBAND:
+            return
+
+        try:
+            if prediction_error > 0:
+                await self.state.release_dopamine(
+                    min(1.0, prediction_error * REWARD_PREDICTION_GAIN),
+                    reason=f"turn exceeded expectation by {prediction_error:.2f}",
+                )
+            else:
+                await self.state.release_cortisol(
+                    min(1.0, -prediction_error * STRESS_PREDICTION_GAIN),
+                    reason=f"turn fell short of expectation by {-prediction_error:.2f}",
+                )
+        except Exception as e:
+            # An endocrine failure must never take down the turn: the hormone
+            # modulates how the agent speaks, it does not decide whether it can.
+            logger.warning("[Endocrine] Prediction-error release failed: %s", e)
+
+    async def _apply_self_correction_stress(self, reason: str):
+        """Catching yourself mid-violation is a stressor.
+
+        Deliberately fired from the pipeline rather than from `ActionService`,
+        which has no `StateService` handle. Action reports what happened; state
+        decides the physiological response. Plumbing a mutable state service
+        into the action layer to save one event type would invert that.
+        """
+        try:
+            await self.state.release_cortisol(
+                SELF_CORRECTION_STRESS, reason=f"self-correction: {reason}"
+            )
+        except Exception as e:
+            logger.warning("[Endocrine] Self-correction release failed: %s", e)
 
     async def _async_system2_appraisal(self, user_utterance: str):
         try:

--- a/backend/app/cognitive/pipeline.py
+++ b/backend/app/cognitive/pipeline.py
@@ -392,6 +392,13 @@ class CognitivePipeline:
                     if chunk["type"] == "done":
                         done_chunk = chunk
                         continue
+                    # The retry is the likeliest place to trip a second
+                    # metacognitive violation, since it runs with a hardened
+                    # prompt after one rejection. Skipping the filter here would
+                    # leak `self_correction` to the transport *and* swallow the
+                    # cortisol release on the one path that most deserves it.
+                    if await self._consume_internal_chunk(chunk):
+                        continue
                     yield chunk
         stage_times["stage_9_validation_ms"] = (time.perf_counter() - t_start) * 1000.0
 

--- a/backend/app/cognitive/reappraisal.py
+++ b/backend/app/cognitive/reappraisal.py
@@ -91,7 +91,7 @@ class ReappraisalEngine:
         actual_text_valence: float,
         acoustic_delta: float = 0.0,
         behavioral_signal: float = 0.5,
-    ):
+    ) -> Optional[float]:
         """
         §8.1: Evaluate the outcome of the agent's last response.
 
@@ -99,17 +99,29 @@ class ReappraisalEngine:
 
         §8.2: Adjust appraisal parameters based on prediction error.
         The system updates appraisal PARAMETERS (w₁, w₂), not emotions.
+
+        Returns the **reward prediction error** (actual − expected), or `None`
+        when no comparison was made: disabled, no expectation recorded, rate
+        limited, or the outcome landed within tolerance.
+
+        The sign is deliberately flipped relative to the internal `delta`
+        (expected − actual) used for weight updates. Positive here means the
+        turn went *better* than predicted, which is the direction the caller
+        cares about, and matching the sign convention of the literature this
+        implements (Schultz) keeps the endocrine channel readable. `None` and
+        `0.0` are different answers — "no comparison" versus "exactly as
+        expected" — so callers must not conflate them.
         """
         if not self.enabled:
-            return
+            return None
 
         if self._expected_valence is None or self._pre_response_state is None:
-            return
+            return None
 
         # Rate limiting: don't evaluate more than once per 2 seconds
         now = time.time()
         if now - self._last_evaluation_time < 2.0:
-            return
+            return None
         self._last_evaluation_time = now
 
         # §8.1: Multi-signal outcome computation
@@ -126,7 +138,10 @@ class ReappraisalEngine:
                 "[Reappraisal] Δ=%.3f — within tolerance, no adaptation.", delta
             )
             self._reset_turn_state()
-            return
+            # Within tolerance: the turn went as predicted. No prediction
+            # error means no phasic burst, which is the point of the model --
+            # a reward that was fully expected does not fire one.
+            return None
 
         # Confidence weighting: reduce learning rate for noisy signals
         confidence = min(1.0, abs(actual_text_valence) + 0.3)
@@ -149,6 +164,7 @@ class ReappraisalEngine:
         )
 
         self._reset_turn_state()
+        return -delta
 
     def get_weights(self) -> Dict[str, float]:
         """Returns current adaptive appraisal weights."""

--- a/backend/tests/test_endocrine_channels.py
+++ b/backend/tests/test_endocrine_channels.py
@@ -19,10 +19,12 @@ your own identity constraints is a stressor.
 """
 
 import math
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from app.cognitive.appraisal import AppraisalVector
+from app.cognitive.decision import ActionPlan
 from app.cognitive.pipeline import (
     PREDICTION_ERROR_DEADBAND,
     REWARD_PREDICTION_GAIN,
@@ -142,10 +144,49 @@ async def test_a_malformed_prediction_error_moves_no_hormone(error):
 
 
 @pytest.mark.asyncio
-async def test_an_enormous_prediction_error_cannot_saturate_the_hormone():
-    """A runaway signal must not pin sampling parameters at an extreme."""
+async def test_an_enormous_prediction_error_cannot_push_cortisol_past_its_ceiling():
+    """A runaway signal must clamp at the ceiling rather than overflow it.
+
+    `cortisol <= 1.0` alone would be vacuous: with the release deleted entirely
+    the hormone sits at its 0.5 tonic baseline and still satisfies it. So assert
+    that the burst both landed and stopped at the top.
+
+    Approximate, not exact: the phasic term begins decaying the moment it is
+    recorded, so the total is asymptotically 1.0 (0.99999998 here) and never
+    precisely it. `== 1.0` would pass or fail on scheduling luck.
+    """
     pipeline, service = _pipeline()
     await pipeline._apply_reward_prediction_error(-500.0)
+    assert service.current_state.cortisol_phasic_peak > 0.0
+    assert service.current_state.cortisol == pytest.approx(1.0)
+    assert service.current_state.cortisol <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_a_mood_collapse_after_a_burst_cannot_push_cortisol_over_one():
+    """The tonic floor can rise *underneath* a burst that is already at the top.
+
+    `release_cortisol` clamps the total at release time, but the phasic peak it
+    stores is relative to whatever the tonic floor was *then*. If mood then
+    collapses, tonic climbs independently and the sum exceeds 1.0 — here 0.5 +
+    0.5 becomes roughly 0.9 + 0.5. Only the clamp on the `cortisol` property
+    catches that, which is why the release-time clamp alone is not enough.
+
+    It matters because `_compute_endocrine_options` maps cortisol onto sampling
+    temperature; a value above 1.0 walks straight out of the intended range.
+    """
+    pipeline, service = _pipeline()
+    await pipeline._apply_reward_prediction_error(-500.0)
+    assert service.current_state.cortisol == pytest.approx(1.0)
+
+    # The floor rises after the fact.
+    service.current_state.mood = -1.0
+    assert service.current_state.cortisol_tonic > 0.5, "fixture failed to lift tonic"
+    assert (
+        service.current_state.cortisol_tonic + service.current_state.cortisol_phasic
+        > 1.0
+    ), "fixture does not actually exercise the property clamp"
+
     assert service.current_state.cortisol <= 1.0
 
 
@@ -197,6 +238,106 @@ async def test_the_self_correction_event_is_consumed_not_forwarded():
 
     assert service.current_state.cortisol_phasic_peak == pytest.approx(
         SELF_CORRECTION_STRESS
+    )
+
+
+def _full_pipeline_with_failing_validation(retry_chunks):
+    """A pipeline driven through `execute()`, forced down the retry branch.
+
+    `validate_response` rejects the first response and accepts the second, which
+    is the only way to reach the second `action.execute` loop in stage 9.
+    """
+    service = StateService(graph_store=None, db_path=":memory:")
+    service.current_state.mood = 0.0
+    service.current_state.fatigue = 0.0
+
+    perception = AsyncMock()
+    perception.perceive.return_value = MagicMock(
+        event_type="USER_MESSAGE",
+        raw_content="hello",
+        intent="CHAT",
+        event_id="evt-retry",
+        metadata={},
+    )
+    appraisal = MagicMock()
+    appraisal.appraise.return_value = AppraisalVector(
+        relevance=1.0,
+        novelty=0.5,
+        goal_congruence=0.2,
+        agency=0.8,
+        norm_alignment=1.0,
+        relationship_impact=0.1,
+    )
+    decision = MagicMock()
+    decision.decide = AsyncMock(
+        return_value=ActionPlan(
+            action_type="RESPOND_CHAT",
+            goal="GREET",
+            payload={"message": "hi", "identity_prompt": "be yourself"},
+        )
+    )
+
+    calls = {"n": 0}
+
+    async def execute(plan):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            yield {"type": "content", "data": "first attempt"}
+            yield {"type": "done", "data": ""}
+        else:
+            for chunk in retry_chunks:
+                yield chunk
+
+    action = MagicMock()
+    action.execute.side_effect = execute
+
+    identity = MagicMock()
+    identity.get_persona_prompt.return_value = "System prompt"
+    identity.validate_response = AsyncMock(
+        side_effect=[(False, "Safety/Toxicity boundary violation"), (True, "")]
+    )
+
+    pipeline = CognitivePipeline(
+        perception=perception,
+        appraisal=appraisal,
+        state=service,
+        decision=decision,
+        action=action,
+        learning=AsyncMock(),
+        identity=identity,
+    )
+    return pipeline, service, calls
+
+
+@pytest.mark.asyncio
+async def test_the_self_correction_signal_is_consumed_on_the_retry_pass_too():
+    """Stage 9's retry loop is a second, easy-to-forget copy of the action loop.
+
+    It is also the likeliest place to emit this signal: it runs only after a
+    response was already rejected, with a hardened prompt. Filtering the first
+    loop and not this one would leak `self_correction` to the transport on the
+    exact path that most deserves the cortisol, and the bug would be invisible
+    to any test that only drives the happy path.
+    """
+    pipeline, service, calls = _full_pipeline_with_failing_validation(
+        [
+            {"type": "content", "data": "corrected attempt"},
+            {"type": "self_correction", "data": "Safety/Toxicity boundary violation"},
+            {"type": "done", "data": ""},
+        ]
+    )
+
+    results = [c async for c in pipeline.execute({"type": "USER_MESSAGE", "content": "hi"})]
+
+    assert calls["n"] == 2, "the retry branch was never reached"
+    assert not any(c["type"] == "self_correction" for c in results), (
+        "internal signal leaked to the transport from the retry loop"
+    )
+    assert any(
+        c["type"] == "content" and c["data"] == "corrected attempt" for c in results
+    ), "the retry's real content must still reach the user"
+    assert service.current_state.cortisol_phasic_peak > 0.0, (
+        "the retry's self-correction must still raise cortisol"
     )
 
 
@@ -254,7 +395,10 @@ async def test_an_outcome_within_tolerance_reports_no_prediction_error():
     error = await engine.evaluate_outcome(
         actual_text_valence=0.4, acoustic_delta=0.0, behavioral_signal=0.5
     )
-    assert error is None or abs(error) >= PREDICTION_ERROR_DEADBAND
+    # Flatly `None`, not "None or something the deadband would filter": the
+    # weaker form would still pass if the tolerance branch started reporting a
+    # hormone-eligible signal, which is the exact regression this guards.
+    assert error is None
 
 
 def test_the_gains_keep_a_single_turn_from_saturating_a_hormone():

--- a/backend/tests/test_endocrine_channels.py
+++ b/backend/tests/test_endocrine_channels.py
@@ -1,0 +1,265 @@
+"""
+The events that actually move the hormones.
+
+Both hormones had a release API and almost nothing calling it: one channel for
+dopamine (somatic comfort recognition) and none at all for cortisol. A hormone
+with no channel is only a formula — it can be released in a unit test and never
+by anything the agent experiences.
+
+Two channels here:
+
+**Reward prediction error → both hormones.** Not outcome. Firing a burst on any
+good turn would double-count what tonic dopamine already tracks, since the tonic
+term is valence × arousal and a good turn raises valence by itself. Phasic
+dopamine signals *better than expected* (Schultz), and the reappraisal module was
+already computing that exact quantity and discarding it after tuning weights.
+
+**Self-correction → cortisol.** Catching yourself mid-sentence about to violate
+your own identity constraints is a stressor.
+"""
+
+import math
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.cognitive.pipeline import (
+    PREDICTION_ERROR_DEADBAND,
+    REWARD_PREDICTION_GAIN,
+    SELF_CORRECTION_STRESS,
+    STRESS_PREDICTION_GAIN,
+    CognitivePipeline,
+)
+from app.cognitive.reappraisal import ReappraisalEngine
+from app.state.agent_state import StateService
+
+
+def _pipeline():
+    """A pipeline with a real StateService and everything else stubbed."""
+    service = StateService(graph_store=None, db_path=":memory:")
+    service.current_state.mood = 0.0
+    service.current_state.fatigue = 0.0
+    pipeline = CognitivePipeline(*[MagicMock()] * 7)
+    pipeline.state = service
+    return pipeline, service
+
+
+# --------------------------------------------------------------------------
+# reward prediction error
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_better_than_expected_turn_fires_a_reward_burst():
+    """The reward channel. Without it phasic dopamine is unreachable in practice.
+
+    Only the somatic vision path could fire it before, so an agent with no
+    camera had a reward hormone that never once fired.
+    """
+    pipeline, service = _pipeline()
+    await pipeline._apply_reward_prediction_error(0.8)
+    assert service.current_state.dopamine_phasic_peak == pytest.approx(
+        0.8 * REWARD_PREDICTION_GAIN
+    )
+    assert service.current_state.cortisol_phasic_peak == 0.0
+
+
+@pytest.mark.asyncio
+async def test_a_worse_than_expected_turn_fires_a_stress_burst():
+    """The stress channel — cortisol previously had none at all."""
+    pipeline, service = _pipeline()
+    await pipeline._apply_reward_prediction_error(-0.8)
+    assert service.current_state.cortisol_phasic_peak == pytest.approx(
+        0.8 * STRESS_PREDICTION_GAIN
+    )
+    assert service.current_state.dopamine_phasic_peak == 0.0
+
+
+@pytest.mark.asyncio
+async def test_disappointment_hits_harder_than_delight():
+    """Negativity bias, and the safer failure direction.
+
+    Cortisol narrows the agent's own sampling temperature, so over-reacting to
+    a bad turn degrades gracefully while over-reacting to a good one makes it
+    erratic exactly when it is already doing well.
+    """
+    assert STRESS_PREDICTION_GAIN > REWARD_PREDICTION_GAIN
+
+    pipeline, service = _pipeline()
+    await pipeline._apply_reward_prediction_error(-0.5)
+    stress = service.current_state.cortisol_phasic_peak
+
+    pipeline, service = _pipeline()
+    await pipeline._apply_reward_prediction_error(0.5)
+    reward = service.current_state.dopamine_phasic_peak
+
+    assert stress > reward
+
+
+@pytest.mark.asyncio
+async def test_no_evaluation_is_not_the_same_as_no_surprise():
+    """`None` means reappraisal declined to evaluate; `0.0` means "as expected".
+
+    Conflating them would push a zero-amount release on every turn the module
+    skipped. That is harmless today *only* because the release methods reject
+    non-positive amounts — a coincidence downstream, not a guarantee here.
+    """
+    pipeline, service = _pipeline()
+    await pipeline._apply_reward_prediction_error(None)
+    assert service.current_state.dopamine_phasic_peak == 0.0
+    assert service.current_state.cortisol_phasic_peak == 0.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error", [0.0, 0.05, -0.05, PREDICTION_ERROR_DEADBAND - 1e-9])
+async def test_an_unsurprising_turn_fires_nothing(error):
+    """A fully expected reward must not fire a phasic burst — that is the model.
+
+    Without a deadband the hormones would twitch on every turn's rounding noise
+    and the phasic terms would never return to zero.
+    """
+    pipeline, service = _pipeline()
+    await pipeline._apply_reward_prediction_error(error)
+    assert service.current_state.dopamine_phasic_peak == 0.0
+    assert service.current_state.cortisol_phasic_peak == 0.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error", [float("nan"), float("inf"), float("-inf"), "big", object()]
+)
+async def test_a_malformed_prediction_error_moves_no_hormone(error):
+    """NaN passes `abs(x) < deadband` (False) and would reach the release path.
+
+    The release methods have their own finiteness guard, but relying on it from
+    here means a caller bug shows up as a hormone reading rather than as an
+    ignored input.
+    """
+    pipeline, service = _pipeline()
+    await pipeline._apply_reward_prediction_error(error)
+    assert service.current_state.dopamine_phasic_peak == 0.0
+    assert service.current_state.cortisol_phasic_peak == 0.0
+
+
+@pytest.mark.asyncio
+async def test_an_enormous_prediction_error_cannot_saturate_the_hormone():
+    """A runaway signal must not pin sampling parameters at an extreme."""
+    pipeline, service = _pipeline()
+    await pipeline._apply_reward_prediction_error(-500.0)
+    assert service.current_state.cortisol <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_a_failing_endocrine_release_does_not_break_the_turn():
+    """The hormone modulates how the agent speaks, not whether it can.
+
+    If a release raises, the user must still get their answer.
+    """
+    pipeline, _ = _pipeline()
+
+    async def boom(*args, **kwargs):
+        raise RuntimeError("redis down")
+
+    pipeline.state.release_dopamine = boom
+    await pipeline._apply_reward_prediction_error(0.8)  # must not raise
+
+
+# --------------------------------------------------------------------------
+# self-correction
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_catching_your_own_violation_raises_cortisol():
+    """A metacognitive violation is the clearest stressor the agent has."""
+    pipeline, service = _pipeline()
+    before = service.current_state.cortisol
+    await pipeline._apply_self_correction_stress("Safety/Toxicity boundary violation")
+    assert service.current_state.cortisol_phasic_peak > 0.0
+    assert service.current_state.cortisol > before
+
+
+@pytest.mark.asyncio
+async def test_the_self_correction_event_is_consumed_not_forwarded():
+    """Downstream consumers switch on a small set of chunk types.
+
+    An unrecognised one reaches the transport as a malformed message, so this
+    internal signal must be swallowed by the pipeline that acts on it.
+    """
+    pipeline, service = _pipeline()
+
+    # The real routing method, not a copy of it in the test.
+    assert await pipeline._consume_internal_chunk(
+        {"type": "self_correction", "data": "boundary violation"}
+    ) is True
+    assert await pipeline._consume_internal_chunk({"type": "content", "data": "hi"}) is False
+    assert await pipeline._consume_internal_chunk({"type": "done"}) is False
+
+    assert service.current_state.cortisol_phasic_peak == pytest.approx(
+        SELF_CORRECTION_STRESS
+    )
+
+
+# --------------------------------------------------------------------------
+# the reappraisal contract this depends on
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reappraisal_reports_the_error_with_the_reward_sign_convention():
+    """`evaluate_outcome` returns actual − expected, not its internal delta.
+
+    It computes `delta = expected − actual` for weight updates. Returning that
+    raw would invert the endocrine channel: every pleasant surprise would fire
+    cortisol and every disappointment dopamine. The sign flip is load-bearing.
+    """
+    engine = ReappraisalEngine()
+    if not engine.enabled:
+        pytest.skip("reappraisal disabled by config")
+
+    engine.record_pre_response_state({"valence": 0.0, "arousal": 0.5})
+    engine.record_expected_outcome("COMFORT", current_valence=0.0)  # expects +0.3
+    engine._last_evaluation_time = 0.0
+
+    # Actual outcome far above the expectation → positive prediction error.
+    error = await engine.evaluate_outcome(actual_text_valence=0.9, behavioral_signal=0.9)
+    assert error is not None
+    assert error > 0
+
+
+@pytest.mark.asyncio
+async def test_reappraisal_returns_none_rather_than_zero_when_it_does_not_evaluate():
+    """The distinction the pipeline relies on to tell "quiet" from "expected"."""
+    engine = ReappraisalEngine()
+    # No expectation recorded for this turn.
+    assert await engine.evaluate_outcome(actual_text_valence=0.9) is None
+
+
+@pytest.mark.asyncio
+async def test_an_outcome_within_tolerance_reports_no_prediction_error():
+    """Reappraisal already ignores |delta| < 0.1 for weight updates.
+
+    Reporting a prediction error it declined to learn from would give the
+    endocrine channel a second, looser definition of "significant".
+    """
+    engine = ReappraisalEngine()
+    if not engine.enabled:
+        pytest.skip("reappraisal disabled by config")
+
+    engine.record_pre_response_state({"valence": 0.0, "arousal": 0.5})
+    engine.record_expected_outcome("COMFORT", current_valence=0.0)
+    engine._last_evaluation_time = 0.0
+
+    # Chosen so actual_outcome lands within 0.1 of the 0.3 expectation.
+    error = await engine.evaluate_outcome(
+        actual_text_valence=0.4, acoustic_delta=0.0, behavioral_signal=0.5
+    )
+    assert error is None or abs(error) >= PREDICTION_ERROR_DEADBAND
+
+
+def test_the_gains_keep_a_single_turn_from_saturating_a_hormone():
+    """One surprising turn should colour the next few minutes, not max out."""
+    assert 0.0 < REWARD_PREDICTION_GAIN < 1.0
+    assert 0.0 < STRESS_PREDICTION_GAIN < 1.0
+    assert 0.0 < SELF_CORRECTION_STRESS < 1.0
+    assert math.isfinite(PREDICTION_ERROR_DEADBAND) and PREDICTION_ERROR_DEADBAND > 0.0


### PR DESCRIPTION
Step 4. Closes the "NOT done" item both #70 and #73 left open: a hormone with no channel is only a formula.

Before this, `release_dopamine` had exactly one caller (somatic comfort recognition) and `release_cortisol` had none. **An agent with no camera had a reward hormone that had never once fired.**

## Reward channel: prediction error, not outcome

The tempting wiring — fire dopamine when a turn goes well — is wrong. Tonic dopamine is already `valence × arousal`, and a good turn raises valence by itself, so a burst on top would be the same signal counted twice.

Phasic dopamine is supposed to mean **better than expected** (Schultz, cited in `dopamine_phasic`'s own docstring). It turns out `ReappraisalEngine` was already computing precisely that quantity, using it to tune appraisal weights, and then discarding it. `evaluate_outcome` now returns it.

**The sign flip is load-bearing.** Internally reappraisal uses `delta = expected − actual` for weight updates. Returning that raw would invert the endocrine channel — cortisol on every pleasant surprise, dopamine on every disappointment. The returned value is `actual − expected`, matching the literature's convention. There is a test on this specifically, because it is the kind of bug that produces a plausible-looking agent with its emotions backwards.

**`None` and `0.0` are different answers** — "no comparison was made" versus "exactly as expected". Reappraisal returns `None` when disabled, when no expectation was recorded, when rate-limited, and when the outcome fell within its existing 0.1 tolerance. The pipeline's deadband reuses that same 0.1 rather than introducing a second definition of "significant" that could drift apart from it.

## Stress channel: self-correction

Catching yourself mid-sentence about to violate your own identity constraints is the clearest stressor the agent has.

`ActionService` yields a `self_correction` chunk; the pipeline consumes it and fires cortisol. The action layer **reports rather than acts** — it has no `StateService`, and giving it one to fire a hormone would invert the dependency. Action reports what happened; state decides the physiological response.

The chunk is consumed, not forwarded: downstream consumers switch on a small set of chunk types, and an unrecognised one reaches the transport as a malformed message.

Gains are asymmetric — stress 0.45, reward 0.35. Negativity bias, and also the safer failure direction: cortisol narrows the agent's own sampling temperature, so over-reacting to a bad turn degrades gracefully while over-reacting to a good one makes it erratic exactly when things are going well.

## Verification

`tests/test_endocrine_channels.py`, **21 tests**. Eight mutations, **seven caught**:

| Mutation | Failures |
|---|---|
| deadband removed | 3 |
| finiteness guard removed | 3 |
| reward/stress polarity swapped | 3 |
| self-correction fires no cortisol | 1 |
| `self_correction` chunk forwarded downstream | 1 |
| reappraisal returns unflipped sign | 1 |
| tolerance path returns `0.0` instead of `None` | 1 |
| **explicit `is None` check removed** | **0 — survived** |

**The survivor is reported, not hidden.** Deleting `if prediction_error is None: return` changes nothing, because `float(None)` raises `TypeError` and the conversion guard below already catches it. The check is defence in depth and a statement of intent, not independently load-bearing. The honest count is seven of eight — a test contorted to detect a redundant branch would be testing the branch rather than the behaviour.

**A weak test was caught mid-development.** My first chunk-routing test reimplemented the pipeline's loop inside the test and asserted against its own copy — it would have passed with the real routing deleted. Extracted the routing into `_consume_internal_chunk` so the test drives the real method.

**Line-ending trap, worth knowing.** This repo has no `.gitattributes` and `core.autocrlf=false`, so files carry mixed conventions — `pipeline.py` and `reappraisal.py` are LF, `action.py` is CRLF. Editing through Python's text mode rewrote whole files and turned a five-line change into an 1800-line diff. Each file was restored to its own committed convention; the diff here is +5 / +100 / +21, which is the actual change.

Full backend suite: **523 passed, 0 failures** (502 + 21). `ruff check .` clean.

## Not done

The reward channel depends on `REAPPRAISAL_ENABLED`; with it off, phasic dopamine falls back to the somatic path alone. Grounding failures and generation errors are plausible additional stressors and are not wired. **The gains are reasoned, not measured** — no calibration against real conversation has been done, and they should be read as starting points. Cortisol still has no channel for user-expressed frustration, which is probably the most obvious one missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hormone responses to meaningful reward prediction errors, triggering dopamine for positive outcomes and cortisol for negative outcomes.
  * Added cortisol responses to self-correction events.
  * Added safeguards to ignore invalid, insignificant, or unavailable evaluation results.
* **Bug Fixes**
  * Self-correction signals are now handled internally without appearing as regular downstream messages.
  * Improved outcome evaluation semantics for unavailable and within-tolerance results.
* **Tests**
  * Added comprehensive coverage for endocrine channels, self-correction handling, edge cases, and safe hormone bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->