### PR TITLE
feat(persona): seed a friend with a life from config/biography.md

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -3595,4 +3595,74 @@ Also added the test docstring CodeRabbit flagged on
 `test_no_file_contributes_nothing`.
 
 Full non-benchmark suite: **571 passed**, `ruff check .` clean.
+---
+
+## 2026-07-19 — Seeding a friend with a life
+
+Extends the authoring surface so a user can describe a *person*, not just a
+temperament. Requested case: someone wants to model the humanoid on a real
+friend and write a full documentary of her.
+
+### Why this is not more schema fields
+
+A documentary is mostly episodes — what happened, who is in it, how she argues,
+the phrase she uses when she is tired. That material fits neither the persona
+schema nor the system prompt.
+
+Prompt-resident text is paid for on **every single turn**: a biography of any
+real length would sit in the context window on each one, costing latency and
+crowding out the conversation, while most of it is irrelevant to whatever is
+being said right now. The agent already owns the correct machine for this — an
+episodic store with vector search, graph links and ACT-R activation — and it had
+only ever been fed by conversation.
+
+So the split is:
+
+- `identity_summary` in persona.toml, capped at 1200 characters, always in the
+  prompt. Two paragraphs of who someone *is*.
+- `config/biography.md`, read once and written into episodic memory. Retrieval
+  then decides what surfaces: mention her sister and the sister paragraphs come
+  back; talk about work and they stay put. It can be fifty pages.
+
+### Decisions
+
+**Paragraphs, not sections.** A whole section as one memory retrieves
+all-or-nothing, so one detail drags in five unrelated ones. Each paragraph
+carries its heading folded into the stored text rather than held as metadata,
+because retrieval matches on content — a passage filed under "Her sister" that
+never says "sister" would otherwise be unreachable by the obvious cue.
+
+**Idempotent per paragraph, not per file.** A single "seeded" flag forces a
+choice between duplicating the whole history on every boot and never being able
+to extend the documentary. Fingerprints are over heading *and* text, so moving a
+passage to a different section counts as new — its meaning depends on where it
+was filed. Seeding runs after hydration so the record of what is already stored
+comes from the durable store rather than a local file that may be behind it;
+otherwise a redeployed agent re-seeds its entire past.
+
+Seeded memories carry `source="biography"` so they can be told apart from lived
+ones — needed for re-seeding and pruning, and for being honest about where the
+agent's sense of a shared history actually came from.
+
+`add_memory` already reinforces identical content rather than duplicating it,
+but relying on that alone would still redo the embedding work for the whole file
+on every start and would tie correctness to a downstream implementation detail.
+
+### Verification
+
+`tests/test_biography_seeding.py` (16 tests). **7 mutations, all 7 caught**:
+fingerprint ignoring the heading, the already-seeded list ignored, the heading
+not folded into stored text, one bad passage aborting the rest, biography
+importance dropping to ordinary, blank lines no longer splitting paragraphs, and
+the source marker lost.
+
+**583 non-benchmark tests pass**, `ruff check .` clean.
+
+**NOT done:** no re-read after edits within a run — a biography changed while
+the agent is running is picked up on next start, not live. Nothing prunes
+biography memories if the user deletes a passage; the fingerprints make that
+possible but it is not implemented. `identity_summary` and `speech_patterns` are
+prompt-resident and count against context on every turn, which is a real budget
+this now spends without measuring — worth checking against the 120s stream
+ceiling once there is a real persona to measure with.
 

--- a/backend/app/cognitive/core.py
+++ b/backend/app/cognitive/core.py
@@ -20,6 +20,11 @@ from .decision import DecisionService
 from .action import ActionService
 from .learning import ReflectionService
 from .identity import IdentityManager
+from ..persona.biography import (
+    find_biography_file,
+    read_biography,
+    seed_biography,
+)
 from .pipeline import CognitivePipeline
 
 logger = logging.getLogger(__name__)
@@ -41,6 +46,8 @@ class CognitiveService:
     ):
         self.identity = IdentityManager(base_path=base_path)
         self.identity_store = identity_store
+        # Kept so the biography can be seeded into episodic memory at startup.
+        self.memory_store = memory_store
         self.perception = PerceptionService(llm_service=llm_service)
         self.appraisal = AppraisalEngine()  # §1: OCC/Lazarus/EMA
         self.reappraisal = ReappraisalEngine()  # Gross/Bosse feedback loop
