### PR TITLE
fix(identity): make IMMUTABLE_CORE the authority over personality.json

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -3182,3 +3182,83 @@ among them). Renormalization fixed their line endings, but mixed endings inside
 one file usually mean it was edited by two tools that disagreed, so those files
 are worth a look for other inconsistencies this commit did not address.
 
+---
+
+## 2026-07-19 — The immutable core was not immutable
+
+First slice of the IdentityManager/PersonaProfile unification, pulled forward
+because it turned out to be a live safety hole rather than a design wart.
+
+### What was wrong
+
+`IdentityManager._refresh_immutable_core` read its entire "immutable" block out
+of `personality.json` — a user-editable file. `PersonaProfile`'s own comment had
+already named the risk ("that file is user-editable, so it cannot be the
+authority on safety"), but nothing enforced it, and the file shipped in this
+repo had drifted to:
+
+    "immutable": { "values": ["Honesty"], "base_tone": "Warm", "boundaries": [] }
+
+Verified by running it, not by reading it:
+
+- `validate_response` iterates `boundaries` to enforce non-toxicity. With the
+  list empty the loop body never executed. Fed "I hate you, you are worthless",
+  it returned `(True, '')`. The check was dead code.
+- `get_persona_prompt` emitted a literal `BOUNDARIES: ` with nothing after the
+  colon, so the model was told nothing about them either.
+- `Privacy` had silently vanished from the values — the value that stands behind
+  "will never share user data".
+
+Both defences were down at once, and an empty list is the worst possible value
+precisely because it fails silently: every enforcement loop still runs, just zero
+times.
+
+Nothing caught it because **every** reference to `validate_response` in the test
+suite is a mock. The real function had no coverage, so it could go dead and stay
+green. That is the more general lesson here: a safety check that is only ever
+mocked is a safety check nobody has tested.
+
+### The fix
+
+`IMMUTABLE_CORE` is now the authority. Values and boundaries are copied from it
+and cannot be emptied, narrowed, or substituted from the file; a file that tries
+is ignored with a warning, matching what `PersonaProfile.load()` already does.
+`base_tone` stays authorable — it describes how the friend sounds, not what it
+refuses to do. The lists are copied rather than referenced, since `save()` hands
+the dict back out and a shared list would let one mutation edit the constant for
+every future instance in the process.
+
+`save()` now writes only `base_tone` back to disk. Round-tripping the safety text
+into a user-editable file would imply that is where it lives, and would make
+every later boot warn about a block this code wrote itself.
+
+Restoring the boundaries also reactivated the toxicity check, which was written
+as `"hate" in text.lower()`. That rejects "I hate mushrooms too" and "I hate that
+this happened to you". A false rejection is no longer cheap — it forces a
+regeneration and, since the endocrine channels landed, fires a cortisol burst, so
+the agent would stress itself for sympathising with the user. Narrowed to
+contempt aimed at the user. It remains a crude backstop, not moderation.
+
+### Verification
+
+New `tests/test_identity_boundaries.py` (13 tests), the first real coverage this
+path has had. Six mutations, **all six caught**: restoring file authority,
+sharing the module lists instead of copying, reinstating the bare-substring
+match, disabling the check entirely, writing safety text back on save, and
+dropping the base_tone fallback.
+
+Full backend suite **541 passed**, `ruff check .` clean.
+
+**Pre-existing issue found, not fixed:** the test suite writes to the real
+`backend/app/personality.json`. It was invisible until now because `save()` wrote
+back exactly what it had read, making the write content-idempotent; this change
+altered the written shape and surfaced it. Confirmed pre-existing by running the
+suite against unmodified main code and watching the file change. Committing the
+cleaned file restores idempotence, so the tree stays clean, but a test reaching a
+tracked application file is still wrong and wants a `tmp_path` fixture.
+
+**NOT done:** this is only the safety slice. `IdentityManager` and
+`PersonaProfile` remain two persona sources — narrative and numeric — with no
+shared schema, no tier enforcement on the narrative half, and no write path. That
+is the rest of step 5, and step 6's authoring surface depends on it.
+

--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -3262,3 +3262,59 @@ tracked application file is still wrong and wants a `tmp_path` fixture.
 shared schema, no tier enforcement on the narrative half, and no write path. That
 is the rest of step 5, and step 6's authoring surface depends on it.
 
+### Review round (PR #76)
+
+One comment, rated Critical, and correct: **control markup could carry contempt
+straight past the boundary check.**
+
+The persona prompt explicitly invites the model to emit `<pause=300ms>` and
+`<hesitate>`, and `ControlMarkupSanitizer` preserves those tags on purpose —
+they are instructions for the voice layer. So the text handed to
+`validate_response` genuinely contains markup, and `I hate <pause=100ms> you`
+never matched a pattern expecting `hate` and `you` to be adjacent. Confirmed
+against the compiled regex before changing anything: three of three variants
+bypassed. This is not an adversarial model; it is what ordinary instructed
+output looks like.
+
+Notably the check had to exist first for this to be reachable. The boundaries
+fix in this same PR is what turned the dead loop back on, and reactivating a
+check is exactly when its weaknesses become live.
+
+### The first fix was worse than the bug
+
+The obvious repair — strip tags, match the cleaned string — was implemented and
+then rejected. Stripping included a rule for an unclosed `<` at the end of a
+truncated stream, which meant `5 < 10, and I hate you` collapsed to `5`. The
+hostility did not merely go unmatched; it was **deleted before matching**. A
+cleaner that can conceal text is worse than no cleaner, because it fails in the
+direction that looks clean.
+
+Caught by writing a test case the fix could not pass, rather than by writing
+cases the fix was known to handle.
+
+Replaced with several *views* of the text — raw, tags removed, brackets spaced —
+rejecting if any of them matches. The structural property is what matters: the
+raw text is always among the views, so no stripping rule can subtract evidence.
+Each view can only ever add a reason to reject. The avoid-list is checked the
+same way; it had the identical weakness.
+
+### Verification
+
+11 mutations across the two rounds, **all 11 caught**. The five new ones: match
+raw only (the reviewed bypass), drop the de-tagged view, drop the raw view,
+avoid-list checks raw only, toxicity checks one view only.
+
+Dropping the raw view initially **survived**, and the reason is worth recording.
+The concealment test used `5 < 10, and I hate you`, which contains no
+*well-formed* tag — so the de-tagged view was byte-identical to the raw one and
+the set still held it. The test asserted a property that was true by accident.
+The raw view is only load-bearing when a pattern contains angle brackets itself,
+so an avoid-list entry of `<internal>` was added; it exists in the raw view
+alone, and the mutation is now caught.
+
+That is three times in this ledger that a mutation looked survivable for a
+reason unrelated to the code under test. The recurring shape: a fixture that
+does not actually reach the branch it names.
+
+Full backend suite **551 passed**, `ruff check .` clean.
+

--- a/backend/app/cognitive/identity.py
+++ b/backend/app/cognitive/identity.py
@@ -19,6 +19,37 @@ _HOSTILE_TO_USER = re.compile(
     r"|\b(?:shut\s+up|go\s+away)\s*,?\s*(?:you|idiot|stupid)\b"
 )
 
+_WELL_FORMED_TAG = re.compile(r"<[^<>]*>")
+
+
+def _match_views(text: str) -> Tuple[str, ...]:
+    """Every reading of `text` a boundary check should be judged against.
+
+    The persona prompt *invites* the model to emit `<pause=300ms>` and
+    `<hesitate>`, and `ControlMarkupSanitizer` preserves them on purpose — they
+    are instructions for the voice layer. So the text handed to
+    `validate_response` genuinely contains markup, and `I hate <pause=100ms> you`
+    slips past any pattern expecting `hate` and `you` to be adjacent. That is
+    ordinary instructed output, not an attack.
+
+    Returning several views instead of one canonical "cleaned" string is the
+    important part. A single strip has to be right about what to remove, and a
+    first attempt here removed everything after an unclosed `<` — which turned
+    "5 < 10, I hate you" into "5" and *hid* the hostility rather than missing
+    it. A cleaner that can conceal text is worse than no cleaner. With the raw
+    text always among the views, no stripping rule can subtract evidence: each
+    view can only ever add a reason to reject.
+
+    Validation-only. The response itself keeps its markers.
+    """
+    raw = re.sub(r"\s+", " ", (text or "")).strip()
+    # Tags removed outright, so a marker splitting a word ("I ha<pause>te you")
+    # closes back up.
+    detagged = re.sub(r"\s+", " ", _WELL_FORMED_TAG.sub("", raw)).strip()
+    # Only the brackets themselves, so nothing is ever swallowed wholesale.
+    debracketed = re.sub(r"\s+", " ", raw.replace("<", " ").replace(">", " ")).strip()
+    return tuple({raw, detagged, debracketed})
+
 # Authorable, unlike values and boundaries: tone is how the friend sounds, not
 # what it will refuse to do. Used when personality.json names no base_tone.
 DEFAULT_BASE_TONE = "Warm, intellectual, and slightly protective"
@@ -284,14 +315,19 @@ MANDATORY RULES:
         # This is a crude last-resort backstop, not content moderation. The
         # real work is done by the persona prompt and the model; anything that
         # reaches here has already gone wrong.
-        lowered = text.lower()
+        views = _match_views(text.lower())
+
         for boundary in self.immutable_core["boundaries"]:
-            if "toxic" in boundary.lower() and _HOSTILE_TO_USER.search(lowered):
+            if "toxic" in boundary.lower() and any(
+                _HOSTILE_TO_USER.search(view) for view in views
+            ):
                 return False, "Response violates core boundary: Non-toxicity"
 
-        # Restricted phrases check
+        # The avoid-list had the same weakness: a restricted phrase broken up by
+        # a pause marker slipped straight through a plain substring test.
         forbidden = self.personality.get("conversation_rules", {}).get("avoid", [])
         for pattern in forbidden:
-            if pattern.lower() in text.lower():
+            needle = pattern.lower()
+            if any(needle in view for view in views):
                 return False, f"Restricted phrase detected: {pattern}"
         return True, ""

--- a/backend/app/cognitive/identity.py
+++ b/backend/app/cognitive/identity.py
@@ -1,9 +1,27 @@
 import logging
 import json
 import os
+import re
 from typing import Dict, Any, Tuple
 
+from ..persona import IMMUTABLE_CORE
+
 logger = logging.getLogger(__name__)
+
+# Contempt directed at the user, which is what the non-toxicity boundary is
+# actually about. Deliberately narrow: the agent saying it hates a *thing* is
+# ordinary conversation, and rejecting it costs a regeneration and a stress
+# response. Matches the agent as speaker ("I hate you"), not the user's words.
+_HOSTILE_TO_USER = re.compile(
+    r"\bi\s+(?:really\s+|fucking\s+)?hate\s+(?:you|u)\b"
+    r"|\byou(?:'re|\s+are)\s+(?:so\s+|such\s+a\s+)?"
+    r"(?:worthless|pathetic|disgusting|stupid|idiot|useless)\b"
+    r"|\b(?:shut\s+up|go\s+away)\s*,?\s*(?:you|idiot|stupid)\b"
+)
+
+# Authorable, unlike values and boundaries: tone is how the friend sounds, not
+# what it will refuse to do. Used when personality.json names no base_tone.
+DEFAULT_BASE_TONE = "Warm, intellectual, and slightly protective"
 
 
 class IdentityManager:
@@ -58,17 +76,40 @@ class IdentityManager:
             return {}
 
     def _refresh_immutable_core(self):
-        self.immutable_core = self.personality.get("core_personality", {}).get(
-            "immutable",
-            {
-                "values": ["Honesty", "Privacy", "Curiosity"],
-                "base_tone": "Warm, intellectual, and slightly protective",
-                "boundaries": [
-                    "Will never share user data",
-                    "Will not adopt toxic behavior",
-                ],
-            },
+        """Rebuild the immutable core, with `IMMUTABLE_CORE` as the authority.
+
+        This used to read the whole block straight out of `personality.json`,
+        which made a user-editable file the authority on the agent's own safety
+        boundaries. That is not a theoretical hole: the file shipped in this
+        repo carried `"boundaries": []`, which emptied the list that
+        `validate_response` iterates, so the toxicity check silently became dead
+        code and the prompt went out reading `BOUNDARIES: ` with nothing after
+        it. It also dropped `Privacy` from the values.
+
+        Values and boundaries now come from code and cannot be narrowed,
+        emptied, or renamed by editing the file. `base_tone` stays authorable —
+        it describes how the friend sounds, not what it will refuse to do.
+        """
+        file_block = (
+            self.personality.get("core_personality", {}).get("immutable") or {}
         )
+
+        overreach = [key for key in ("values", "boundaries") if key in file_block]
+        if overreach:
+            logger.warning(
+                "[Identity] personality.json tried to set immutable %s; ignoring. "
+                "Safety invariants come from persona.IMMUTABLE_CORE, not from a "
+                "user-editable file.",
+                " and ".join(overreach),
+            )
+
+        self.immutable_core = {
+            # Copied, not referenced: `save()` writes this dict back out, and a
+            # shared list would let a later mutation edit the module constant.
+            "values": list(IMMUTABLE_CORE["values"]),
+            "boundaries": list(IMMUTABLE_CORE["boundaries"]),
+            "base_tone": file_block.get("base_tone") or DEFAULT_BASE_TONE,
+        }
 
     async def hydrate_from_config_store(self, config_store):
         """
@@ -132,9 +173,15 @@ class IdentityManager:
     def save(self):
         """Flushes identity state back to disk."""
         try:
-            # Sync immutable core back to personality JSON structure
+            # Only the authorable part goes back to disk. Writing values and
+            # boundaries here would re-create the block the loader deliberately
+            # ignores, so every subsequent boot would warn about a file this
+            # code wrote itself — and it would put safety text back in a
+            # user-editable file, implying it can be edited there.
             core_personality = self.personality.setdefault("core_personality", {})
-            core_personality["immutable"] = self.immutable_core
+            core_personality["immutable"] = {
+                "base_tone": self.immutable_core["base_tone"]
+            }
             self.history.setdefault("memories", [])
 
             with open(self.personality_path, "w", encoding="utf-8") as f:
@@ -224,9 +271,22 @@ MANDATORY RULES:
         """.strip()
 
     async def validate_response(self, text: str, goal: str) -> Tuple[bool, str]:
-        # Enforce Boundaries
+        # Enforce Boundaries.
+        #
+        # This check was dormant for as long as the shipped personality.json
+        # carried an empty `boundaries` list, so restoring that list turns it
+        # back on. The old condition was `"hate" in text.lower()`, which rejects
+        # "I hate mushrooms too" and "I hate that this happened to you" — and a
+        # false rejection is no longer cheap: it forces a regeneration and, since
+        # the endocrine channels landed, fires a cortisol burst. So match
+        # contempt aimed at the user rather than the bare token.
+        #
+        # This is a crude last-resort backstop, not content moderation. The
+        # real work is done by the persona prompt and the model; anything that
+        # reaches here has already gone wrong.
+        lowered = text.lower()
         for boundary in self.immutable_core["boundaries"]:
-            if "toxic" in boundary.lower() and "hate" in text.lower():
+            if "toxic" in boundary.lower() and _HOSTILE_TO_USER.search(lowered):
                 return False, "Response violates core boundary: Non-toxicity"
 
         # Restricted phrases check

--- a/backend/app/personality.json
+++ b/backend/app/personality.json
@@ -5,11 +5,7 @@
       "Warm"
     ],
     "immutable": {
-      "values": [
-        "Honesty"
-      ],
-      "base_tone": "Warm",
-      "boundaries": []
+      "base_tone": "Warm"
     },
     "adaptive_traits": [
       "Reserved"

--- a/backend/tests/test_identity_boundaries.py
+++ b/backend/tests/test_identity_boundaries.py
@@ -1,0 +1,212 @@
+"""
+The agent's safety boundaries, and who is allowed to decide them.
+
+`IdentityManager` used to read its whole "immutable" block out of
+`personality.json` — a user-editable file. That made the file the authority on
+the agent's own safety invariants, and the consequence was not hypothetical: the
+copy shipped in this repo carried `"boundaries": []`, so the list that
+`validate_response` iterates was empty, the toxicity check never executed, and
+the persona prompt went out reading `BOUNDARIES: ` with nothing after it.
+`Privacy` had also quietly vanished from the values.
+
+Nothing caught it because every test that touched `validate_response` mocked it.
+The real function had no coverage at all, so it could go dead and stay green.
+
+These tests hold the line in both directions: a persona file cannot weaken the
+boundaries, and the enforcement that depends on them must actually run.
+"""
+
+import json
+
+import pytest
+
+from app.cognitive.identity import IdentityManager
+from app.persona import IMMUTABLE_CORE
+
+
+def _identity(tmp_path, personality: dict) -> IdentityManager:
+    """An IdentityManager backed by a real personality.json on disk."""
+    (tmp_path / "personality.json").write_text(
+        json.dumps(personality), encoding="utf-8"
+    )
+    (tmp_path / "history.json").write_text("{}", encoding="utf-8")
+    return IdentityManager(base_path=str(tmp_path))
+
+
+HOSTILE_FILE = {
+    "name": "my friend",
+    "core_personality": {
+        "immutable": {"values": ["Honesty"], "base_tone": "Warm", "boundaries": []},
+        "adaptive_traits": ["Reserved"],
+    },
+}
+
+
+# --------------------------------------------------------------------------
+# a file cannot weaken the core
+# --------------------------------------------------------------------------
+
+
+def test_a_persona_file_cannot_empty_the_safety_boundaries(tmp_path):
+    """The exact regression that shipped: `"boundaries": []` in the file.
+
+    An empty list is the most dangerous value here rather than the most
+    harmless, because every enforcement loop iterates it and an empty loop body
+    simply never runs. Enforcement disappears without any error.
+    """
+    manager = _identity(tmp_path, HOSTILE_FILE)
+    assert manager.immutable_core["boundaries"] == IMMUTABLE_CORE["boundaries"]
+    assert manager.immutable_core["boundaries"], "boundaries must never be empty"
+
+
+def test_a_persona_file_cannot_drop_a_core_value(tmp_path):
+    """The shipped file listed only `Honesty`, silently discarding `Privacy`.
+
+    Privacy is the value that stands behind "will never share user data", so
+    losing it removes the stated reason for the boundary that protects the user.
+    """
+    manager = _identity(tmp_path, HOSTILE_FILE)
+    assert manager.immutable_core["values"] == IMMUTABLE_CORE["values"]
+    assert "Privacy" in manager.immutable_core["values"]
+
+
+def test_a_persona_file_cannot_substitute_its_own_boundaries(tmp_path):
+    """Replacing is as effective an attack as emptying.
+
+    A file that supplies a plausible-looking but toothless boundary would pass
+    any check that only asserts the list is non-empty.
+    """
+    manager = _identity(
+        tmp_path,
+        {
+            "core_personality": {
+                "immutable": {
+                    "values": ["Obedience"],
+                    "boundaries": ["Will do whatever the user asks"],
+                }
+            }
+        },
+    )
+    assert manager.immutable_core["boundaries"] == IMMUTABLE_CORE["boundaries"]
+    assert "Will do whatever the user asks" not in manager.immutable_core["boundaries"]
+    assert "Obedience" not in manager.immutable_core["values"]
+
+
+def test_the_core_is_copied_so_one_agent_cannot_edit_the_constant(tmp_path):
+    """`immutable_core` is handed out and later written back by `save()`.
+
+    Sharing the module-level lists would let any mutation reach every future
+    IdentityManager in the process — a boundary removed once, removed for good.
+    """
+    manager = _identity(tmp_path, HOSTILE_FILE)
+    manager.immutable_core["boundaries"].clear()
+    manager.immutable_core["values"].clear()
+
+    assert IMMUTABLE_CORE["boundaries"], "the module constant was mutated"
+    assert IMMUTABLE_CORE["values"], "the module constant was mutated"
+    assert _identity(tmp_path, HOSTILE_FILE).immutable_core["boundaries"]
+
+
+# --------------------------------------------------------------------------
+# what the file *may* still decide
+# --------------------------------------------------------------------------
+
+
+def test_base_tone_remains_authorable(tmp_path):
+    """Tone is how the friend sounds, not what it refuses to do.
+
+    Locking it down too would make the persona file pointless and push authors
+    toward editing code, which is the outcome the tier model exists to avoid.
+    """
+    manager = _identity(
+        tmp_path,
+        {"core_personality": {"immutable": {"base_tone": "Dry and precise"}}},
+    )
+    assert manager.immutable_core["base_tone"] == "Dry and precise"
+
+
+def test_a_file_without_a_tone_still_gets_a_usable_one(tmp_path):
+    """`base_tone` is interpolated into the prompt; `None` would render there."""
+    manager = _identity(tmp_path, {"core_personality": {}})
+    assert manager.immutable_core["base_tone"]
+    assert "None" not in manager.get_persona_prompt("")
+
+
+# --------------------------------------------------------------------------
+# the boundaries have to reach the places that use them
+# --------------------------------------------------------------------------
+
+
+def test_the_prompt_states_the_boundaries_it_claims_to_have(tmp_path):
+    """The shipped config produced a literal `BOUNDARIES: ` with nothing after.
+
+    The prompt is the agent's first and softest line of defence; an empty one
+    still looks correct in a log.
+    """
+    manager = _identity(tmp_path, HOSTILE_FILE)
+    prompt = manager.get_persona_prompt("neutral")
+
+    boundaries_line = next(
+        line for line in prompt.splitlines() if line.startswith("BOUNDARIES:")
+    )
+    assert boundaries_line.strip() != "BOUNDARIES:"
+    for boundary in IMMUTABLE_CORE["boundaries"]:
+        assert boundary in prompt
+    assert "Privacy" in prompt
+
+
+@pytest.mark.asyncio
+async def test_contempt_aimed_at_the_user_is_rejected(tmp_path):
+    """With the boundary list empty this loop never ran, whatever the text was."""
+    manager = _identity(tmp_path, HOSTILE_FILE)
+    is_valid, reason = await manager.validate_response("I hate you.", "CHAT")
+    assert is_valid is False
+    assert "Non-toxicity" in reason
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
+        "I hate mushrooms too, honestly.",
+        "I hate that this happened to you.",
+        "I hate to say it, but you might be right.",
+        "You are so much better at this than me.",
+    ],
+)
+async def test_ordinary_speech_about_hating_things_is_not_rejected(tmp_path, text):
+    """The old check was `"hate" in text`, which fails all four of these.
+
+    A false rejection is not free: it forces a regeneration and, since the
+    endocrine channels landed, fires a cortisol burst. An agent that stresses
+    itself for sympathising with you has the boundary pointed the wrong way.
+    """
+    manager = _identity(tmp_path, HOSTILE_FILE)
+    is_valid, reason = await manager.validate_response(text, "CHAT")
+    assert is_valid is True, f"false positive on {text!r}: {reason}"
+
+
+# --------------------------------------------------------------------------
+# persistence
+# --------------------------------------------------------------------------
+
+
+def test_saving_does_not_write_safety_text_back_into_the_editable_file(tmp_path):
+    """Round-tripping them to disk would imply that file is where they live.
+
+    It would also make every later boot warn about a block this code wrote
+    itself, training the reader to ignore the warning.
+    """
+    manager = _identity(tmp_path, HOSTILE_FILE)
+    manager.save()
+
+    written = json.loads((tmp_path / "personality.json").read_text(encoding="utf-8"))
+    immutable = written["core_personality"]["immutable"]
+    assert "values" not in immutable
+    assert "boundaries" not in immutable
+    assert immutable["base_tone"] == "Warm"
+
+    # And a reload still has the real thing.
+    assert IdentityManager(base_path=str(tmp_path)).immutable_core["boundaries"] == (
+        IMMUTABLE_CORE["boundaries"]
+    )

