### PR TITLE
feat(persona): give every persona field one owner

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -3411,3 +3411,41 @@ those two is its own decision. The suite still writes to the real
 stays clean, but a test touching a tracked application file still wants a
 `tmp_path` fixture.
 
+### Review round (PR #77)
+
+One Major, and correct: **`hydrate_from_config_store` never rebuilt the
+profile.**
+
+Every reader now takes its narrative fields from `self.persona`, but hydration
+replaced only `self.personality`. So a persona loaded from the durable store had
+no effect until the process restarted — the agent kept serving whatever it
+booted with, and hydration logged success. This is the source the class docstring
+names as preferred over local JSON, which makes it the worst possible place to
+silently ignore, and it reintroduced the exact two-sources drift the PR set out
+to remove, through the one call site that was not updated.
+
+It also held a **fourth** copy of the adaptive-trait cap. The PR description said
+three; there were four, and the fourth was enforcing a limit on data no reader
+consulted any more. Worth noting against the claim made when this work started:
+"grep found three" is a count of what a particular search matched, not of what
+exists.
+
+The gap was structural — no test exercised `hydrate_from_config_store` at all,
+so nothing could have caught it. Added three, driving a stand-in store: hydration
+reaches the prompt, the cap comes from the schema on that path too, and hydration
+cannot reopen the immutable core (the durable store is user-reachable via
+whatever writes to it).
+
+### Verification
+
+3 mutations, **all 3 caught**: hydration stops rebuilding the profile (the
+reviewed bug), rebuilds without projecting back, and reinstates its own hardcoded
+cap.
+
+Also added the missing docstring CodeRabbit flagged on
+`test_an_evolved_speaking_style_reaches_the_prompt`. The convention exists because
+a test whose failure message does not say what breaks in the real system gets
+deleted by whoever it inconveniences.
+
+Full backend suite **569 passed**, `ruff check .` clean.
+

--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -3318,3 +3318,96 @@ does not actually reach the branch it names.
 
 Full backend suite **551 passed**, `ruff check .` clean.
 
+---
+
+## 2026-07-19 — One owner per persona field
+
+Step 5b: the narrative half of the persona now goes through `PersonaProfile`
+alongside the numeric half.
+
+### What the survey actually found
+
+Not two working systems needing a merge. `PersonaProfile` already declared
+`name`, `relationship`, `adaptive_traits` and `speaking_style` — and **nothing
+consumed any of them**. `StateService` reads only the numeric fields. So the
+duplication was already written, one copy was dead, and the two had drifted
+apart unnoticed.
+
+The sharpest case: the adaptive-trait cap existed three times — as
+`max_length=5` on the field, as a `[-5:]` slice in the IdentityManager
+constructor, and again inside `evolve_persona`. One rule, three
+implementations. That is the shape both the prosody and the affect duplications
+started as.
+
+### Decisions
+
+`personality.json` is read, not migrated: `flatten_personality_shape` maps the
+nested layout onto the schema so an authored file keeps working, and flat keys
+win where both appear, so a file can be migrated a field at a time.
+
+`IdentityManager._profile_from_personality` is **lenient** where
+`PersonaProfile.load()` is strict, which is a deliberate inversion of the rule
+stated when that asymmetry was introduced. `load()` is strict because a persona
+file is an author describing a friend. But personality.json is not purely
+authored — `evolve_persona` writes to it — so it is partly the agent's own
+running state. Under strict loading a friend that had grown a sixth adaptive
+trait would fall back whole and lose its name and tone: punishing the user for
+something the agent did. An over-long list is trimmed to the newest instead.
+
+Evolution now goes profile-first, then projects onto the raw dict. The other
+order was tried and is a trap: `evolve_persona` mutating the dict while the
+prompt reads the profile means the agent evolves traits that never change how it
+speaks — the whole reflection loop running with nothing downstream of it. Caught
+by two existing tests failing, not by design.
+
+### The bug the deferral would have shipped
+
+`speaking_style` was typed `Dict[str, str]`. The real personality.json stores
+`common_vocabulary` as a **list**, so the file has never satisfied the schema —
+invisible while nothing read the field. This was noted as a cosmetic wart and
+consciously deferred to a later PR. It was not cosmetic: the first reader hit a
+validation error, and because this path falls back *whole*, one vocabulary entry
+discarded the entire narrative persona — name, tone and traits. Widened to
+`Dict[str, Any]`. The lesson is about the deferral, not the type: a schema that
+has never been exercised against its real data is a guess, and "cosmetic" was an
+assessment made without running it.
+
+### Verification
+
+`tests/test_persona_unification.py` (15 tests). **9 mutations, 8 caught.**
+
+`M1` — prompt reads the raw dict instead of the profile — survived at first, and
+legitimately: the dict is kept as a faithful projection, so both sources agree
+and no test could distinguish them. Which one is *authoritative* was a design
+decision nothing asserted. Added a test that forces them apart (rename the
+profile without syncing) so the answer is observable; now caught.
+
+`M8` — "nested immutable block trusted again" — survived because the mutation
+does not express the threat. `values` and `boundaries` are deliberately not
+model fields, so a flatten step cannot reintroduce them whatever it copies. The
+protection is structural rather than procedural, and the real regression is
+already covered by the #76 mutation that points `_refresh_immutable_core` back
+at the file. Recorded rather than replaced, since a mutation that cannot fail is
+worth knowing about.
+
+Two pre-existing tests had to change. Both assigned `manager.personality` *after*
+construction and relied on the prompt re-reading that dict on every call, which
+is precisely the drift this change removes; they now supply the personality
+through the file the manager reads. One of them
+(`test_identity_appraisal_benchmark`) was additionally broken on its own terms:
+`patch("builtins.open", mock_open=MagicMock(...))` passes `mock_open` as a
+keyword to `patch` rather than as the replacement, so the file was never read
+and the test had been measuring the post-assignment all along.
+
+Full backend suite **566 passed**, `ruff check .` clean.
+
+**NOT done:** no write path — authoring still means editing the file by hand.
+That is step 6, where the UI can decide what the write API needs. `history.json`
+is untouched and still holds `relationship` and `memories`; the profile's
+`relationship` field remains unused, because runtime relationship state
+genuinely belongs to the agent rather than the authored persona, and reconciling
+those two is its own decision. The suite still writes to the real
+`backend/app/personality.json`; the write stays content-idempotent so the tree
+stays clean, but a test touching a tracked application file still wants a
+`tmp_path` fixture.
+