@@ -95,11 +102,53 @@ class CognitiveService:
         if self.agent:
             await self.agent.publish(subject, data)
 
+    SEEDED_KEY = "biography_seeded"
+
+    async def seed_biography_once(self, path: Any = None) -> int:
+        """Write any not-yet-seeded biography passages into episodic memory.
+
+        Returns the number stored, so a caller can tell "nothing to do" from
+        "did not run". Idempotent by paragraph fingerprint rather than by a
+        single flag, so the documentary can be extended later without either
+        duplicating what is already there or refusing the new material.
+
+        Failures never propagate. A friend who does not remember the story you
+        wrote for them is a degraded friend; an agent that will not start is no
+        friend at all.
+        """
+        try:
+            entries = read_biography(path or find_biography_file())
+            if not entries:
+                return 0
+
+            already = self.identity.history.get(self.SEEDED_KEY) or []
+            stored = await seed_biography(entries, self.memory_store, already)
+            if not stored:
+                return 0
+
+            self.identity.history[self.SEEDED_KEY] = list(already) + stored
+            self.identity.save()
+            await self.identity.persist_to_config_store()
+            logger.info(
+                "[Biography] Seeded %d passage(s); %d known in total.",
+                len(stored),
+                len(self.identity.history[self.SEEDED_KEY]),
+            )
+            return len(stored)
+        except Exception as exc:
+            logger.error("[Biography] Seeding failed (%s); continuing.", exc)
+            return 0
+
     async def initialize(self, agent: Any = None):
         """Load identity and hydrate states. Subscribes to Mesh heartbeats."""
         if self.identity_store:
             await self.identity.hydrate_from_config_store(self.identity_store)
         await self.state.hydrate_state()
+
+        # After hydration, so the record of what has already been seeded comes
+        # from the durable store rather than from a local file that may be
+        # behind it — otherwise a redeployed agent re-seeds its whole history.
+        await self.seed_biography_once()
 
         # Initialize appraisal engine with identity boundaries
         boundaries = self.identity.personality.get("boundaries", [])

--- a/backend/app/cognitive/identity.py
+++ b/backend/app/cognitive/identity.py
@@ -455,11 +455,20 @@ class IdentityManager:
             list(self.persona.speaking_style.get("common_vocabulary", []))[:30]
         )
 
