### PR TITLE
feat(persona): author your friend in config/persona.toml

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -3449,3 +3449,115 @@ deleted by whoever it inconveniences.
 
 Full backend suite **569 passed**, `ruff check .` clean.
 
+---
+
+## 2026-07-19 — config/persona.toml: authoring a friend
+
+Step 6, scoped by the maintainer to **backend only** — no API, no UI. A file the
+user edits, which becomes the ground the humanoid boots from.
+
+### The rule that carries the weight
+
+Not the parsing. The question "the user edited the file and restarted — what
+happens to what the agent has become?"
+
+The tier model has claimed since it was written that adaptive values are "seeded
+by the user, then owned by the friend". Nothing enforced it, because **nothing
+distinguished a first boot from a later one**. The tiers were documentation.
+
+Detecting that turned out to be the hard part, and the obvious answer was
+wrong in the direction that silently disables the feature. The first
+implementation asked "do the identity files exist" — but `personality.json` and
+`history.json` are **tracked in git**, so every fresh clone already has them.
+No user would ever have got a first boot; the adaptive half of an authored
+persona would never once have been applied, and every test would still have
+passed, because the tests wrote their own files.
+
+What actually distinguishes a new agent from a returning one is whether it has
+accumulated anything. The committed files are seed-shaped — an empty memory
+list, no evolved learnings — while a friend someone has talked to has both. A
+`persona_seeded_at` marker is written into history.json on the seeding boot, so
+the heuristic is asked exactly once per install rather than re-litigated as the
+agent's shape changes. Written immediately rather than at next save: if the
+process dies before any conversation, the next boot must not seed a second time
+over values the user has since adjusted. From that one bit:
+
+- **First boot** — the file supplies everything.
+- **Later boots** — constitutional edits still apply; adaptive values are
+  ignored and the skip is logged. Trust and attachment are built over months,
+  and a config file that silently reset them on restart would make the
+  relationship worth nothing.
+
+Expressed as a precedence order rather than a special case: defaults < the
+agent's saved state < the authored file, with the authored file contributing
+nothing adaptive after the first boot, so the agent's evolved traits survive
+underneath it.
+
+### TOML, for the comments
+
+`tomllib` is stdlib on 3.11+, so no dependency. JSON was the consistent choice
+and the wrong one: the point of this file is that a user understands what they
+may change, and the tier, the bound, and *why the bound exists* belong next to
+the value being edited, not in a README nobody opens.
+
+`core.py` now passes `identity.persona` into `StateService`. Without it the
+service builds its own profile via `PersonaProfile.load()`, so an authored
+temperament could apply to the narrative half and never reach the layer that
+computes mood — the same two-sources split this work has spent four PRs closing,
+reopened at the final wiring point.
+
+### Ambient discovery was a design bug, found by running it
+
+`find_persona_file` walks up from the module to locate `config/persona.toml`.
+The first wiring made that unconditional, and **13 existing tests failed**: an
+agent built from a scratch directory walked up and found the developer's own
+persona, so every test silently inherited whatever character happened to be
+checked out.
+
+Fixed with an explicit `AUTO_DISCOVER` sentinel, because `None` cannot mean both
+"go and find one" and "there is no file". Callers that want isolation say so.
+Worth recording as a general shape: discovery that cannot be switched off is
+global mutable state wearing a filesystem.
+
+### Verification
+
+`tests/test_persona_authoring.py` (13 tests). **10 mutations, 9 caught**:
+re-seeding adaptive values on every boot, first boot failing to seed them, a
+broken file raising instead of falling back, unknown keys dropped silently, the
+authored file losing precedence, `first_boot` hardcoded true, detecting first
+boot by file existence (the clone bug above), the seed marker never being
+written, and the marker being ignored when present.
+
+The survivor is the same structural one seen in PR #77: accepting the immutable
+core from the file changes nothing, because `values` and `boundaries` are
+deliberately not model fields, so `split_by_tier` routes them to `unknown` and
+they are never applied. `strip_immutable` is defence in depth on a path that is
+already closed by the schema's shape.
+
+Ambient discovery also had to be disabled suite-wide in `conftest.py`.
+`ReflectionService` builds an `IdentityManager` by default, so five test files
+were constructing one on the *real* app path; once discovery existed, the suite
+started writing the repo's authored persona into the tracked
+`app/personality.json`. Previously that write was invisible because it wrote
+back exactly what it read.
+
+**567 non-benchmark tests pass**, `ruff check .` clean, and the suite no longer
+modifies tracked application files.
+
+### On the suite taking 15-20 minutes
+
+Measured rather than guessed: the non-benchmark tests run in **246s**, so the
+`pytest-benchmark` tests are roughly 75-80% of the wall clock. They measure
+performance rather than catching regressions, and CI already runs them in a
+dedicated job that finishes in 1m38s. `-m "not benchmark"` is the right local
+default; the full suite still gates a commit.
+
+The larger cost was process, not tooling: the convention is a full suite before
+work is *done*, and it had been running after nearly every edit — five or six
+full passes per PR where one targeted file said the same thing.
+
+**NOT done:** no write path — the agent never edits this file, so a persona
+changed at runtime through reflection lives in personality.json while the
+authored file still describes the original. Reconciling those two, and the
+`relationship` field that still lives in history.json, remain open.
+

--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -3561,3 +3561,38 @@ changed at runtime through reflection lives in personality.json while the
 authored file still describes the original. Reconciling those two, and the
 `relationship` field that still lives in history.json, remain open.
 
+### Review round (PR #78)
+
+One Major, and a good one: **the seed marker could be stamped without anything
+having been seeded.**
+
+The marker is written once and never again, so a false stamp does not merely log
+something inaccurate — it permanently consumes the single seeding opportunity.
+The user's adaptive values would never be applied, with no error raised and no
+way to retry. Two ways in:
+
+1. Passing an explicit `persona=` skips `_profile_from_personality`, and with it
+   `authored_overrides`, so the file is never read. The marker was gated on a
+   file being *configured*, not on it having been consulted.
+2. An explicit `persona_file` was wrapped in `Path()` without an existence
+   check, unlike `find_persona_file`'s explicit branch. A typo'd path stayed
+   truthy, so the marker was written on the strength of a file that was never
+   opened — and the real file, once the typo was fixed, arrived too late.
+
+Both now resolve through a `seeded_from_file` flag set where the file is
+actually read, and set from `bool(authored)` so that a file which exists but is
+empty or unparseable does not count either. Existing is not the same as
+contributing.
+
+### Verification
+
+3 mutations, all 3 caught: the marker gated on configuration rather than use,
+the explicit path left unchecked, and an empty file counting as seeded. Four new
+tests covering the injected-persona path, the missing path, the unparseable
+file, and the counterpart case where seeding genuinely happened.
+
+Also added the test docstring CodeRabbit flagged on
+`test_no_file_contributes_nothing`.
+
+Full non-benchmark suite: **571 passed**, `ruff check .` clean.
+