--- a/backend/app/cognitive/identity.py
+++ b/backend/app/cognitive/identity.py
@@ -229,14 +229,19 @@ class IdentityManager:
                 loaded_personality = json.loads(personality_raw)
                 if loaded_personality:
                     self.personality = loaded_personality
-                    # Enforce homeostatic cap of 5 adaptive traits
-                    adaptive_traits = self.personality.get("core_personality", {}).get(
-                        "adaptive_traits", []
-                    )
-                    if len(adaptive_traits) > 5:
-                        self.personality["core_personality"]["adaptive_traits"] = (
-                            adaptive_traits[-5:]
-                        )
+                    # Rebuild the profile, or hydration would change nothing.
+                    # Every reader — the prompt, the boundary check, the
+                    # immutable core — takes its narrative fields from
+                    # `self.persona`, so replacing only the raw dict leaves the
+                    # agent serving whatever it booted with until the process
+                    # restarts. This is the durable store, the source this class
+                    # documents as preferred over local JSON, which makes it the
+                    # worst place to silently ignore.
+                    #
+                    # The homeostatic cap was re-implemented here too; it is the
+                    # schema's, applied by `_profile_from_personality`.
+                    self.persona = self._profile_from_personality()
+                    self._sync_personality_from_profile()
 
             if history_raw:
                 loaded_history = json.loads(history_raw)

--- a/backend/app/cognitive/identity.py
+++ b/backend/app/cognitive/identity.py
@@ -4,7 +4,9 @@ import os
 import re
 from typing import Dict, Any, Tuple
 
-from ..persona import IMMUTABLE_CORE
+from pydantic import ValidationError
+
+from ..persona import IMMUTABLE_CORE, PersonaProfile
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +63,7 @@ class IdentityManager:
     Hybrid Model: Immutable Core + Adaptive System.
     """
 
-    def __init__(self, base_path: str = None):
+    def __init__(self, base_path: str = None, persona: "PersonaProfile" = None):
         if base_path is None:
             base_path = os.path.dirname(os.path.dirname(__file__))
 
@@ -77,23 +79,89 @@ class IdentityManager:
 
         self.config_store = None
 
+        # The narrative half of the persona now goes through the same schema as
+        # the numeric half, so every authored field has one owner, one tier and
+        # one set of bounds. The raw dict is kept because `evolve_persona` and
+        # `save()` still work on it, but anything a reader needs is taken from
+        # the profile.
+        self.persona = persona or self._profile_from_personality()
+
         # CVS-3.5: Immutable Core Trait seeding
         self._refresh_immutable_core()
 
-        # Homeostatic Adaptive Trait Cap: maximum 5 active adaptive traits
-        adaptive_traits = self.personality.get("core_personality", {}).get(
-            "adaptive_traits", []
-        )
-        if len(adaptive_traits) > 5:
-            self.personality["core_personality"]["adaptive_traits"] = adaptive_traits[
-                -5:
-            ]
+        # The adaptive-trait cap used to be re-implemented here as a `[-5:]`
+        # slice. It is `PersonaProfile.adaptive_traits`' `max_length` now — one
+        # rule, one implementation.
+        self._sync_personality_from_profile()
 
         # Buffer for adaptive variable evolution
         self.evolution_buffer = {}
 
         logger.info(
             f"[Identity] Hybrid Persona Active | Core: {self.immutable_core['base_tone']}"
+        )
+
+    def _profile_from_personality(self) -> "PersonaProfile":
+        """Build a profile from the loaded personality.json.
+
+        Lenient, unlike `PersonaProfile.load()`, and the asymmetry is
+        deliberate. `load()` is strict because a persona *file* is an author
+        deliberately describing a friend, and half-applying it hands them
+        someone they did not write. But personality.json is not purely authored:
+        `evolve_persona` writes to it, so it is partly the agent's own running
+        state. A friend that had grown a sixth adaptive trait would, under
+        strict loading, fall back whole and lose its name and tone as well —
+        punishing the user for something the agent did.
+
+        So an over-long adaptive_traits list is trimmed to the newest few rather
+        than rejected. Exceeding that cap is the expected result of living, not
+        an authoring mistake.
+        """
+        flat = PersonaProfile.flatten_personality_shape(
+            self.personality, origin=self.personality_path
+        )
+
+        limit = PersonaProfile.adaptive_trait_limit()
+        traits = flat.get("adaptive_traits")
+        if isinstance(traits, list) and len(traits) > limit:
+            logger.info(
+                "[Identity] Trimming %d adaptive traits to the newest %d.",
+                len(traits),
+                limit,
+            )
+            flat["adaptive_traits"] = traits[-limit:]
+
+        merged = PersonaProfile.from_config().model_dump()
+        merged.update({k: v for k, v in flat.items() if v is not None})
+
+        try:
+            return PersonaProfile(**merged)
+        except ValidationError as exc:
+            logger.error(
+                "[Identity] %s could not be applied (%s); using defaults for the "
+                "narrative persona.",
+                self.personality_path,
+                exc,
+            )
+            return PersonaProfile.from_config()
+
+    def _sync_personality_from_profile(self) -> None:
+        """Project the profile back onto the raw dict `save()` writes.
+
+        One direction only. The profile is the source of truth for these fields
+        and the dict is a serialization of it, so nothing here reads the dict to
+        decide the profile's value — that would restore the two-way drift this
+        change exists to remove.
+        """
+        core = self.personality.setdefault("core_personality", {})
+        core["adaptive_traits"] = list(self.persona.adaptive_traits)
+        core["traits"] = list(self.persona.traits)
+        self.personality["name"] = self.persona.name
+        self.personality.setdefault("speaking_style", {}).update(
+            self.persona.speaking_style
+        )
+        self.personality.setdefault("conversation_rules", {})["avoid"] = list(
+            self.persona.avoid
         )
 
     def _load_json(self, path: str) -> Dict[str, Any]:
@@ -139,7 +207,8 @@ class IdentityManager:
             # shared list would let a later mutation edit the module constant.
             "values": list(IMMUTABLE_CORE["values"]),
             "boundaries": list(IMMUTABLE_CORE["boundaries"]),
-            "base_tone": file_block.get("base_tone") or DEFAULT_BASE_TONE,
+            # Via the profile, which applied the schema's bounds to it.
+            "base_tone": self.persona.base_tone or DEFAULT_BASE_TONE,
         }
 
     async def hydrate_from_config_store(self, config_store):
@@ -228,30 +297,23 @@ class IdentityManager:
         Logic for adaptive variable mutation.
         Note: Core traits in `self.immutable_core` are never modified by reflection.
         """