+        # Only ever a few sentences (the schema caps it), because this is paid
+        # for on every turn. The long history lives in episodic memory and
+        # arrives through retrieval when it is actually relevant.
+        who = self.persona.identity_summary.strip()
+        who_block = f"\nWHO YOU ARE:\n{who}\n" if who else ""
+        patterns = ", ".join(self.persona.speech_patterns)
+        patterns_block = f"CHARACTERISTIC PHRASES: {patterns}\n" if patterns else ""
+
         return f"""
 YOU ARE {self.persona.name}. 🤖✨
 IMMUTABLE VALUES: {", ".join(core["values"])}
 CORE TONE: {core["base_tone"]}
 BOUNDARIES: {", ".join(core["boundaries"])}
+{who_block}{patterns_block}
 
 ADAPTIVE TRAITS: {adaptive_traits}
 RELATIONSHIP: {h.get("relationship", "User")}

--- a/backend/app/persona/biography.py
+++ b/backend/app/persona/biography.py
@@ -1,0 +1,227 @@
+"""
+Seeding a friend with a life.
+
+`config/persona.toml` describes *temperament* — how someone feels, how fast,
+for how long. It cannot describe a person. Who they are is mostly episodes:
+what happened to them, who is in their life, how they argue, the phrase they
+always use when they are tired.
+
+That material does not belong in the persona schema and it does not belong in
+the system prompt either. A biography of any real length would sit in the
+context window of every single turn, costing latency on each one, while most of
+it is irrelevant to whatever is being said right now. The agent already has the
+right machine for this — an episodic memory store with vector search, graph
+links and ACT-R activation — and it was only ever fed by conversation.
+
+So a `biography.md` is read once and written into memory as episodes. From then
+on the ordinary retrieval path decides what surfaces: mention her sister and the
+sister paragraphs come back; talk about work and they stay put. The documentary
+can be fifty pages, because only the relevant few sentences are ever in play.
+
+**Granularity is paragraphs, not sections.** A whole section as one memory
+retrieves all-or-nothing, so a question about one detail drags in five unrelated
+ones and crowds out everything else. Each paragraph carries its heading as
+context, which is what makes an isolated line like "she never apologises first"
+still mean something when it surfaces on its own.
+"""
+
+import hashlib
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, List, Optional, Sequence, Set
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BIOGRAPHY_FILE = "config/biography.md"
+
+# Biography material is foundational rather than incidental: it should outrank a
+# passing remark from last Tuesday when both match a cue. Not pinned to the
+# maximum, because things the user actually says should still be able to win.
+BIOGRAPHY_IMPORTANCE = 0.75
+
+# Marks these memories as seeded rather than lived, so they can be told apart
+# later -- for re-seeding, for pruning, and for honesty about where the agent's
+# sense of a shared past actually came from.
+BIOGRAPHY_SOURCE = "biography"
+
+_HEADING = re.compile(r"^(#{1,6})\s+(.*\S)\s*$")
+
+
+@dataclass(frozen=True)
+class BiographyEntry:
+    """One paragraph of the documentary, with the heading it sat under."""
+
+    heading: str
+    text: str
+
+    @property
+    def fingerprint(self) -> str:
+        """Identity of this paragraph, for seeding it exactly once.
+
+        Over heading *and* text, so moving a paragraph to a different section
+        counts as new — its meaning depends on what it was filed under.
+        """
+        digest = hashlib.sha256()
+        digest.update(self.heading.encode("utf-8"))
+        digest.update(b"\x00")
+        digest.update(self.text.encode("utf-8"))
+        return digest.hexdigest()
+
+    @property
+    def memory_text(self) -> str:
+        """What actually gets stored.
+
+        The heading is folded in rather than kept as metadata because retrieval
+        matches on content: a paragraph filed under "Her sister" that never says
+        "sister" would otherwise be unreachable by the obvious cue.
+        """
+        if not self.heading:
+            return self.text
+        return f"{self.heading}: {self.text}"
+
+
+def parse_biography(markdown: str) -> List[BiographyEntry]:
+    """Split prose into paragraphs, each tagged with its nearest heading.
+
+    Deliberately forgiving. This file is written by a person describing someone
+    they know, not authored against a spec, so anything structural that is
+    missing is inferred rather than rejected: text before the first heading is
+    kept, blank-line-separated paragraphs are the unit, and heading depth is
+    ignored beyond nesting the trail.
+    """
+    entries: List[BiographyEntry] = []
+    heading_trail: List[str] = []
+    buffer: List[str] = []
+
+    def flush() -> None:
+        text = " ".join(" ".join(buffer).split()).strip()
+        buffer.clear()
+        if text:
+            entries.append(
+                BiographyEntry(heading=" / ".join(heading_trail), text=text)
+            )
+
+    for line in (markdown or "").splitlines():
+        match = _HEADING.match(line)
+        if match:
+            flush()
+            depth = len(match.group(1))
+            # Keep the enclosing headings so "How she argues / With family"
+            # reads as one place rather than two unrelated labels.
+            heading_trail = heading_trail[: depth - 1]
+            while len(heading_trail) < depth - 1:
+                heading_trail.append("")
+            heading_trail.append(match.group(2))
+            heading_trail = [h for h in heading_trail if h]
+            continue
+
+        if not line.strip():
+            flush()
+            continue
+
+        buffer.append(line.strip())
+
+    flush()
+    return entries
+
+
+def read_biography(path: Optional[Path]) -> List[BiographyEntry]:
+    """Parse the biography file, returning `[]` on any problem.
+
+    Never raises: an unreadable biography must not stop the agent from starting.
+    A friend who does not remember your history is still a friend you can talk
+    to; a process that will not boot is not.
+    """
+    if path is None:
+        return []
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except Exception as exc:
+        logger.error(
+            "[Biography] Could not read %s (%s). The agent will start without "
+            "its seeded history.",
+            path,
+            exc,
+        )
+        return []
+    return parse_biography(text)
+
+
+def find_biography_file(explicit: Optional[str] = None) -> Optional[Path]:
+    """Locate `config/biography.md`, walking up from this module.
+
+    Same reasoning as the persona file: the agents are launched from the repo
+    root, from `backend/`, and from a container WORKDIR, so a path relative to
+    the process working directory resolves differently in each.
+    """
+    if explicit:
+        path = Path(explicit)
+        return path if path.exists() else None
+
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / DEFAULT_BIOGRAPHY_FILE
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def pending_entries(
+    entries: Sequence[BiographyEntry], already_seeded: Iterable[str]
+) -> List[BiographyEntry]:
+    """The paragraphs not yet written to memory.
+
+    Per-paragraph rather than a single "seeded" flag so the documentary can be
+    *added to*. Writing another page later seeds only the new pages, instead of
+    forcing a choice between duplicating the whole file and never extending it.
+    """
+    seen: Set[str] = set(already_seeded or ())
+    return [entry for entry in entries if entry.fingerprint not in seen]
+
+
+async def seed_biography(
+    entries: Sequence[BiographyEntry],
+    memory_store: Any,
+    already_seeded: Iterable[str] = (),
+) -> List[str]:
+    """Write pending paragraphs into episodic memory.
+
+    Returns the fingerprints actually stored, for the caller to persist. A
+    failure on one paragraph is logged and skipped rather than aborting: a
+    partly-seeded history is worth more than none, and the next boot retries
+    only what is still missing.
+    """
+    if memory_store is None:
+        return []
+
+    pending = pending_entries(entries, already_seeded)
+    if not pending:
+        return []
+
+    logger.info("[Biography] Seeding %d new passage(s) into memory.", len(pending))
+
+    stored: List[str] = []
+    for entry in pending:
+        try:
+            await memory_store.add_memory(
+                content=entry.memory_text,
+                wing="personal",
+                room=entry.heading or None,
+                importance=BIOGRAPHY_IMPORTANCE,
+                source=BIOGRAPHY_SOURCE,
+                metadata={
+                    "biography_heading": entry.heading,
+                    "biography_fingerprint": entry.fingerprint,
+                },
+            )
+        except Exception as exc:
+            logger.error(
+                "[Biography] Could not seed passage under %r (%s); skipping it.",
+                entry.heading or "(untitled)",
+                exc,
+            )
+            continue
+        stored.append(entry.fingerprint)
+
+    return stored

--- a/backend/app/persona/profile.py
+++ b/backend/app/persona/profile.py
@@ -153,6 +153,24 @@ class PersonaProfile(BaseModel):
         min_length=1,
         max_length=200,
     )
+
+    # A few sentences that must colour *every* reply — not a biography.
+    #
+    # The length cap is the point of this field, not a formality. Whatever goes
+    # here occupies the context window on every single turn, so it is paid for
+    # on each one in latency and in room taken from actual conversation. The
+    # long material belongs in `config/biography.md`, which is seeded into
+    # episodic memory and surfaces only when it is relevant.
+    #
+    # 1200 characters is roughly two paragraphs: enough for who someone is,
+    # short of enough to start listing what happened to them.
+    identity_summary: str = _constitutional(default="", max_length=1200)
+
+    # Turns of phrase that are recognisably hers. Kept separate from
+    # `speaking_style` because these are constitutional — the way a person
+    # talks is not something the agent should reflect its way out of, whereas
+    # the register it adopts with you is.
+    speech_patterns: List[str] = _constitutional(default_factory=list, max_length=20)
     traits: List[str] = _constitutional(default_factory=list, max_length=8)
     # Phrases the friend must not say. Constitutional rather than adaptive: a
     # user asking never to hear something is not a preference the agent gets to

--- a/backend/tests/test_biography_seeding.py
+++ b/backend/tests/test_biography_seeding.py
@@ -1,0 +1,236 @@
+"""
+Seeding a friend with a life, and doing it exactly once.
+
+`config/persona.toml` describes temperament. It cannot describe a person —
+who someone is is mostly episodes, and those belong in the episodic memory
+store, not in the persona schema and not in the system prompt.
+
+Prompt-resident material is paid for on every single turn, so a biography of
+any real length there would cost latency on each one while most of it is
+irrelevant to whatever is being said. Seeded as memories instead, the ordinary
+retrieval path decides what surfaces. That is what lets the documentary be long.
+
+The behaviour that needs pinning is idempotence. Seeding is not a one-shot flag
+but a per-paragraph fingerprint, because the alternative to that is a choice
+between duplicating the whole file every boot and never being able to add to it.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.persona.biography import (
+    BIOGRAPHY_SOURCE,
+    BiographyEntry,
+    find_biography_file,
+    parse_biography,
+    pending_entries,
+    read_biography,
+    seed_biography,
+)
+
+DOC = """# Biography
+
+## How she talks
+
+She switches between English and Hindi mid-sentence.
+
+She says "haan haan" twice when only half listening.
+
+## How she argues
+
+She goes quiet rather than loud.
+"""
+
+
+# --------------------------------------------------------------------------
+# parsing
+# --------------------------------------------------------------------------
+
+
+def test_each_paragraph_becomes_its_own_memory():
+    """Granularity decides whether retrieval is usable.
+
+    A whole section as one memory returns all-or-nothing, so a question about
+    one detail drags in every unrelated detail beside it and crowds the context
+    with things nobody asked about.
+    """
+    entries = parse_biography(DOC)
+    texts = [e.text for e in entries]
+    assert "She switches between English and Hindi mid-sentence." in texts
+    assert 'She says "haan haan" twice when only half listening.' in texts
+    assert "She goes quiet rather than loud." in texts
+
+
+def test_a_paragraph_carries_the_heading_it_sat_under():
+    """An isolated line has to still mean something when it surfaces alone.
+
+    "She goes quiet rather than loud" retrieved with no context could be about
+    anything; filed under "How she argues" it is an answer.
+    """
+    entries = parse_biography(DOC)
+    argues = [e for e in entries if "quiet rather than loud" in e.text][0]
+    assert "How she argues" in argues.heading
+    assert argues.memory_text.startswith("Biography / How she argues:")
+
+
+def test_the_heading_is_folded_into_the_stored_text():
+    """Retrieval matches on content, not on metadata columns.
+
+    A paragraph filed under "Her sister" that never says "sister" would be
+    unreachable by the obvious cue if the heading stayed out of the text.
+    """
+    entry = BiographyEntry(heading="Her sister", text="They speak every Sunday.")
+    assert entry.memory_text == "Her sister: They speak every Sunday."
+
+
+def test_prose_before_any_heading_is_still_kept():
+    """The file is written by a person, not authored against a spec."""
+    entries = parse_biography("She is stubborn about small things.\n")
+    assert len(entries) == 1
+    assert entries[0].heading == ""
+    assert entries[0].text == "She is stubborn about small things."
+
+
+def test_line_wrapping_does_not_split_a_paragraph():
+    """People hard-wrap prose. Wrapping is not a semantic boundary."""
+    entries = parse_biography("## X\n\nshe is\nvery\nstubborn\n")
+    assert len(entries) == 1
+    assert entries[0].text == "she is very stubborn"
+
+
+def test_an_empty_or_missing_biography_yields_nothing():
+    assert parse_biography("") == []
+    assert parse_biography("## Heading with no body\n") == []
+    assert read_biography(None) == []
+
+
+def test_an_unreadable_biography_does_not_raise(tmp_path):
+    """A friend who forgets your history is still a friend you can talk to.
+    A process that will not boot is not."""
+    assert read_biography(tmp_path / "does_not_exist.md") == []
+
+
+# --------------------------------------------------------------------------
+# seeding exactly once
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_seeding_writes_every_passage_the_first_time():
+    store = AsyncMock()
+    entries = parse_biography(DOC)
+    stored = await seed_biography(entries, store)
+    assert len(stored) == len(entries)
+    assert store.add_memory.await_count == len(entries)
+
+
+@pytest.mark.asyncio
+async def test_seeding_twice_does_not_duplicate_the_history():
+    """Re-seeding on every boot would multiply the agent's past.
+
+    The memory store reinforces identical content rather than duplicating it,
+    but relying on that would still redo the embedding work for the whole file
+    on every start, and would tie correctness to a downstream implementation
+    detail.
+    """
+    store = AsyncMock()
+    entries = parse_biography(DOC)
+
+    first = await seed_biography(entries, store)
+    second = await seed_biography(entries, store, already_seeded=first)
+
+    assert second == []
+    assert store.add_memory.await_count == len(entries)
+
+
+@pytest.mark.asyncio
+async def test_adding_to_the_documentary_seeds_only_the_new_part():
+    """The reason fingerprints are per paragraph rather than per file.
+
+    A single "seeded" flag forces a choice between duplicating everything and
+    never being able to write another page.
+    """
+    store = AsyncMock()
+    original = parse_biography(DOC)
+    seeded = await seed_biography(original, store)
+    store.reset_mock()
+
+    extended = parse_biography(DOC + "\n## Work\n\nShe teaches chemistry.\n")
+    new = await seed_biography(extended, store, already_seeded=seeded)
+
+    assert len(new) == 1
+    assert store.add_memory.await_count == 1
+    assert "chemistry" in store.add_memory.await_args.kwargs["content"]
+
+
+def test_moving_a_passage_to_another_section_counts_as_new():
+    """A paragraph's meaning depends on what it was filed under."""
+    a = BiographyEntry(heading="How she argues", text="She goes quiet.")
+    b = BiographyEntry(heading="How she grieves", text="She goes quiet.")
+    assert a.fingerprint != b.fingerprint
+
+
+def test_pending_entries_reports_what_is_left():
+    entries = parse_biography(DOC)
+    assert pending_entries(entries, []) == entries
+    assert pending_entries(entries, [e.fingerprint for e in entries]) == []
+
+
+# --------------------------------------------------------------------------
+# how it is stored
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_seeded_memories_are_marked_as_seeded_not_lived():
+    """The agent's sense of a shared past should be honest about its origin.
+
+    Without a distinguishable source there is no way to re-seed, prune, or
+    later tell the user which memories came from a file they wrote rather than
+    from a conversation that happened.
+    """
+    store = AsyncMock()
+    await seed_biography(parse_biography(DOC)[:1], store)
+    kwargs = store.add_memory.await_args.kwargs
+    assert kwargs["source"] == BIOGRAPHY_SOURCE
+    assert kwargs["metadata"]["biography_fingerprint"]
+    assert kwargs["importance"] > 0.5, "biography should outrank a passing remark"
+
+
+@pytest.mark.asyncio
+async def test_one_bad_passage_does_not_abandon_the_rest():
+    """A partly-seeded history beats none, and the next boot retries the gap."""
+    store = AsyncMock()
+    calls = {"n": 0}
+
+    async def flaky(**kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("qdrant down")
+
+    store.add_memory = flaky
+    entries = parse_biography(DOC)
+    stored = await seed_biography(entries, store)
+
+    assert len(stored) == len(entries) - 1
+    # The failed one is absent, so it is still pending next time.
+    assert pending_entries(entries, stored)
+
+
+@pytest.mark.asyncio
+async def test_no_memory_store_is_not_an_error():
+    """Agents without a memory store still have to start."""
+    assert await seed_biography(parse_biography(DOC), None) == []
+
+
+# --------------------------------------------------------------------------
+# the shipped file
+# --------------------------------------------------------------------------
+
+
+def test_the_shipped_biography_parses():
+    """The example a user starts from must survive its own parser."""
+    found = find_biography_file()
+    assert found is not None and found.name == "biography.md"
+    assert read_biography(found), "the shipped biography produced no passages"

--- a/config/biography.md
+++ b/config/biography.md
@@ -1,0 +1,52 @@
+# Biography
+
+Write about the person here, in your own words. This file is read once and
+written into the agent's **episodic memory** — it is not pasted into the prompt.
+That distinction is what lets it be long: only the passages relevant to what is
+being said ever come back.
+
+How to write it:
+
+- **Headings organise, paragraphs are the unit.** Each blank-line-separated
+  paragraph becomes one memory, tagged with the heading it sits under. Keep a
+  paragraph to one idea and it will surface cleanly on its own.
+- **Write prose, not bullet-point facts.** "She goes quiet when she is angry
+  rather than loud, and it takes a day" recalls better than "trait: reserved",
+  because retrieval matches on meaning.
+- **You can add to this file later.** Only new passages are seeded; existing
+  ones are left alone, so extending the documentary never duplicates it.
+- Keep the short, always-true summary in `config/persona.toml` under
+  `identity_summary` instead. This file is for everything that is only
+  sometimes relevant.
+
+Delete these instructions and the example sections below when you start.
+
+---
+
+## How she talks
+
+She switches between English and Hindi mid-sentence without noticing, usually
+landing on Hindi for anything she actually feels. English is for work and for
+arguments she wants to win.
+
+She says "haan haan" twice when she is only half listening, and once when she is
+genuinely agreeing. Nobody has ever pointed this out to her.
+
+## How she argues
+
+She goes quiet rather than loud. The silence is not sulking, it is drafting, and
+whatever comes out twenty minutes later will be organised and difficult to
+counter.
+
+She apologises by making tea and changing the subject to something you care
+about. An actual apology, in words, means she thinks the thing was serious.
+
+## Her family
+
+Her younger brother calls every Sunday and she complains about it every week
+without once letting it go to voicemail.
+
+## Work
+
+She teaches secondary-school chemistry and is fond of the students who argue
+with her. The ones who write down everything she says worry her.

--- a/config/persona.toml
+++ b/config/persona.toml
@@ -45,6 +45,25 @@ name = "Pankudi"
 # and boundaries are not editable here.
 base_tone = "Warm, intellectual, and slightly protective"
 
+# A few sentences that should colour EVERY reply.
+#
+# This one is worth understanding before you write it. Whatever goes here sits
+# in the context window on every single turn, so you pay for it every time the
+# agent speaks. Keep it to who the person fundamentally is.
+#
+# The life story — what happened to them, who is in it, the specific memories —
+# goes in `config/biography.md` instead. That file is seeded into episodic
+# memory and surfaces only when it is relevant, so it can be as long as you
+# like. Capped at 1200 characters here on purpose: enough for two paragraphs
+# about who someone is, not enough to start listing what happened to them.
+identity_summary = """
+"""
+
+# Turns of phrase that are recognisably theirs. Up to 20.
+# Constitutional rather than adaptive: how a person talks is not something the
+# agent should reflect its way out of.
+speech_patterns = []
+
 # Fixed character traits. Up to 8.
 traits = ["Warm", "Curious"]
 


### PR DESCRIPTION
Builds on #78. The use case: someone wants to model the humanoid on a real friend and write a **full documentary** of her.

## Why this isn't more schema fields

A documentary is mostly *episodes* — what happened, who's in it, how she argues, the phrase she uses when she's tired. That fits neither the persona schema nor the system prompt.

Prompt-resident text is paid for on **every single turn**. A biography of any real length would sit in the context window on each one, costing latency and crowding out the actual conversation, while most of it is irrelevant to whatever is being said right now.

The agent already owns the right machine for this — an episodic store with vector search, graph links and ACT-R activation — and it had only ever been fed by conversation.

So the split is:

| | Where | Cost |
|---|---|---|
| `identity_summary` (≤1200 chars) | always in the prompt | every turn |
| `config/biography.md` | seeded into episodic memory | only when relevant |

Mention her sister and the sister paragraphs come back; talk about work and they stay put. **That's what lets the documentary be fifty pages.**

## Three decisions worth reviewing

**Paragraphs, not sections.** A whole section as one memory retrieves all-or-nothing, so one detail drags in five unrelated ones and crowds the context with things nobody asked about.

**The heading is folded into the stored text**, not kept as metadata. Retrieval matches on content — a passage filed under "Her sister" that never says *sister* would be unreachable by the obvious cue.

**Idempotent per paragraph, not per file.** A single "seeded" flag forces a choice between duplicating the whole history every boot and never being able to extend the documentary. Fingerprints cover heading *and* text, so moving a passage to a different section counts as new — its meaning depends on where it was filed.

Seeding runs *after* hydration, so the already-seeded record comes from the durable store rather than a local file that may be behind it. Otherwise a redeployed agent re-seeds its entire past.

Seeded memories carry `source="biography"` so they can be told apart from lived ones — needed for re-seeding and pruning, and for being honest about where the agent's sense of a shared history actually came from.

`add_memory` already reinforces identical content rather than duplicating it, but relying on that alone would still redo the embedding work for the whole file on every start, and would tie correctness to a downstream implementation detail.

## Verification

`tests/test_biography_seeding.py` — 16 tests. **7 mutations, all 7 caught**: fingerprint ignoring the heading, the already-seeded list ignored, the heading not folded into stored text, one bad passage aborting the rest, biography importance dropping to ordinary, blank lines no longer splitting paragraphs, and the source marker lost.

**587 non-benchmark tests pass, `ruff check .` clean.**

Rebased onto main after #78 merged (built on a local branch rather than opening a stacked PR — that's the #69 failure mode). The only conflict was the ledger; both entries kept in chronological order, and the full suite re-run afterwards to prove the resolution was semantically correct rather than merely git-clean.

## Not done

- **No live re-read.** A biography edited while the agent is running is picked up on next start.
- **No pruning.** If you delete a passage, its memory stays. The fingerprints make pruning possible; it isn't implemented.
- `identity_summary` and `speech_patterns` are prompt-resident and spend context budget on every turn. This PR spends that budget without measuring it — worth checking against the 120s stream ceiling once there's a real persona to measure with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)