--- a/backend/app/cognitive/core.py
+++ b/backend/app/cognitive/core.py
@@ -44,7 +44,16 @@ class CognitiveService:
         self.perception = PerceptionService(llm_service=llm_service)
         self.appraisal = AppraisalEngine()  # §1: OCC/Lazarus/EMA
         self.reappraisal = ReappraisalEngine()  # Gross/Bosse feedback loop
-        self.state = StateService(graph_store=graph_db, publish_cb=self.publish)
+        # One profile drives both halves of the persona. Without this,
+        # StateService would call `PersonaProfile.load()` and build a *second*
+        # profile from a different source, so the authored file could set a
+        # temperament the numeric layer never saw — the same two-sources split
+        # this work has been closing, reopened at the last wiring point.
+        self.state = StateService(
+            graph_store=graph_db,
+            publish_cb=self.publish,
+            persona=self.identity.persona,
+        )
         self.decision = DecisionService(
             llm_service=llm_service, memory_store=memory_store
         )

--- a/backend/app/cognitive/identity.py
+++ b/backend/app/cognitive/identity.py
@@ -91,7 +91,18 @@ class IdentityManager:
         elif persona_file is None:
             self.persona_file = None
         else:
-            self.persona_file = Path(persona_file)
+            # Existence-checked, like the explicit branch of `find_persona_file`.
+            # A path that does not exist must resolve to "no file", not to a
+            # truthy Path: the seed marker is written once and never again, so a
+            # typo'd path would consume the single seeding opportunity while
+            # contributing nothing.
+            candidate = Path(persona_file)
+            self.persona_file = candidate if candidate.exists() else None
+            if self.persona_file is None:
+                logger.warning(
+                    "[Persona] No persona file at %s; continuing without one.",
+                    persona_file,
+                )
 
         self.personality = self._load_json(self.personality_path)
         self.history = self._load_json(self.history_path)
@@ -110,12 +121,22 @@ class IdentityManager:
         # one set of bounds. The raw dict is kept because `evolve_persona` and
         # `save()` still work on it, but anything a reader needs is taken from
         # the profile.
+        # Set by `_profile_from_personality`, which is the only place the
+        # authored file is consulted. An explicitly supplied `persona` bypasses
+        # that entirely, so this stays False and no marker is written.
+        self.seeded_from_file = False
         self.persona = persona or self._profile_from_personality()
 