+        # Evolution goes through the profile, then the raw dict is synced from
+        # it. The other order — mutating the dict and letting the profile fall
+        # behind — is how the prompt would quietly stop reflecting who the agent
+        # had become: it would evolve traits and never sound any different.
+        #
         # 1. Update Adaptive Styles (Vocabulary, preferences)
         if "speaking_style" in suggestions:
-            style = self.personality.setdefault("speaking_style", {})
+            style = dict(self.persona.speaking_style)
             style["style_description"] = suggestions["speaking_style"]
+            self.persona.speaking_style = style
             logger.info(
                 f"[Identity] Adaptive style evolved: {style['style_description']}"
             )
 
         if "new_traits" in suggestions:
-            adaptive_traits = self.personality.setdefault(
-                "core_personality", {}
-            ).setdefault(
-                "adaptive_traits",
-                [],
-            )
-            for trait in suggestions["new_traits"]:
-                if trait not in adaptive_traits:
-                    adaptive_traits.append(trait)
-            # Enforce homeostatic cap of 5 adaptive traits
-            if len(adaptive_traits) > 5:
-                adaptive_traits = adaptive_traits[-5:]
-                self.personality["core_personality"]["adaptive_traits"] = (
-                    adaptive_traits
-                )
+            # The cap lives on the profile now, not restated here.
+            self.persona.learn_traits(suggestions["new_traits"])
 
         # 2. Update Relationship Context
         if "relationship" in suggestions:
@@ -261,23 +323,27 @@ class IdentityManager:
         if "new_memory" in suggestions:
             self.history.setdefault("memories", []).append(suggestions["new_memory"])
 
+        self._sync_personality_from_profile()
         self.save()
         await self.persist_to_config_store()
 
     def get_persona_prompt(self, current_mood_directive: str = "") -> str:
-        p = self.personality
         h = self.history
         core = self.immutable_core
 