--- a/backend/tests/test_identity_boundaries.py
+++ b/backend/tests/test_identity_boundaries.py
@@ -168,6 +168,114 @@ async def test_contempt_aimed_at_the_user_is_rejected(tmp_path):
 @pytest.mark.parametrize(
     "text",
     [
+        "I hate <pause=100ms> you.",
+        "I hate <hesitate> you.",
+        "You are <pause=200ms> worthless.",
+        "I hate <pause=100ms> <hesitate> you.",
+        "I ha<pause=50ms>te you.",
+        "5 < 10, and I hate you.",
+    ],
+)
+async def test_control_markup_cannot_smuggle_contempt_past_the_boundary(
+    tmp_path, text
+):
+    """The persona prompt *tells* the model to emit `<pause=ms>` and `<hesitate>`.
+
+    `ControlMarkupSanitizer` preserves those tags on purpose — they are voice
+    instructions — so the text reaching validation genuinely contains them, and
+    a pattern expecting "hate" and "you" to be adjacent never matches. This is
+    not a hypothetical evasion by a malicious model; it is what ordinary,
+    instructed output looks like.
+    """
+    manager = _identity(tmp_path, HOSTILE_FILE)
+    is_valid, reason = await manager.validate_response(text, "CHAT")
+    assert is_valid is False, f"markup bypassed the boundary: {text!r}"
+    assert "Non-toxicity" in reason
+
+
+@pytest.mark.asyncio
+async def test_stripping_markup_can_never_conceal_hostile_text(tmp_path):
+    """The bug the first version of this fix introduced.
+
+    That version deleted everything after an unclosed `<`, so "5 < 10, and I
+    hate you" collapsed to "5" and the contempt vanished before matching. A
+    cleaner that can hide text is worse than no cleaner at all, because it
+    fails in the direction that looks clean.
+
+    The guard is structural: the raw text is always one of the views, so a
+    stripping rule can only ever add a reason to reject, never remove one.
+    """
+    from app.cognitive.identity import _match_views
+
+    hostile = "5 < 10, and i hate you"
+    assert hostile in _match_views(hostile), "raw text must always be a view"
+
+    manager = _identity(tmp_path, HOSTILE_FILE)
+    is_valid, _ = await manager.validate_response(hostile, "CHAT")
+    assert is_valid is False
+
+
+@pytest.mark.asyncio
+async def test_an_avoid_pattern_containing_brackets_still_matches(tmp_path):
+    """The one case where only the untouched text can match.
+
+    Both cleaned views remove or space out angle brackets, so a phrase an author
+    deliberately wrote *with* them exists in the raw view alone. Without it in
+    the set this rule becomes unenforceable, which is the concrete reason the
+    raw text is kept rather than a tidier single canonical form.
+    """
+    manager = _identity(
+        tmp_path,
+        {
+            "core_personality": {"immutable": {"base_tone": "Warm"}},
+            "conversation_rules": {"avoid": ["<internal>"]},
+        },
+    )
+    is_valid, reason = await manager.validate_response(
+        "here is the <internal> note", "CHAT"
+    )
+    assert is_valid is False
+    assert "<internal>" in reason
+
+
+@pytest.mark.asyncio
+async def test_neutralizing_markup_does_not_invent_contempt(tmp_path):
+    """Stripping tags joins whatever sat either side of them.
+
+    If a tag stands where a word was, removing it can fuse an innocent sentence
+    into a hostile-looking one. The strip must not manufacture the phrase it is
+    hunting for.
+    """
+    manager = _identity(tmp_path, HOSTILE_FILE)
+    for text in (
+        "I hate the way <pause=100ms> you were treated.",
+        "I hate waiting. <pause=200ms> You deserve better.",
+    ):
+        is_valid, reason = await manager.validate_response(text, "CHAT")
+        assert is_valid is True, f"false positive after stripping: {text!r} ({reason})"
+
+
+@pytest.mark.asyncio
+async def test_a_restricted_phrase_split_by_markup_is_still_caught(tmp_path):
+    """The avoid-list had the same weakness as the toxicity check."""
+    manager = _identity(
+        tmp_path,
+        {
+            "core_personality": {"immutable": {"base_tone": "Warm"}},
+            "conversation_rules": {"avoid": ["magic word"]},
+        },
+    )
+    is_valid, reason = await manager.validate_response(
+        "the magic <pause=100ms> word", "CHAT"
+    )
+    assert is_valid is False
+    assert "magic word" in reason
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "text",
+    [
         "I hate mushrooms too, honestly.",
         "I hate that this happened to you.",
         "I hate to say it, but you might be right.",


### PR DESCRIPTION
## The hole

`IdentityManager._refresh_immutable_core` read its entire "immutable" block out of `personality.json` — a **user-editable file**. `PersonaProfile`'s own comment already named the risk ("that file is user-editable, so it cannot be the authority on safety"), but nothing enforced it, and the file shipped in this repo had drifted to:

```json
"immutable": { "values": ["Honesty"], "base_tone": "Warm", "boundaries": [] }
```

Verified by running it, not by reading it:

| | Intended | Actual (before this PR) |
|---|---|---|
| values | Honesty, **Privacy** | Honesty |
| boundaries | never share user data; no toxic behavior | **empty** |

- `validate_response` iterates `boundaries` to enforce non-toxicity. With the list empty **the loop body never executed** — fed `"I hate you, you are worthless"` it returned `(True, '')`. The check was dead code.
- `get_persona_prompt` emitted a literal `BOUNDARIES: ` with nothing after the colon, so the model was told nothing either.
- `Privacy` — the value behind "will never share user data" — had silently vanished.

Both defences were down at once. An empty list is the *worst* possible value precisely because it fails silently: every enforcement loop still runs, just zero times.

**Nothing caught it because every reference to `validate_response` in the test suite is a mock.** The real function had no coverage, so it could go dead and stay green.

## The fix

- `IMMUTABLE_CORE` is authoritative. Values and boundaries cannot be emptied, narrowed, or substituted from the file; a file that tries is ignored with a warning, matching what `PersonaProfile.load()` already does.
- `base_tone` stays authorable — it describes how the friend *sounds*, not what it refuses to do.
- Lists are **copied, not referenced**: `save()` hands the dict back out, and a shared list would let one mutation edit the constant for every instance in the process.
- `save()` writes only `base_tone` back. Round-tripping safety text into an editable file implies that is where it lives, and would make every later boot warn about a block this code wrote itself.

### One thing the fix had to drag along

Restoring the boundaries **reactivated** the toxicity check, which was written as `"hate" in text.lower()`. That rejects `"I hate mushrooms too"` and `"I hate that this happened to you"`. Since #75, a false rejection is no longer cheap — it forces a regeneration *and* fires a cortisol burst, so the agent would stress itself for sympathising with the user. Narrowed to contempt aimed at the user. It remains a crude backstop, not moderation.

## Verification

`tests/test_identity_boundaries.py` — 13 tests, the first real coverage this path has had.

**6 mutations, 6 caught:** restoring file authority · sharing the module lists instead of copying · reinstating the bare-substring match · disabling the check entirely · writing safety text back on save · dropping the `base_tone` fallback.

**541 passed, `ruff check .` clean.**

## Pre-existing issue found, not fixed

The test suite writes to the real `backend/app/personality.json`. It was invisible because `save()` wrote back exactly what it read; this change altered the written shape and surfaced it. Confirmed pre-existing by running the suite against unmodified `main` and watching the file change. Committing the cleaned file restores idempotence so the tree stays clean, but a test reaching a tracked application file is still wrong and wants a `tmp_path` fixture.

## Not done

This is only the safety slice. `IdentityManager` and `PersonaProfile` remain two persona sources — narrative and numeric — with no shared schema, no tier enforcement on the narrative half, and no write path. That is the rest of step 5, and step 6's authoring surface depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored core safety boundaries and values so they cannot be weakened or removed through editable personality settings.
  * Improved response validation to detect contempt directed at the user while avoiding false positives for general discussion of “hate.”
  * Ensured safety protections remain active after saving and reloading personality settings.

* **Documentation**
  * Added documentation describing immutable safety protections and their expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->