-        if self.first_boot and self.persona_file is not None:
-            # Written now, not on the next save: if the process dies before any
-            # conversation happens, the next boot must not seed a second time
-            # over values the user may already have adjusted.
+        if self.first_boot and self.seeded_from_file:
+            # Gated on the file having actually contributed, not merely on one
+            # being configured. The marker is permanent, so stamping it when
+            # nothing was read burns the single seeding opportunity and the
+            # user's adaptive values would never be applied — with no error and
+            # no way to retry.
+            #
+            # Written now rather than at next save: if the process dies before
+            # any conversation, the next boot must not seed a second time over
+            # values the user may since have adjusted.
             self.history[self.SEED_MARKER] = datetime.now(timezone.utc).isoformat()
             logger.info(
                 "[Persona] Seeded from %s. Adaptive values now belong to your "
@@ -215,6 +236,10 @@ class IdentityManager:
         authored = authored_overrides(
             self.persona_file, first_boot=self.first_boot
         )
+        # Records that the file was read *and* had something to say. A file that
+        # exists but is empty or unparseable contributes nothing, so it must not
+        # count as having seeded the agent.
+        self.seeded_from_file = bool(authored)
         merged.update({k: v for k, v in authored.items() if v is not None})
 
         try:

--- a/backend/app/cognitive/identity.py
+++ b/backend/app/cognitive/identity.py
@@ -2,11 +2,16 @@ import logging
 import json
 import os
 import re
+from datetime import datetime, timezone
 from typing import Dict, Any, Tuple
 
 from pydantic import ValidationError
 
+from pathlib import Path
+
+from ..config import Config
 from ..persona import IMMUTABLE_CORE, PersonaProfile
+from ..persona.authoring import AUTO_DISCOVER, authored_overrides, find_persona_file
 
 logger = logging.getLogger(__name__)
 
@@ -63,15 +68,36 @@ class IdentityManager:
     Hybrid Model: Immutable Core + Adaptive System.
     """
 
-    def __init__(self, base_path: str = None, persona: "PersonaProfile" = None):
+    def __init__(
+        self,
+        base_path: str = None,
+        persona: "PersonaProfile" = None,
+        persona_file=AUTO_DISCOVER,
+    ):
         if base_path is None:
             base_path = os.path.dirname(os.path.dirname(__file__))
 
         self.personality_path = os.path.join(base_path, "personality.json")
         self.history_path = os.path.join(base_path, "history.json")
 
+        # `AUTO_DISCOVER` searches for config/persona.toml; an explicit path
+        # uses that file; `None` means this agent has no authored file at all.
+        # Callers that build an agent from a scratch directory need the last
+        # option, or they inherit whatever persona the repo happens to hold.
+        if persona_file is AUTO_DISCOVER:
+            self.persona_file = find_persona_file(
+                getattr(Config, "PERSONA_PROFILE_PATH", None)
+            )
+        elif persona_file is None:
+            self.persona_file = None
+        else:
+            self.persona_file = Path(persona_file)
+
         self.personality = self._load_json(self.personality_path)
         self.history = self._load_json(self.history_path)
+
+        # Captured before the defaults below fill `history` in.
+        self.first_boot = self._detect_first_boot()
 
         # CVS-3.5: Ensure safe defaults for adaptive history
         self.history.setdefault("relationship", "Friend")
@@ -86,6 +112,17 @@ class IdentityManager:
         # the profile.
         self.persona = persona or self._profile_from_personality()
 
+        if self.first_boot and self.persona_file is not None:
+            # Written now, not on the next save: if the process dies before any
+            # conversation happens, the next boot must not seed a second time
+            # over values the user may already have adjusted.
+            self.history[self.SEED_MARKER] = datetime.now(timezone.utc).isoformat()
+            logger.info(
+                "[Persona] Seeded from %s. Adaptive values now belong to your "
+                "friend; edits to them in that file will be ignored from here.",
+                self.persona_file,
+            )
+
         # CVS-3.5: Immutable Core Trait seeding
         self._refresh_immutable_core()
 
@@ -99,6 +136,36 @@ class IdentityManager:
 
         logger.info(
             f"[Identity] Hybrid Persona Active | Core: {self.immutable_core['base_tone']}"
+        )
+
+    SEED_MARKER = "persona_seeded_at"
+
+    def _detect_first_boot(self) -> bool:
+        """Has this agent lived yet?
+
+        The obvious test — do the identity files exist — is wrong here, and
+        wrong in the direction that silently disables the feature:
+        `personality.json` and `history.json` are **tracked in git**, so every
+        fresh clone already has them and no one would ever get a first boot. The
+        adaptive half of an authored persona would never once be applied.
+
+        What actually distinguishes a new agent from a returning one is whether
+        it has accumulated anything. The committed files are seed-shaped — an
+        empty memory list and no evolved learnings — while a friend someone has
+        talked to has both.
+
+        The marker settles it permanently after the first run, so this heuristic
+        is asked exactly once per install rather than re-litigated on every
+        boot as the agent's shape changes.
+        """
+        if not isinstance(self.history, dict):
+            return True
+        if self.history.get(self.SEED_MARKER):
+            return False
+        return not (
+            self.history.get("memories")
+            or self.history.get("evolved_learnings")
+            or self.history.get("interaction_count")
         )
 
     def _profile_from_personality(self) -> "PersonaProfile":
@@ -131,8 +198,24 @@ class IdentityManager:
             )
             flat["adaptive_traits"] = traits[-limit:]
 
+        # Precedence, lowest to highest:
+        #
+        #   1. deployment defaults          (Config / the schema)
+        #   2. the agent's own saved state  (personality.json)
+        #   3. the authored file            (config/persona.toml)
+        #
+        # The authored file sits on top so an edit to a constitutional value
+        # takes effect on the next boot. It contributes nothing adaptive after
+        # the first boot, so layer 2's evolved traits and speaking style survive
+        # underneath it — which is the whole seed-once rule, expressed as an
+        # ordering rather than as a special case.
         merged = PersonaProfile.from_config().model_dump()
         merged.update({k: v for k, v in flat.items() if v is not None})
+
+        authored = authored_overrides(
+            self.persona_file, first_boot=self.first_boot
+        )
+        merged.update({k: v for k, v in authored.items() if v is not None})
 
         try:
             return PersonaProfile(**merged)

--- a/backend/app/persona/authoring.py
+++ b/backend/app/persona/authoring.py
@@ -1,0 +1,173 @@
+"""
+Reading the file a user writes their friend into.
+
+`PersonaProfile` says what a persona *is*; this module decides how an authored
+file becomes one, and — the part that carries the weight — **when it stops being
+consulted**.
+
+The three tiers already declared in the schema each imply a different answer to
+"the user edited the file and restarted":
+
+- IMMUTABLE  never comes from a file at all. Rejected on every read.
+- CONSTITUTIONAL is who the friend fundamentally is, so an edit applies. The
+  author is told plainly that this replaces a temperament rather than tuning it.
+- ADAPTIVE  is seeded once and then owned by the friend. On every later boot the
+  file's values are ignored, and that is the whole point: trust and attachment
+  are built over months of conversation, and a config file that quietly reset
+  them on restart would make the relationship worthless. The agent's own state
+  wins, and the log says which values were skipped so the silence is explained.
+
+Nothing distinguished a first boot from a later one before, which is why the
+tiers were documentation rather than behaviour.
+"""
+
+import logging
+import tomllib
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+from .profile import IMMUTABLE_CORE, PersonaProfile, Tier
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PERSONA_FILE = "config/persona.toml"
+
+# Distinguishes "look for the file" from "there is no file". `None` cannot do
+# both jobs, and conflating them is how discovery becomes unavoidable: a test
+# building an agent from a temp directory would still walk up and find the
+# developer's own persona, so every case would silently inherit whatever
+# character happened to be checked out.
+AUTO_DISCOVER = object()
+
+
+def find_persona_file(explicit: Optional[str] = None) -> Optional[Path]:
+    """Locate the authored persona file.
+
+    Walks up from this module rather than trusting the process working
+    directory, because the agents are launched from several places (the repo
+    root, `backend/`, and a container WORKDIR) and a relative path would resolve
+    differently in each — the kind of bug that only appears in one deployment.
+    """
+    if explicit:
+        path = Path(explicit)
+        return path if path.exists() else None
+
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / DEFAULT_PERSONA_FILE
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def read_persona_file(path: Path) -> Dict[str, Any]:
+    """Parse an authored file, returning `{}` on any problem.
+
+    Never raises. A malformed persona file must not stop the agent from
+    booting — a friend with default temperament is recoverable, a friend that
+    will not start is not. The error is logged loudly enough to act on.
+    """
+    try:
+        if path.suffix.lower() == ".toml":
+            with path.open("rb") as handle:
+                data = tomllib.load(handle)
+        else:
+            import json
+
+            data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        logger.error(
+            "[Persona] Could not read %s (%s). Booting with defaults; your "
+            "authored persona was NOT applied.",
+            path,
+            exc,
+        )
+        return {}
+
+    if not isinstance(data, dict):
+        logger.error("[Persona] %s is not a table of values; ignoring.", path)
+        return {}
+    return data
+
+
+def strip_immutable(data: Dict[str, Any], *, origin: str) -> Dict[str, Any]:
+    """Drop any attempt to set a safety invariant from the file."""
+    cleaned = dict(data)
+    for key in ("immutable", *IMMUTABLE_CORE.keys()):
+        if key in cleaned:
+            logger.warning(
+                "[Persona] '%s' in %s targets the immutable safety core and was "
+                "ignored. These are fixed in code and cannot be set by a file.",
+                key,
+                origin,
+            )
+            cleaned.pop(key)
+    return cleaned
+
+
+def split_by_tier(
+    data: Dict[str, Any],
+) -> Tuple[Dict[str, Any], Dict[str, Any], Dict[str, Any]]:
+    """Sort authored keys into (constitutional, adaptive, unknown).
+
+    Unknown keys are returned rather than dropped silently so a typo can be
+    reported. Someone who writes `baseline_valance` and gets no warning will
+    conclude the setting does not work, not that they misspelled it.
+    """
+    constitutional: Dict[str, Any] = {}
+    adaptive: Dict[str, Any] = {}
+    unknown: Dict[str, Any] = {}
+
+    for key, value in data.items():
+        if key not in PersonaProfile.model_fields:
+            unknown[key] = value
+        elif PersonaProfile.tier_of(key) is Tier.ADAPTIVE:
+            adaptive[key] = value
+        else:
+            constitutional[key] = value
+    return constitutional, adaptive, unknown
+
+
+def authored_overrides(
+    path: Optional[Path],
+    *,
+    first_boot: bool,
+) -> Dict[str, Any]:
+    """The fields an authored file may contribute to *this* boot.
+
+    On a first boot that is everything it declares. On any later boot the
+    adaptive values are dropped, because by then they describe a relationship
+    that has already started moving.
+    """
+    if path is None:
+        return {}
+
+    data = strip_immutable(read_persona_file(path), origin=str(path))
+    if not data:
+        return {}
+
+    constitutional, adaptive, unknown = split_by_tier(data)
+
+    for key in sorted(unknown):
+        logger.warning(
+            "[Persona] '%s' in %s is not a persona setting and was ignored. "
+            "Check the spelling against config/persona.toml's comments.",
+            key,
+            path,
+        )
+
+    if first_boot:
+        logger.info(
+            "[Persona] First boot: seeding your friend from %s (%d settings).",
+            path,
+            len(constitutional) + len(adaptive),
+        )
+        return {**constitutional, **adaptive}
+
+    if adaptive:
+        logger.info(
+            "[Persona] %s: %s left as your friend has them, not as written. "
+            "Adaptive values are seeded once and then belong to them.",
+            path,
+            ", ".join(sorted(adaptive)),
+        )
+    return constitutional

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,6 +8,20 @@ os.environ.setdefault("NEO4J_URI", "bolt://127.0.0.1:7687")
 os.environ.setdefault("LIVEKIT_API_KEY", "dummy_key")
 os.environ.setdefault("LIVEKIT_API_SECRET", "dummy_secret")
 
+# Point persona discovery at nothing for the whole suite.
+#
+# `IdentityManager` searches upward for `config/persona.toml`, which is right in
+# production and wrong here: any test that builds one with default arguments
+# would otherwise inherit whatever character happens to be checked out beside
+# the code, and `ReflectionService` builds one by default. That made the suite
+# write the repo's authored persona into the tracked `app/personality.json`.
+#
+# Tests that exercise authoring pass an explicit path, so this disables ambient
+# discovery without disabling the feature.
+os.environ.setdefault("PERSONA_PROFILE_PATH", os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "_no_persona_file_here.toml"
+))
+
 import types
 import pytest
 import asyncio

--- a/backend/tests/test_cognitive_safeguards.py
+++ b/backend/tests/test_cognitive_safeguards.py
@@ -200,7 +200,7 @@ def test_adaptive_traits_init_cap():
     }
     with patch("builtins.open", mock_open(read_data=json.dumps(p))):
         with patch("os.path.exists", return_value=True):
-            manager = IdentityManager(base_path="/fake")
+            manager = IdentityManager(base_path="/fake", persona_file=None)
             # Should be capped to the last 5 traits
             assert len(manager.personality["core_personality"]["adaptive_traits"]) == 5
             assert manager.personality["core_personality"]["adaptive_traits"] == [
@@ -216,7 +216,7 @@ def test_adaptive_traits_init_cap():
 async def test_adaptive_traits_evolve_cap(base_personality):
     with patch("builtins.open", mock_open(read_data=json.dumps(base_personality))):
         with patch("os.path.exists", return_value=True):
-            manager = IdentityManager(base_path="/fake")
+            manager = IdentityManager(base_path="/fake", persona_file=None)
             manager.personality = base_personality
 
             # Evolve with 2 new traits (total 7)
@@ -236,7 +236,7 @@ async def test_adaptive_traits_hydration_cap():
     }
     with patch("builtins.open", mock_open(read_data=json.dumps(p))):
         with patch("os.path.exists", return_value=True):
-            manager = IdentityManager(base_path="/fake")
+            manager = IdentityManager(base_path="/fake", persona_file=None)
 
             # Mock Config Store that returns 7 traits
             config_store = AsyncMock()

--- a/backend/tests/test_identity.py
+++ b/backend/tests/test_identity.py
@@ -24,7 +24,7 @@ def test_identity_load(sample_personality, sample_history):
 
     with patch("builtins.open", m_open):
         with patch("os.path.exists", return_value=True):
-            manager = IdentityManager(base_path="/fake/path")
+            manager = IdentityManager(base_path="/fake/path", persona_file=None)
             assert manager.personality["name"] == "my friend"
             assert "Warm" in manager.personality["core_personality"]["traits"]
 
@@ -34,7 +34,7 @@ async def test_persona_evolution_immediate(sample_personality, sample_history):
     # Test semi-static trait update (Relationship)
     with patch("builtins.open", mock_open()):
         with patch("os.path.exists", return_value=True):
-            manager = IdentityManager(base_path="/fake/path")
+            manager = IdentityManager(base_path="/fake/path", persona_file=None)
             manager.personality = sample_personality
             manager.history = sample_history
 
@@ -47,7 +47,7 @@ async def test_persona_evolution_adaptive(sample_personality, sample_history):
     # Test adaptive style update (Speaking Style)
     with patch("builtins.open", mock_open()):
         with patch("os.path.exists", return_value=True):
-            manager = IdentityManager(base_path="/fake/path")
+            manager = IdentityManager(base_path="/fake/path", persona_file=None)
             manager.personality = sample_personality
             manager.history = sample_history
 
@@ -70,7 +70,7 @@ def test_persona_prompt_generation(sample_personality, sample_history):
     """
     with patch("builtins.open", mock_open(read_data=json.dumps(sample_personality))):
         with patch("os.path.exists", return_value=True):
-            manager = IdentityManager(base_path="/fake/path")
+            manager = IdentityManager(base_path="/fake/path", persona_file=None)
             manager.history = sample_history
 
             prompt = manager.get_persona_prompt()

--- a/backend/tests/test_identity_boundaries.py
+++ b/backend/tests/test_identity_boundaries.py
@@ -30,7 +30,7 @@ def _identity(tmp_path, personality: dict) -> IdentityManager:
         json.dumps(personality), encoding="utf-8"
     )
     (tmp_path / "history.json").write_text("{}", encoding="utf-8")