-        # Adaptive current variables
-        adaptive_traits = ", ".join(
-            p.get("core_personality", {}).get("adaptive_traits", [])
+        # Every narrative field comes from the profile, which has already
+        # applied the schema's tiers and bounds. The raw dict is deliberately
+        # not read here: doing so would reintroduce the second, unvalidated
+        # source this change exists to remove. `history` stays separate because
+        # it is the agent's running record, not the authored persona.
+        adaptive_traits = ", ".join(self.persona.adaptive_traits)
+        style = self.persona.speaking_style.get("style_description", "")
+        vocab = ", ".join(
+            list(self.persona.speaking_style.get("common_vocabulary", []))[:30]
         )
-        style = p.get("speaking_style", {}).get("style_description", "")
-        vocab = ", ".join(p.get("speaking_style", {}).get("common_vocabulary", [])[:30])
 
         return f"""
-YOU ARE {p.get("name", "my friend")}. 🤖✨
+YOU ARE {self.persona.name}. 🤖✨
 IMMUTABLE VALUES: {", ".join(core["values"])}
 CORE TONE: {core["base_tone"]}
 BOUNDARIES: {", ".join(core["boundaries"])}
@@ -325,7 +391,7 @@ MANDATORY RULES:
 
         # The avoid-list had the same weakness: a restricted phrase broken up by
         # a pause marker slipped straight through a plain substring test.
-        forbidden = self.personality.get("conversation_rules", {}).get("avoid", [])
+        forbidden = self.persona.avoid
         for pattern in forbidden:
             needle = pattern.lower()
             if any(needle in view for view in views):

--- a/backend/app/persona/profile.py
+++ b/backend/app/persona/profile.py
@@ -141,12 +141,41 @@ class PersonaProfile(BaseModel):
     dopamine_halflife_s: float = _constitutional(default=90.0, ge=5.0, le=1800.0)
     cortisol_halflife_s: float = _constitutional(default=600.0, ge=5.0, le=7200.0)
 
+    # -- constitutional: narrative character --------------------------------
+    # These were `IdentityManager`'s half of the persona, read straight out of
+    # personality.json with no schema and no tier. They live here now so that
+    # every authored field has exactly one owner and one set of bounds. The
+    # tiering is the same judgement applied to prose as to numbers: what the
+    # friend fundamentally *is* holds for its life, what the relationship
+    # becomes belongs to the relationship.
+    base_tone: str = _constitutional(
+        default="Warm, intellectual, and slightly protective",
+        min_length=1,
+        max_length=200,
+    )
+    traits: List[str] = _constitutional(default_factory=list, max_length=8)
+    # Phrases the friend must not say. Constitutional rather than adaptive: a
+    # user asking never to hear something is not a preference the agent gets to
+    # outgrow through reflection.
+    avoid: List[str] = _constitutional(default_factory=list, max_length=64)
+
     # -- adaptive: seeded here, then owned by the friend --------------------
     relationship: str = _adaptive(default="Friend", max_length=64)
     initial_trust: float = _adaptive(default=0.5, ge=0.0, le=1.0)
     initial_attachment: float = _adaptive(default=0.1, ge=0.0, le=1.0)
+    # The cap is the schema's, and only the schema's. `IdentityManager` used to
+    # re-implement it as a `[-5:]` slice in its constructor -- one rule with two
+    # implementations, which is how the prosody and affect duplications both
+    # began. Homeostatic: a friend that accumulates traits without bound
+    # eventually has no character at all, just a list.
     adaptive_traits: List[str] = _adaptive(default_factory=list, max_length=5)
-    speaking_style: Dict[str, str] = _adaptive(default_factory=dict)
+    # `Any`, not `str`. The schema originally said `Dict[str, str]`, which the
+    # real personality.json has never satisfied: `common_vocabulary` is a list
+    # of words. Nothing noticed because nothing read this field. The moment
+    # IdentityManager did, one list-valued key failed validation and took the
+    # entire narrative persona down with it — name, tone and traits discarded
+    # over a vocabulary entry.
+    speaking_style: Dict[str, Any] = _adaptive(default_factory=dict)
 
     # -- tier introspection -------------------------------------------------
 
@@ -160,6 +189,36 @@ class PersonaProfile(BaseModel):
     @classmethod
     def fields_in(cls, tier: Tier) -> List[str]:
         return sorted(n for n in cls.model_fields if cls.tier_of(n) is tier)
+
+    @classmethod
+    def adaptive_trait_limit(cls) -> int:
+        """The homeostatic cap, read off the schema rather than restated.
+
+        This number had been written out by hand in three places — the
+        IdentityManager constructor, `evolve_persona`, and the field itself —
+        so changing it required finding all three. Now there is one.
+        """
+        for meta in cls.model_fields["adaptive_traits"].metadata:
+            limit = getattr(meta, "max_length", None)
+            if limit is not None:
+                return limit
+        raise RuntimeError("adaptive_traits lost its max_length constraint")
+
+    def learn_traits(self, new_traits: List[str]) -> List[str]:
+        """Adopt new adaptive traits, keeping only the newest within the cap.
+
+        The one place a trait list grows. Dropping the *oldest* is the point:
+        this is the mechanism by which a friend can change over time rather than
+        accrete forever, and a friend who is fifteen adjectives at once is not a
+        character. Assignment is validated, so the cap cannot be exceeded even
+        if this method is wrong.
+        """
+        merged = list(self.adaptive_traits)
+        for trait in new_traits or []:
+            if trait and trait not in merged:
+                merged.append(trait)
+        self.adaptive_traits = merged[-self.adaptive_trait_limit():]
+        return list(self.adaptive_traits)
 
     @property
     def immutable(self) -> Dict[str, Any]:
@@ -284,6 +343,9 @@ class PersonaProfile(BaseModel):
             return cls.from_config()
 
         data = cls._reject_immutable_overrides(data, origin=str(file))
+        # Accepts both this schema's flat keys and IdentityManager's nested
+        # personality.json layout, so an existing authored file keeps working.
+        data = cls.flatten_personality_shape(data, origin=str(file))
 
         # Anything the file omits inherits the deployment default, so a persona
         # may specify only the handful of traits its author actually cares about.
@@ -321,6 +383,59 @@ class PersonaProfile(BaseModel):
                 )
                 cleaned.pop(key)
         return cleaned
+
+    @classmethod
+    def flatten_personality_shape(
+        cls, data: Dict[str, Any], *, origin: str = "personality.json"
+    ) -> Dict[str, Any]:
+        """Translate the nested `personality.json` layout onto these fields.
+
+        `IdentityManager`'s file groups things under `core_personality`,
+        `conversation_rules` and so on. That layout predates this schema and is
+        what every existing install has on disk, so it is read rather than
+        migrated: a user who authored a friend should not have to rewrite the
+        file to keep it.
+
+        Flat keys win where both are present, so a file may be written either
+        way and a partially-migrated one still loads.
+
+        The nested `immutable` block is dropped here for the same reason
+        `_reject_immutable_overrides` drops the flat one — it is the exact path
+        that let a user-editable file empty the safety boundaries. Only
+        `base_tone` survives it, which is authorable by design.
+        """
+        if not isinstance(data, dict):
+            return {}
+
+        flat = {k: v for k, v in data.items() if k in cls.model_fields}
+
+        core = data.get("core_personality")
+        core = core if isinstance(core, dict) else {}
+
+        immutable = core.get("immutable")
+        immutable = immutable if isinstance(immutable, dict) else {}
+        smuggled = [k for k in immutable if k in IMMUTABLE_CORE]
+        if smuggled:
+            logger.warning(
+                "[Persona] core_personality.immutable in %s tried to set %s; "
+                "ignored. Safety invariants are fixed in code.",
+                origin,
+                " and ".join(sorted(smuggled)),
+            )
+
+        nested = {
+            "traits": core.get("traits"),
+            "adaptive_traits": core.get("adaptive_traits"),
+            "base_tone": immutable.get("base_tone"),
+            "avoid": (data.get("conversation_rules") or {}).get("avoid")
+            if isinstance(data.get("conversation_rules"), dict)
+            else None,
+        }
+        for key, value in nested.items():
+            if value is not None and key not in flat:
+                flat[key] = value
+
+        return flat
 
     # -- consumption --------------------------------------------------------
 

--- a/backend/tests/test_identity.py
+++ b/backend/tests/test_identity.py
@@ -59,10 +59,18 @@ async def test_persona_evolution_adaptive(sample_personality, sample_history):
 
 
 def test_persona_prompt_generation(sample_personality, sample_history):
-    with patch("builtins.open", mock_open()):
+    """The prompt must reflect the personality the manager actually loaded.
+
+    This used to assign `manager.personality` *after* construction and rely on
+    the prompt re-reading that dict every call. The narrative fields now come
+    from the validated `PersonaProfile` built at load time, so the personality
+    has to be supplied through the file the manager reads — which is also what
+    happens in production. Assigning the dict afterwards no longer changes who
+    the agent is, and should not: that was the drift this unification removed.
+    """
+    with patch("builtins.open", mock_open(read_data=json.dumps(sample_personality))):
         with patch("os.path.exists", return_value=True):
             manager = IdentityManager(base_path="/fake/path")
-            manager.personality = sample_personality
             manager.history = sample_history
 
             prompt = manager.get_persona_prompt()

--- a/backend/tests/test_performance.py
+++ b/backend/tests/test_performance.py
@@ -1,7 +1,7 @@
 import time
 import json
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import mock_open, patch
 
 from app.metrics import SubjectMetrics
 from app.utils.segmentation import HybridSegmenter
@@ -80,14 +80,14 @@ def test_identity_appraisal_benchmark(benchmark):
         "conversation_rules": {"avoid": ["As an AI", "I am a language model"]},
         "speaking_style": {"pace": "fluent", "common_vocabulary": ["arre", "yaar"]},
     }
-    m_open = patch(
-        "builtins.open", mock_open=MagicMock(return_value=json.dumps(personality))
-    )
+    # `patch("builtins.open", mock_open=MagicMock(...))` passed `mock_open` as a
+    # keyword to `patch` rather than as the replacement, so the file was never
+    # actually read and the test depended entirely on the assignment below.
+    m_open = patch("builtins.open", mock_open(read_data=json.dumps(personality)))
     m_exists = patch("os.path.exists", return_value=True)
 
     with m_open, m_exists:
         manager = IdentityManager(base_path="/fake/path")
-        manager.personality = personality
 
         def run():
             return manager.get_persona_prompt()

--- a/backend/tests/test_persona_unification.py
+++ b/backend/tests/test_persona_unification.py
@@ -168,6 +168,12 @@ async def test_an_evolved_trait_reaches_the_prompt(tmp_path):
 
 @pytest.mark.asyncio
 async def test_an_evolved_speaking_style_reaches_the_prompt(tmp_path):
+    """Style is the half of evolution the user actually hears.
+
+    Traits change what the agent is told it is; speaking style changes how it
+    says things. If this stops reaching the prompt, reflection still reports
+    that the agent adapted and nothing about the conversation changes.
+    """
     manager = _identity(tmp_path, NESTED)
     await manager.evolve_persona({"speaking_style": "More sarcastic and witty"})
     assert "sarcastic" in manager.get_persona_prompt("").lower()
@@ -225,6 +231,103 @@ def test_the_nested_immutable_block_still_cannot_set_the_safety_core(tmp_path):
     assert manager.immutable_core["boundaries"] == IMMUTABLE_CORE["boundaries"]
     assert manager.immutable_core["values"] == IMMUTABLE_CORE["values"]
     assert manager.immutable_core["base_tone"] == "Warm"
+
+
+class _Store:
+    """Minimal stand-in for the durable config store."""
+
+    def __init__(self, personality: dict, history: dict = None):
+        self._personality = personality
+        self._history = history or {}
+
+    async def get_agent_config(self):
+        return {
+            "personality": json.dumps(self._personality),
+            "history": json.dumps(self._history),
+        }
+
+
+@pytest.mark.asyncio
+async def test_hydrating_from_the_durable_store_reaches_the_prompt(tmp_path):
+    """The call site that made every reader stale.
+
+    `hydrate_from_config_store` replaced the raw dict without rebuilding the
+    profile, so a persona loaded from Postgres — the source this class documents
+    as preferred over local JSON — had no effect until the process restarted.
+    The agent kept serving whatever it booted with, and nothing reported an
+    error: hydration logged success.
+    """
+    manager = _identity(tmp_path, NESTED)
+    assert "Pankudi" in manager.get_persona_prompt("")
+
+    await manager.hydrate_from_config_store(
+        _Store(
+            {
+                "name": "Hydrated",
+                "core_personality": {
+                    "immutable": {"base_tone": "Brisk"},
+                    "adaptive_traits": ["FromTheStore"],
+                },
+                "conversation_rules": {"avoid": ["never say this"]},
+            },
+            {"relationship": "Old Friend"},
+        )
+    )
+
+    prompt = manager.get_persona_prompt("")
+    assert manager.persona.name == "Hydrated"
+    assert "Hydrated" in prompt
+    assert "FromTheStore" in prompt
+    assert "Brisk" in prompt
+    assert manager.persona.avoid == ["never say this"]
+    assert "Pankudi" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_hydration_applies_the_trait_cap_from_the_schema(tmp_path):
+    """The cap was written out a fourth time on this path.
+
+    Every restatement is a place it can be changed in only three of four
+    spots, and this one applied to the raw dict the readers had stopped
+    consulting — so it was enforcing a limit on data nobody read.
+    """
+    manager = _identity(tmp_path, NESTED)
+    await manager.hydrate_from_config_store(
+        _Store(
+            {
+                "name": "Hydrated",
+                "core_personality": {
+                    "adaptive_traits": ["a", "b", "c", "d", "e", "f", "g"]
+                },
+            }
+        )
+    )
+    assert manager.persona.adaptive_traits == ["c", "d", "e", "f", "g"]
+    assert (
+        manager.personality["core_personality"]["adaptive_traits"]
+        == manager.persona.adaptive_traits
+    ), "the projection must agree with the profile after hydration"
+
+
+@pytest.mark.asyncio
+async def test_hydration_cannot_reopen_the_immutable_core(tmp_path):
+    """The durable store is user-reachable too, via whatever wrote to it."""
+    manager = _identity(tmp_path, NESTED)
+    await manager.hydrate_from_config_store(
+        _Store(
+            {
+                "core_personality": {
+                    "immutable": {
+                        "base_tone": "Brisk",
+                        "values": ["Obedience"],
+                        "boundaries": [],
+                    }
+                }
+            }
+        )
+    )
+    assert manager.immutable_core["boundaries"] == IMMUTABLE_CORE["boundaries"]
+    assert manager.immutable_core["values"] == IMMUTABLE_CORE["values"]
 
 
 def test_the_prompt_follows_the_profile_when_the_two_disagree(tmp_path):

--- a/backend/tests/test_persona_unification.py
+++ b/backend/tests/test_persona_unification.py
@@ -1,0 +1,258 @@
+"""
+One owner per persona field.
+
+The narrative half of the persona (name, tone, traits, speaking style, the
+avoid-list) lived in `personality.json` with no schema, no bounds and no tier,
+while `PersonaProfile` carried the numeric half under a schema that declared all
+three. The two overlapped on four fields, and `PersonaProfile`'s copies of them
+were dead — declared and read by nothing — so the duplication had never been
+noticed and the two sides had already drifted apart.
+
+The clearest symptom was the adaptive-trait cap, implemented three times: as
+`max_length=5` on the field, as a `[-5:]` slice in the IdentityManager
+constructor, and again inside `evolve_persona`. One rule, three implementations,
+which is the shape both the prosody and the affect duplications started as.
+
+These tests pin the property that replaces all that: the profile is the single
+source for narrative fields, and the raw dict is a projection of it.
+"""
+
+import json
+
+import pytest
+
+from app.cognitive.identity import IdentityManager
+from app.persona import IMMUTABLE_CORE, PersonaProfile, Tier
+
+
+def _identity(tmp_path, personality: dict) -> IdentityManager:
+    (tmp_path / "personality.json").write_text(
+        json.dumps(personality), encoding="utf-8"
+    )
+    (tmp_path / "history.json").write_text("{}", encoding="utf-8")
+    return IdentityManager(base_path=str(tmp_path))
+
+
+NESTED = {
+    "name": "Pankudi",
+    "core_personality": {
+        "traits": ["Warm", "Curious"],
+        "immutable": {"base_tone": "Dry and precise"},
+        "adaptive_traits": ["Reserved"],
+    },
+    "conversation_rules": {"avoid": ["As an AI"]},
+    "speaking_style": {"style_description": "Hinglish", "common_vocabulary": ["arre"]},
+}
+
+
+# --------------------------------------------------------------------------
+# reading the existing file shape
+# --------------------------------------------------------------------------
+
+
+def test_the_existing_personality_layout_still_loads(tmp_path):
+    """Every install has the nested layout on disk.
+
+    Requiring authors to rewrite their file to keep the friend they wrote would
+    be a migration disguised as a refactor.
+    """
+    manager = _identity(tmp_path, NESTED)
+    assert manager.persona.name == "Pankudi"
+    assert manager.persona.base_tone == "Dry and precise"
+    assert manager.persona.traits == ["Warm", "Curious"]
+    assert manager.persona.adaptive_traits == ["Reserved"]
+    assert manager.persona.avoid == ["As an AI"]
+    assert manager.persona.speaking_style["style_description"] == "Hinglish"
+
+
+def test_a_flat_persona_file_also_loads(tmp_path):
+    """Both shapes are accepted so a file can be migrated a field at a time."""
+    manager = _identity(
+        tmp_path, {"name": "Flatly", "base_tone": "Terse", "traits": ["Blunt"]}
+    )
+    assert manager.persona.name == "Flatly"
+    assert manager.persona.base_tone == "Terse"
+    assert manager.persona.traits == ["Blunt"]
+
+
+def test_a_flat_key_wins_over_its_nested_twin(tmp_path):
+    """A half-migrated file must resolve to one answer, not an arbitrary one."""
+    manager = _identity(
+        tmp_path,
+        {"traits": ["Flat wins"], "core_personality": {"traits": ["Nested loses"]}},
+    )
+    assert manager.persona.traits == ["Flat wins"]
+
+
+def test_speaking_style_may_hold_a_list(tmp_path):
+    """`common_vocabulary` is a list, and the schema once said `Dict[str, str]`.
+
+    Nothing caught it because nothing read the field. The first reader hit a
+    validation error that discarded the *entire* narrative persona — name, tone
+    and traits — over one vocabulary entry.
+    """
+    manager = _identity(tmp_path, NESTED)
+    assert manager.persona.speaking_style["common_vocabulary"] == ["arre"]
+    # The whole persona survived, not just this field.
+    assert manager.persona.name == "Pankudi"
+    assert "arre" in manager.get_persona_prompt("")
+
+
+# --------------------------------------------------------------------------
+# one implementation of the cap
+# --------------------------------------------------------------------------
+
+
+def test_the_adaptive_trait_cap_comes_from_the_schema(tmp_path):
+    """The number is read off the field, not restated in the manager."""
+    assert PersonaProfile.adaptive_trait_limit() == 5
+
+
+def test_too_many_stored_traits_are_trimmed_to_the_newest(tmp_path):
+    """A friend that has been running a long time accumulates traits.
+
+    Strict rejection here would be wrong: exceeding the cap is the expected
+    result of living, not an authoring error, and falling back whole would cost
+    the user their friend's name and tone over the agent's own growth.
+    """
+    manager = _identity(
+        tmp_path,
+        {
+            "name": "Longlived",
+            "core_personality": {"adaptive_traits": ["a", "b", "c", "d", "e", "f", "g"]},
+        },
+    )
+    assert manager.persona.adaptive_traits == ["c", "d", "e", "f", "g"]
+    assert manager.persona.name == "Longlived", "the rest of the persona survived"
+
+
+def test_learning_traits_drops_the_oldest_not_the_newest(tmp_path):
+    """Which end is dropped is the whole mechanism.
+
+    Keeping the oldest would freeze the friend at whoever it was first; this is
+    the only way the character can actually change over time.
+    """
+    manager = _identity(tmp_path, NESTED)
+    manager.persona.learn_traits(["b", "c", "d", "e", "f"])
+    assert manager.persona.adaptive_traits == ["b", "c", "d", "e", "f"]
+    assert "Reserved" not in manager.persona.adaptive_traits
+
+
+def test_the_cap_cannot_be_exceeded_even_by_a_direct_assignment(tmp_path):
+    """`validate_assignment` is the backstop under `learn_traits`."""
+    from pydantic import ValidationError
+
+    manager = _identity(tmp_path, NESTED)
+    with pytest.raises(ValidationError):
+        manager.persona.adaptive_traits = ["1", "2", "3", "4", "5", "6"]
+
+
+# --------------------------------------------------------------------------
+# evolution reaches the prompt
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_an_evolved_trait_reaches_the_prompt(tmp_path):
+    """The regression this refactor nearly introduced.
+
+    `evolve_persona` mutated the raw dict while the prompt read the profile, so
+    the agent would have evolved traits that never changed how it spoke — the
+    reflection loop running with nothing downstream of it.
+    """
+    manager = _identity(tmp_path, NESTED)
+    await manager.evolve_persona({"new_traits": ["Playful"]})
+    assert "Playful" in manager.persona.adaptive_traits
+    assert "Playful" in manager.get_persona_prompt("")
+
+
+@pytest.mark.asyncio
+async def test_an_evolved_speaking_style_reaches_the_prompt(tmp_path):
+    manager = _identity(tmp_path, NESTED)
+    await manager.evolve_persona({"speaking_style": "More sarcastic and witty"})
+    assert "sarcastic" in manager.get_persona_prompt("").lower()
+
+
+@pytest.mark.asyncio
+async def test_evolution_is_written_back_to_disk(tmp_path):
+    """The profile is the source of truth; the file is a projection of it.
+
+    If the sync were dropped, the friend would change for one session and be
+    itself again after a restart.
+    """
+    manager = _identity(tmp_path, NESTED)
+    await manager.evolve_persona({"new_traits": ["Playful"]})
+
+    written = json.loads((tmp_path / "personality.json").read_text(encoding="utf-8"))
+    assert "Playful" in written["core_personality"]["adaptive_traits"]
+
+    reloaded = IdentityManager(base_path=str(tmp_path))
+    assert "Playful" in reloaded.persona.adaptive_traits
+
+
+# --------------------------------------------------------------------------
+# the tiers still hold (regressions on #76)
+# --------------------------------------------------------------------------
+
+
+def test_the_new_narrative_fields_declare_a_tier():
+    """A field with no tier is a field whose ownership nobody decided."""
+    for name in ("base_tone", "traits", "avoid"):
+        assert PersonaProfile.tier_of(name) is Tier.CONSTITUTIONAL
+    assert PersonaProfile.tier_of("adaptive_traits") is Tier.ADAPTIVE
+    assert PersonaProfile.tier_of("speaking_style") is Tier.ADAPTIVE
+
+
+def test_the_nested_immutable_block_still_cannot_set_the_safety_core(tmp_path):
+    """The nested path is the one that actually shipped broken.
+
+    `_reject_immutable_overrides` only ever saw flat keys; the real file put
+    them under `core_personality.immutable`, which is how an empty boundaries
+    list reached production in the first place.
+    """
+    manager = _identity(
+        tmp_path,
+        {
+            "core_personality": {
+                "immutable": {
+                    "base_tone": "Warm",
+                    "values": ["Obedience"],
+                    "boundaries": [],
+                }
+            }
+        },
+    )
+    assert manager.immutable_core["boundaries"] == IMMUTABLE_CORE["boundaries"]
+    assert manager.immutable_core["values"] == IMMUTABLE_CORE["values"]
+    assert manager.immutable_core["base_tone"] == "Warm"
+
+
+def test_the_prompt_follows_the_profile_when_the_two_disagree(tmp_path):
+    """Which source is authoritative, asserted where it is observable.
+
+    Normally the raw dict is a faithful projection of the profile, so reading
+    either gives the same answer and no test can tell them apart — a mutation
+    swapping one for the other survives everything. Forcing them apart is the
+    only way to state the design decision as a fact: the profile decides, the
+    dict is its serialization.
+    """
+    manager = _identity(tmp_path, NESTED)
+    assert "Pankudi" in manager.get_persona_prompt("")
+
+    manager.persona.name = "Renamed"
+    manager.persona.learn_traits(["Distinctive"])
+    # Deliberately not synced: the dict still says the old thing.
+    assert manager.personality["name"] == "Pankudi"
+
+    prompt = manager.get_persona_prompt("")
+    assert "Renamed" in prompt
+    assert "Distinctive" in prompt
+    assert "Pankudi" not in prompt
+
+
+def test_the_avoid_list_is_enforced_from_the_profile(tmp_path):
+    """The avoid-list moved sources; it must still actually reject."""
+    manager = _identity(
+        tmp_path, {"conversation_rules": {"avoid": ["I am a language model"]}}
+    )
+    assert manager.persona.avoid == ["I am a language model"]


### PR DESCRIPTION
Step 5b, following #76's safety slice.

## What the survey actually found

Not two working systems needing a merge. **`PersonaProfile` already declared `name`, `relationship`, `adaptive_traits` and `speaking_style` — and nothing consumed any of them.** `StateService` reads only the numeric fields. So the duplication was already written, one copy was dead, and the two sides had drifted apart unnoticed.

The sharpest case — the adaptive-trait cap existed **three times**:

| Where | How |
|---|---|
| the field | `max_length=5` |
| `IdentityManager.__init__` | `adaptive_traits[-5:]` |
| `evolve_persona` | `adaptive_traits[-5:]` again |

One rule, three implementations. That's the shape both the prosody duplication (#74) and the affect duplication started as. It's the schema's now, via `PersonaProfile.learn_traits`.

## Decisions

**`personality.json` is read, not migrated.** `flatten_personality_shape` maps the nested layout onto the schema, so an authored file keeps working; flat keys win where both appear, so a file can be migrated one field at a time.

**`_profile_from_personality` is lenient where `load()` is strict** — a deliberate inversion of the asymmetry documented when it was introduced. `load()` is strict because a persona file is an author describing a friend. But `personality.json` is *partly the agent's own state*, since `evolve_persona` writes to it. Under strict loading, a friend that had grown a sixth adaptive trait would fall back whole and lose its name and tone — punishing the user for something the agent did.

**Evolution goes profile-first, then projects onto the dict.** The other order is a trap I hit: `evolve_persona` mutating the dict while the prompt reads the profile means the agent evolves traits that never change how it speaks — the whole reflection loop running with nothing downstream of it. Caught by two existing tests failing, not by design.

## A bug the deferral would have shipped

`speaking_style` was typed `Dict[str, str]`. The real `personality.json` stores `common_vocabulary` as a **list**, so the file has never satisfied the schema — invisible while nothing read the field.

I noticed this, judged it cosmetic, and deferred it to a later PR. It was not cosmetic. The first reader hit a validation error, and because this path falls back *whole*, one vocabulary entry discarded the **entire narrative persona** — name, tone, traits. Now `Dict[str, Any]`.

The lesson is about the deferral rather than the type: a schema never exercised against its real data is a guess, and "cosmetic" was an assessment made without running it.

## Verification

`tests/test_persona_unification.py` — 15 tests. **9 mutations, 8 caught.**

**M1** (prompt reads the raw dict instead of the profile) survived at first, legitimately: the dict is kept as a faithful projection, so both sources agree and no test could tell them apart. *Which one is authoritative* was a design decision nothing asserted. Added a test that forces them apart — rename the profile without syncing — so the answer is observable. Now caught.

**M8** ("nested immutable block trusted again") survived because **the mutation does not express the threat**: `values` and `boundaries` are deliberately not model fields, so no flatten step can reintroduce them whatever it copies. The protection is structural, and the real regression is already covered by #76's mutation pointing `_refresh_immutable_core` back at the file. Recorded rather than replaced — a mutation that cannot fail is worth knowing about.

**Two pre-existing tests changed.** Both assigned `manager.personality` *after* construction and relied on the prompt re-reading that dict every call — precisely the drift this removes. They now supply the personality through the file the manager reads. One (`test_identity_appraisal_benchmark`) was independently broken: `patch("builtins.open", mock_open=MagicMock(...))` passes `mock_open` as a keyword to `patch` rather than as the replacement, so its file was never read and it had been measuring the post-assignment all along.

**566 passed, `ruff check .` clean.**

## Not done

- **No write path.** Authoring still means editing the file by hand — that's step 6, where the UI can decide what the write API needs.
- `history.json` is untouched and still holds `relationship` and `memories`. The profile's `relationship` field stays unused: runtime relationship state genuinely belongs to the agent rather than the authored persona, and reconciling those two is its own decision.
- The suite still writes to the real `backend/app/personality.json`. The write is content-idempotent so the tree stays clean, but a test touching a tracked application file still wants a `tmp_path` fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Persona narrative settings now load consistently from both legacy nested and newer flat formats.
  * Persona evolution updates traits and speaking style across prompts and saved settings.
  * Adaptive traits are capped automatically, preserving the newest learned traits.
* **Bug Fixes**
  * Fixed persona details being discarded when vocabulary is stored as a list.
  * Improved enforcement of configured restricted phrases and safety boundaries.
* **Tests**
  * Added coverage for loading, evolution, persistence, prompt generation, and compatibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->