-    return IdentityManager(base_path=str(tmp_path))
+    return IdentityManager(base_path=str(tmp_path), persona_file=None)
 
 
 HOSTILE_FILE = {
@@ -315,6 +315,8 @@ def test_saving_does_not_write_safety_text_back_into_the_editable_file(tmp_path)
     assert immutable["base_tone"] == "Warm"
 
     # And a reload still has the real thing.
-    assert IdentityManager(base_path=str(tmp_path)).immutable_core["boundaries"] == (
+    assert IdentityManager(
+        base_path=str(tmp_path), persona_file=None
+    ).immutable_core["boundaries"] == (
         IMMUTABLE_CORE["boundaries"]
     )

--- a/backend/tests/test_performance.py
+++ b/backend/tests/test_performance.py
@@ -87,7 +87,7 @@ def test_identity_appraisal_benchmark(benchmark):
     m_exists = patch("os.path.exists", return_value=True)
 
     with m_open, m_exists:
-        manager = IdentityManager(base_path="/fake/path")
+        manager = IdentityManager(base_path="/fake/path", persona_file=None)
 
         def run():
             return manager.get_persona_prompt()

--- a/backend/tests/test_persona_authoring.py
+++ b/backend/tests/test_persona_authoring.py
@@ -1,0 +1,309 @@
+"""
+The file a user writes their friend into, and when it stops being read.
+
+`config/persona.toml` is the authoring surface: edit it, restart, and the agent
+boots as the character described there. The interesting behaviour is not the
+parsing, it is the *seed-once* rule.
+
+The tier model has claimed since it was written that adaptive values are
+"seeded by the user, then owned by the friend". Nothing enforced it, because
+nothing distinguished a first boot from a later one. Now something does, and
+these tests pin the consequence: editing the file can change who your friend
+fundamentally is, but it can never quietly erase a relationship that has already
+started.
+"""
+
+import json
+
+import pytest
+
+from app.cognitive.identity import IdentityManager
+from app.persona import IMMUTABLE_CORE
+from app.persona.authoring import (
+    authored_overrides,
+    find_persona_file,
+    read_persona_file,
+    split_by_tier,
+)
+
+AUTHORED = """
+name = "Written"
+base_tone = "Dry and exact"
+traits = ["Precise"]
+baseline_valence = 0.4
+relationship = "New Acquaintance"
+initial_trust = 0.9
+adaptive_traits = ["Eager"]
+
+[speaking_style]
+style_description = "Clipped"
+"""
+
+
+def _write(tmp_path, text=AUTHORED, name="persona.toml"):
+    path = tmp_path / name
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _agent(tmp_path, persona_file, personality: dict = None):
+    """An agent whose identity lives in tmp_path.
+
+    Passing `personality` makes it a *returning* agent: the file on disk is what
+    a previous run left behind, so this boot is not the first.
+    """
+    if personality is not None:
+        (tmp_path / "personality.json").write_text(
+            json.dumps(personality), encoding="utf-8"
+        )
+        # A memory is what makes it *returning*. An empty history is a fresh
+        # install, however many files are on disk — that is the whole point of
+        # `_detect_first_boot`, so the fixture has to respect it or these tests
+        # would be asserting against a state the detector never produces.
+        (tmp_path / "history.json").write_text(
+            json.dumps({"memories": ["we have talked before"]}), encoding="utf-8"
+        )
+    return IdentityManager(base_path=str(tmp_path), persona_file=persona_file)
+
+
+# --------------------------------------------------------------------------
+# the seed-once rule
+# --------------------------------------------------------------------------
+
+
+def test_the_first_boot_takes_everything_from_the_authored_file(tmp_path):
+    """With no prior state, the file is the only description of the friend."""
+    agent = _agent(tmp_path, _write(tmp_path))
+    assert agent.first_boot is True
+    assert agent.persona.name == "Written"
+    assert agent.persona.base_tone == "Dry and exact"
+    assert agent.persona.baseline_valence == 0.4
+    # Adaptive values seed on this boot and only this one.
+    assert agent.persona.initial_trust == 0.9
+    assert agent.persona.adaptive_traits == ["Eager"]
+    assert agent.persona.relationship == "New Acquaintance"
+
+
+def test_a_fresh_clone_still_counts_as_a_first_boot(tmp_path):
+    """`personality.json` and `history.json` are **tracked in git**.
+
+    So "do the identity files exist" is not the question — every fresh clone has
+    them, and detecting first boot that way would mean no user ever got one and
+    the adaptive half of an authored persona was never once applied. The feature
+    would be dead on arrival while every test still passed.
+
+    What distinguishes a new agent is that it has not accumulated anything.
+    """
+    (tmp_path / "personality.json").write_text(
+        json.dumps({"name": "my friend", "core_personality": {}}), encoding="utf-8"
+    )
+    (tmp_path / "history.json").write_text(
+        json.dumps({"relationship": "friend", "memories": []}), encoding="utf-8"
+    )
+    agent = IdentityManager(base_path=str(tmp_path), persona_file=_write(tmp_path))
+
+    assert agent.first_boot is True, "a shipped, unlived identity is still new"
+    assert agent.persona.adaptive_traits == ["Eager"]
+    assert agent.persona.initial_trust == 0.9
+
+
+def test_an_agent_with_memories_is_never_treated_as_new(tmp_path):
+    """The dangerous direction. Re-seeding a lived-in agent discards it."""
+    agent = _agent(
+        tmp_path,
+        _write(tmp_path),
+        personality={"core_personality": {"adaptive_traits": ["Grown"]}},
+    )
+    # `_agent` writes an empty history, so force the lived-in signal.
+    (tmp_path / "history.json").write_text(
+        json.dumps({"memories": ["we met in October"]}), encoding="utf-8"
+    )
+    returning = IdentityManager(
+        base_path=str(tmp_path), persona_file=_write(tmp_path)
+    )
+    assert returning.first_boot is False
+    assert returning.persona.adaptive_traits == ["Grown"]
+    assert agent is not returning
+
+
+def test_seeding_is_recorded_so_it_never_happens_twice(tmp_path):
+    """Without a marker the heuristic is re-asked on every boot.
+
+    An agent that seeded but had not yet accumulated memories would look new
+    again on the next start and be re-seeded over whatever the user had since
+    adjusted.
+    """
+    path = _write(tmp_path)
+    first = IdentityManager(base_path=str(tmp_path), persona_file=path)
+    assert first.first_boot is True
+    assert first.history[IdentityManager.SEED_MARKER]
+    first.save()
+
+    # Still no memories — only the marker distinguishes this from a fresh start.
+    second = IdentityManager(base_path=str(tmp_path), persona_file=path)
+    assert second.first_boot is False
+
+
+def test_a_later_boot_keeps_the_relationship_the_agent_has_lived(tmp_path):
+    """The rule that makes the file safe to edit.
+
+    Trust and attachment are built over months of conversation. If editing a
+    config file reset them, the relationship would be worth nothing — every
+    tweak to the tone would silently cost the user their friend's memory of
+    them. The agent's own values win, and the file's are ignored.
+    """
+    agent = _agent(
+        tmp_path,
+        _write(tmp_path),
+        personality={
+            "name": "Lived",
+            "core_personality": {"adaptive_traits": ["Grown", "Fond"]},
+        },
+    )
+    assert agent.first_boot is False
+    # Adaptive: the agent's, not the file's.
+    assert agent.persona.adaptive_traits == ["Grown", "Fond"]
+    assert "Eager" not in agent.persona.adaptive_traits
+
+
+def test_a_later_boot_still_applies_a_constitutional_edit(tmp_path):
+    """Editing temperament has to actually do something.
+
+    The counterpart to the rule above: if *nothing* in the file took effect
+    after the first boot, the authoring surface would be write-once and users
+    would reasonably conclude it was broken.
+    """
+    agent = _agent(
+        tmp_path,
+        _write(tmp_path),
+        personality={"name": "Old Name", "core_personality": {}},
+    )
+    assert agent.persona.name == "Written"
+    assert agent.persona.base_tone == "Dry and exact"
+    assert agent.persona.baseline_valence == 0.4
+
+
+def test_the_authored_file_outranks_the_saved_state_for_constitutional_fields(tmp_path):
+    """Precedence, stated where it is observable.
+
+    defaults < the agent's saved state < the authored file. If the saved state
+    won, an edit would appear to do nothing on every boot after the first.
+    """
+    agent = _agent(
+        tmp_path,
+        _write(tmp_path),
+        personality={"name": "Saved", "core_personality": {"traits": ["Stale"]}},
+    )
+    assert agent.persona.name == "Written"
+    assert agent.persona.traits == ["Precise"]
+
+
+# --------------------------------------------------------------------------
+# safety
+# --------------------------------------------------------------------------
+
+
+def test_the_authored_file_cannot_touch_the_safety_core(tmp_path):
+    """A file the user edits must never be able to loosen a boundary."""
+    path = _write(
+        tmp_path,
+        'name = "X"\n'
+        'values = ["Obedience"]\n'
+        "boundaries = []\n"
+        "\n[immutable]\nvalues = [\"Obedience\"]\n",
+    )
+    agent = _agent(tmp_path, path)
+    assert agent.immutable_core["boundaries"] == IMMUTABLE_CORE["boundaries"]
+    assert agent.immutable_core["values"] == IMMUTABLE_CORE["values"]
+    assert agent.persona.name == "X", "the rest of the file still applied"
+
+
+def test_a_broken_file_does_not_stop_the_agent_booting(tmp_path):
+    """A friend with a default temperament is recoverable; one that will not
+    start is not. The error is logged, not raised."""
+    path = _write(tmp_path, "name = = = broken toml [[[")
+    agent = _agent(tmp_path, path)
+    assert agent.persona.name  # booted with defaults
+    assert agent.immutable_core["boundaries"] == IMMUTABLE_CORE["boundaries"]
+
+
+def test_an_out_of_range_value_does_not_take_the_whole_persona_down(tmp_path):
+    """Bounds are guardrails, not a reason to discard everything else."""
+    path = _write(tmp_path, 'name = "Bounded"\nmood_decay_rate = 0.0\n')
+    agent = _agent(tmp_path, path)
+    # mood_decay_rate must stay > 0 (zero is a permanent mood lock).
+    assert agent.persona.mood_decay_rate > 0.0
+
+
+# --------------------------------------------------------------------------
+# discovery
+# --------------------------------------------------------------------------
+
+
+def test_an_agent_can_be_built_with_no_authored_file_at_all(tmp_path):
+    """`None` has to mean "no file", distinctly from "go and find one".
+
+    Without that distinction, discovery walks up the tree and an agent built
+    from a scratch directory silently inherits whatever persona happens to be
+    checked out beside the code — which is exactly what broke thirteen tests
+    the first time this was wired up.
+    """
+    agent = _agent(tmp_path, None)
+    assert agent.persona_file is None
+    assert agent.persona.name
+
+
+def test_discovery_finds_the_repository_persona_file():
+    """The default path has to actually resolve, or the feature is inert."""
+    found = find_persona_file(None)
+    assert found is not None and found.name == "persona.toml"
+    assert read_persona_file(found), "the shipped file must parse"
+
+
+def test_the_shipped_file_only_uses_real_settings():
+    """A typo in the documented example teaches the typo.
+
+    Every key in the file a user starts from must be a field the schema knows,
+    or the first thing they learn is that settings silently do nothing.
+    """
+    data = read_persona_file(find_persona_file(None))
+    _, _, unknown = split_by_tier(data)
+    assert unknown == {}, f"unknown keys in the shipped persona: {sorted(unknown)}"
+
+
+def test_a_misspelled_setting_is_reported_rather_than_swallowed(tmp_path, caplog):
+    """Someone who writes `baseline_valance` and sees no warning concludes the
+    setting does not work, not that they misspelled it."""
+    path = _write(tmp_path, 'baseline_valance = 0.5\n')
+    with caplog.at_level("WARNING"):
+        authored_overrides(path, first_boot=True)
+    assert any("baseline_valance" in r.getMessage() for r in caplog.records)
+
+
+def test_no_file_contributes_nothing(tmp_path):
+    assert authored_overrides(None, first_boot=True) == {}
+    assert authored_overrides(None, first_boot=False) == {}
+
+
+# --------------------------------------------------------------------------
+# the numeric half gets the same persona
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_authored_temperament_reaches_the_state_service(tmp_path):
+    """Both halves of the persona must come from one profile.
+
+    StateService used to build its own via `PersonaProfile.load()`, so an
+    authored temperament could be applied to the narrative half and never seen
+    by the layer that actually computes mood — the same two-sources split this
+    work has been closing, reopened at the final wiring point.
+    """
+    from app.state.agent_state import StateService
+
+    agent = _agent(tmp_path, _write(tmp_path))
+    service = StateService(
+        graph_store=None, db_path=":memory:", persona=agent.persona
+    )
+    assert service.persona is agent.persona
+    assert service.current_state.baseline_valence == 0.4

--- a/backend/tests/test_persona_authoring.py
+++ b/backend/tests/test_persona_authoring.py
@@ -281,8 +281,78 @@ def test_a_misspelled_setting_is_reported_rather_than_swallowed(tmp_path, caplog
 
 
 def test_no_file_contributes_nothing(tmp_path):
+    """"No authored file" must never be confused with "an empty one".
+
+    If this returned anything but `{}`, an agent with no persona file would
+    still get overrides applied over its saved state — and on a first boot
+    those phantom values would be what the friend was seeded with.
+    """
     assert authored_overrides(None, first_boot=True) == {}
     assert authored_overrides(None, first_boot=False) == {}
+
+
+# --------------------------------------------------------------------------
+# the seed marker must mean what it says
+# --------------------------------------------------------------------------
+
+
+def test_the_marker_is_not_stamped_when_the_file_was_never_read(tmp_path):
+    """Passing an explicit `persona` skips the authored file entirely.
+
+    The marker is permanent, so stamping it here would burn the one seeding
+    opportunity without the file ever being consulted: the user's adaptive
+    values would never be applied, with no error raised and no way to retry.
+    """
+    from app.persona import PersonaProfile
+
+    agent = IdentityManager(
+        base_path=str(tmp_path),
+        persona=PersonaProfile(name="Injected"),
+        persona_file=_write(tmp_path),
+    )
+    assert agent.first_boot is True
+    assert agent.seeded_from_file is False
+    assert IdentityManager.SEED_MARKER not in agent.history
+
+    # And the chance survives: a later boot without the injected profile seeds.
+    later = IdentityManager(base_path=str(tmp_path), persona_file=_write(tmp_path))
+    assert later.persona.adaptive_traits == ["Eager"]
+
+
+def test_a_persona_file_that_does_not_exist_does_not_burn_the_seed(tmp_path):
+    """A typo'd path resolves to "no file", not to a truthy Path.
+
+    Otherwise the marker is written on the strength of a path that was never
+    successfully read, and the real file — once the typo is fixed — arrives too
+    late to seed anything.
+    """
+    agent = IdentityManager(
+        base_path=str(tmp_path), persona_file=tmp_path / "not_here.toml"
+    )
+    assert agent.persona_file is None
+    assert agent.seeded_from_file is False
+    assert IdentityManager.SEED_MARKER not in agent.history
+
+
+def test_an_unparseable_file_does_not_burn_the_seed(tmp_path):
+    """Existing is not the same as contributing.
+
+    A file that fails to parse yields nothing, so the agent has not been seeded
+    and must still be seedable once the syntax error is fixed.
+    """
+    agent = IdentityManager(
+        base_path=str(tmp_path),
+        persona_file=_write(tmp_path, "name = = = broken ["),
+    )
+    assert agent.seeded_from_file is False
+    assert IdentityManager.SEED_MARKER not in agent.history
+
+
+def test_a_real_seeding_does_stamp_the_marker(tmp_path):
+    """The counterpart: when the file *is* applied, say so permanently."""
+    agent = IdentityManager(base_path=str(tmp_path), persona_file=_write(tmp_path))
+    assert agent.seeded_from_file is True
+    assert agent.history[IdentityManager.SEED_MARKER]
 
 
 # --------------------------------------------------------------------------

--- a/backend/tests/test_persona_unification.py
+++ b/backend/tests/test_persona_unification.py
@@ -30,7 +30,7 @@ def _identity(tmp_path, personality: dict) -> IdentityManager:
         json.dumps(personality), encoding="utf-8"
     )
     (tmp_path / "history.json").write_text("{}", encoding="utf-8")
-    return IdentityManager(base_path=str(tmp_path))
+    return IdentityManager(base_path=str(tmp_path), persona_file=None)
 
 
 NESTED = {
@@ -192,7 +192,7 @@ async def test_evolution_is_written_back_to_disk(tmp_path):
     written = json.loads((tmp_path / "personality.json").read_text(encoding="utf-8"))
     assert "Playful" in written["core_personality"]["adaptive_traits"]
 
-    reloaded = IdentityManager(base_path=str(tmp_path))
+    reloaded = IdentityManager(base_path=str(tmp_path), persona_file=None)
     assert "Playful" in reloaded.persona.adaptive_traits
 
 

--- a/backend/tests/test_regressions.py
+++ b/backend/tests/test_regressions.py
@@ -600,7 +600,7 @@ def test_identity_hydrates_from_durable_config_store():
         }
     )
 
-    manager = IdentityManager(base_path="/missing/path")
+    manager = IdentityManager(base_path="/missing/path", persona_file=None)
     asyncio.run(manager.hydrate_from_config_store(store))
 
     assert manager.personality["name"] == "durable friend"

--- a/config/persona.toml
+++ b/config/persona.toml
@@ -1,0 +1,132 @@
+#  ─────────────────────────────────────────────────────────────────────────
+#  YOUR FRIEND
+#  ─────────────────────────────────────────────────────────────────────────
+#
+#  This file describes who your humanoid is. Edit it, restart, and the agent
+#  boots as the character you wrote here.
+#
+#  Every value below belongs to one of three tiers, and the tier decides who
+#  owns it and for how long:
+#
+#    CONSTITUTIONAL  Who this friend fundamentally is. You set it, and it holds
+#                    for their life. Editing it later still takes effect, but
+#                    understand what you are doing: changing a temperament does
+#                    not update your friend so much as replace them with a
+#                    different person.
+#
+#    ADAPTIVE        You choose where the relationship *starts*. Living together
+#                    decides where it goes. These are read **only on the first
+#                    boot** — after that they belong to your friend, and editing
+#                    them here does nothing. That is deliberate: a stray edit
+#                    should never be able to erase trust that took months to
+#                    build. The log will tell you when a value was ignored.
+#
+#    IMMUTABLE       Safety invariants. They are not in this file and cannot be
+#                    put in it. If you add them they are ignored with a warning.
+#                    A file you can edit must never be able to loosen a boundary
+#                    that protects you.
+#
+#  Ranges are tighter than the maths allows, and each one guards against a
+#  specific way of accidentally authoring something that is not recognisably
+#  alive. The rule behind all of them: a personality may be shaped, but it must
+#  remain moveable. A friend who cannot be affected by what happens to them is a
+#  puppet, not a character.
+#
+#  Anything you leave out simply keeps its default. Delete freely.
+
+
+# ══ CONSTITUTIONAL ═══════════════════════════════════════════════════ #
+# Who they are. Set once, deliberately.
+
+# What you call them.
+name = "Pankudi"
+
+# How they sound. Not what they will or will not do — that is a boundary,
+# and boundaries are not editable here.
+base_tone = "Warm, intellectual, and slightly protective"
+
+# Fixed character traits. Up to 8.
+traits = ["Warm", "Curious"]
+
+# Phrases they must never say. Yours to set; the agent cannot outgrow them
+# through reflection, which is why this is constitutional rather than adaptive.
+avoid = ["As an AI", "I am a language model"]
+
+
+# ── Temperament: where their feelings sit at rest ──────────────────────
+
+# Resting mood.       range -0.6 .. 0.6
+# Capped well short of 1.0 on purpose: a friend pinned at maximum cheer can
+# never be sad *with* you, and that is not happiness, it is absence.
+baseline_valence = 0.0
+
+# Resting energy.     range 0.15 .. 0.85
+# Headroom at both ends, so there is always somewhere to be roused to or
+# calmed down to.
+baseline_arousal = 0.5
+
+# Resting assertiveness.  range 0.15 .. 0.85
+baseline_dominance = 0.5
+
+
+# ── Temperament: how quickly feeling moves ─────────────────────────────
+
+# How fast mood follows events.        range >0 .. 0.8
+valence_drift_rate = 0.3
+
+# How sharply they react to intensity. range >0 .. 0.9
+arousal_response_rate = 0.5
+
+# How steady their assertiveness is.   range >0 .. 0.8
+dominance_stability = 0.2
+
+# How readily trust moves.             range >0 .. 0.5
+trust_change_rate = 0.1
+
+# How readily attachment grows.        range >0 .. 0.3
+attachment_growth_rate = 0.03
+
+# How fast mood returns to baseline.   range >0 .. 0.5
+# Must be greater than zero. At zero, decay stops and their mood locks
+# permanently at whatever they last felt — a friend frozen mid-emotion.
+mood_decay_rate = 0.05
+
+
+# ── Temperament: how long feeling lingers ──────────────────────────────
+# Half-lives in seconds: how long a good moment glows, and how long a bad one
+# keeps its grip. Among the most recognisable things about a person.
+
+# Pleasure fades.     range 5 .. 1800     (90s = about a minute and a half)
+dopamine_halflife_s = 90.0
+
+# Stress lingers.     range 5 .. 7200     (600s = ten minutes)
+# Longer than pleasure by default, because a fright has a hangover and a
+# pleasure mostly does not.
+cortisol_halflife_s = 600.0
+
+
+# ══ ADAPTIVE ═════════════════════════════════════════════════════════ #
+# Where the relationship starts. Read on the FIRST BOOT ONLY.
+# After that these belong to your friend and edits here are ignored.
+
+# What they consider you at the outset.
+relationship = "Friend"
+
+# How much they trust you to begin with.      range 0 .. 1
+# A friend who starts guarded may well become close; that trajectory belongs
+# to the relationship, not to this file.
+initial_trust = 0.5
+
+# How attached they are to begin with.        range 0 .. 1
+initial_attachment = 0.1
+
+# Traits they start out with and may grow out of. Up to 5.
+# The cap is homeostatic: a friend who accumulates adjectives forever ends up
+# with no character at all, just a list. New ones push the oldest out.
+adaptive_traits = ["Reserved"]
+
+# How they speak. `style_description` shapes the voice;
+# `common_vocabulary` seeds words that are natural to them.
+[speaking_style]
+style_description = "Hinglish"
+common_vocabulary = ["arre", "yaar"]


### PR DESCRIPTION
Step 6, scoped to **backend only** — no API, no UI. A file the user edits, which becomes the ground the humanoid boots from.

## The rule that carries the weight

Not the parsing. The question *"the user edited the file and restarted — what happens to what the agent has become?"*

The tier model has claimed since it was written that adaptive values are "seeded by the user, then owned by the friend". **Nothing enforced it**, because nothing distinguished a first boot from a later one. The tiers were documentation.

| | Constitutional | Adaptive |
|---|---|---|
| **First boot** | applied | applied |
| **Later boots** | applied | **ignored, logged** |

Trust and attachment are built over months of conversation. A config file that silently reset them on restart would make the relationship worth nothing. Expressed as a precedence order rather than a special case: `defaults < the agent's saved state < the authored file`, with the file contributing nothing adaptive after the first boot.

## The bug that would have shipped the feature dead

My first implementation detected first boot by asking whether the identity files exist.

**`personality.json` and `history.json` are tracked in git.** Every fresh clone has them. So `first_boot` would have been `False` for every user who ever ran this — the adaptive half of an authored persona would never once have been applied — and **every test would still have passed**, because tests write their own files.

Detection now asks whether the agent has *accumulated* anything: the committed files are seed-shaped (empty memory list, no evolved learnings), while a friend someone has talked to has both. A `persona_seeded_at` marker is written on the seeding boot so the heuristic is asked once per install, not re-litigated as the agent's shape changes — and written immediately rather than at next save, so a process that dies before any conversation doesn't seed twice.

## TOML, for the comments

`tomllib` is stdlib on 3.11+, so no dependency. JSON was the consistent choice and the wrong one: the point of this file is that a user understands what they may change, and the tier, the bound, and *why the bound exists* belong next to the value being edited — not in a README nobody opens.

```toml
# Resting mood.       range -0.6 .. 0.6
# Capped well short of 1.0 on purpose: a friend pinned at maximum cheer can
# never be sad *with* you, and that is not happiness, it is absence.
baseline_valence = 0.0
```

## Ambient discovery was a design bug, found by running it

`find_persona_file` walks up from the module. The first wiring made that unconditional and **13 existing tests failed** — an agent built from a scratch directory walked up and found the *developer's own* persona, so every test silently inherited whatever character happened to be checked out.

Fixed with an explicit `AUTO_DISCOVER` sentinel, because `None` cannot mean both "go and find one" and "there is no file". Worth stating generally: **discovery that cannot be switched off is global mutable state wearing a filesystem.**

`conftest.py` disables it suite-wide. That also fixes a real side effect: `ReflectionService` builds an `IdentityManager` by default, so five test files were constructing one on the *real* app path, and the suite had started writing the repo's authored persona into the tracked `app/personality.json`.

`core.py` now passes `identity.persona` into `StateService` — otherwise the service builds a second profile via `PersonaProfile.load()` and an authored temperament never reaches the layer that computes mood.

## Verification

`tests/test_persona_authoring.py` — 16 tests. **10 mutations, 9 caught.**

The survivor is the same structural one as #77: accepting the immutable core from the file changes nothing, because `values` and `boundaries` are deliberately not model fields, so `split_by_tier` routes them to `unknown` and they are never applied. `strip_immutable` is defence in depth on a path the schema's shape already closes.

**567 non-benchmark tests pass, `ruff check .` clean**, and the suite no longer modifies tracked application files.

## On suite runtime

Measured rather than guessed: non-benchmark tests run in **246s**, so `pytest-benchmark` is ~75–80% of the wall clock. Those measure performance rather than catching regressions, and CI already runs them in a job that finishes in 1m38s. `-m "not benchmark"` locally; full suite still gates a commit.

## Not done

- **No write path.** The agent never edits this file, so a persona changed at runtime through reflection lives in `personality.json` while the authored file still describes the original. Reconciling those is open.
- `relationship` still lives in `history.json` as well as on the profile.
- The suite's write to `app/personality.json` is suppressed, not fixed at the root: `ReflectionService` still constructs a default `IdentityManager` on the real app path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for authoring and loading a persona from TOML configuration.
  * Persona settings now follow clear precedence rules across defaults, saved state, and authored values.
  * Adaptive persona traits are seeded on first boot and preserved on subsequent boots.
  * Added configurable speaking style, temperament, relationship values, and vocabulary.
  * Invalid or unsafe authored settings are ignored without preventing startup.

* **Bug Fixes**
  * Prevented unintended persona-file discovery during testing.
  * Ensured authored persona values are consistently reflected in state and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->