### PR TITLE
chore: five small follow-ups, two of which were dead features

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -3810,3 +3810,103 @@ written there directly, but a second-order residue is possible. `--all` (full
 amnesia) was scoped out; only the persona-level reset exists. The conftest
 `PERSONA_PROFILE_PATH` guard stays, since it isolates ambient discovery, which
 is its own reason and unaffected by this change.
+
+---
+
+## 2026-07-19 — Five small follow-ups, two of which were dead features
+
+Cleanup batch after the storage work. Three change behaviour; two remove a
+duplicated implementation. Deliberately excludes the `memory_store.py`
+decomposition (F1), which is its own project.
+
+### `relationship` had two owners and the authored one was read by nobody
+
+`PersonaProfile.relationship` is what `config/persona.toml` sets.
+`history["relationship"]` is what the prompt reads and `evolve_persona` writes.
+Nothing connected them — grep for readers of the profile field returned none —
+so writing `relationship = "New Acquaintance"` in the authored file did
+**nothing at all**, silently. The authoring surface advertised a setting with no
+effect.
+
+The profile field is now the seed and the history entry the live value, which is
+how every other adaptive field already works.
+
+**The first version of this shipped a bug**, caught by an existing regression
+test rather than a new one: seeding fired on any first boot, so an agent
+hydrating from a store that said `"Trusted Friend"` was demoted to the schema
+default `"Friend"` on every start. Seeding is now gated on the author having
+*written* the field. Applying a default is not seeding, it is overwriting.
+
+### Deleting a biography passage did nothing
+
+Seeding was one-directional: adding a paragraph created a memory, deleting one
+left it in place forever. A passage removed because it was wrong — or because
+the person it describes asked for it to go — kept surfacing, and the file read
+as the source of truth while not being one.
+
+`stale_fingerprints` is the counterpart to `pending_entries`, and pruning runs
+*before* seeding so an edited paragraph is removed and re-added in one pass
+rather than briefly existing twice. Fingerprints cover heading and text, so an
+edit correctly appears on both sides.
+
+An empty parse is explicitly **not** treated as "everything was deleted". A
+biography that fails to parse would otherwise erase the entire seeded history on
+one bad edit — the most expensive available reading of an ambiguous situation.
+Qdrant vectors go with the rows, for the same reason as in the reset path.
+
+### The self-correction retry was a divergent copy
+
+Stage 8 and stage 9 ran the same loop over `action.execute`, and they had
+already drifted: the retry never applied the `speculative` tag, so a speculative
+turn that got self-corrected emitted chunks disagreeing with the plan that
+produced them. Nothing reported it, because a missing key reads as "not
+speculative". One `_stream_action_pass` now serves both.
+
+### Affect had two implementations of one wire contract
+
+`_publish_speech_chunk` re-derived the same eight `state_snap.get(...)` defaults
+that `create_chunk_payload` already applies. Same class of defect as the prosody
+drift one layer down, and the same fix: one implementation.
+
+### `scripts/show_persona.py`
+
+Once the durable store became authoritative there was no way to answer "who is
+my friend right now" — `persona.toml` describes the seed, not the agent. Prints
+the live persona by tier, plus provenance (was it ever seeded from a file, how
+many biography passages, how many migrated memories). Read-only by construction.
+
+Refuses to print defaults when hydration *fails*, as opposed to returning
+nothing: showing a persona that is not the stored one, with no indication the
+real answer was never retrieved, is worse than showing nothing.
+
+### Verification
+
+`tests/test_small_followups.py` (11 tests). **9 mutations, 8 caught.**
+
+M2 (dropping the `first_boot` guard on relationship seeding) survives and is
+**expected to**: `authored_overrides` returns `{}` on later boots, so
+`authored_keys` is already empty and the second guard alone suffices. The two
+conditions are not independent. The redundant check is kept and commented,
+because relying on the coupling would tie this method to a detail of another
+module — and the silent failure mode is a friendship reset on every restart.
+
+Two tests initially passed for the wrong reason and were rewritten after
+mutation exposed them: the biography-prune test used a fake store with no
+`pool`, so `prune_biography` bailed on its first line and the test passed
+against a mutant that pruned everything; and the affect test compared
+`_publish_speech_chunk` to `create_chunk_payload`, which is tautological when
+both read the same mapping — it now pins the values against the state snapshot
+as well.
+
+**618 non-benchmark tests pass**, `ruff check .` clean, working tree clean.
+
+**NOT done, and deliberately out of scope:** the `memory_store.py`
+decomposition (F1) — 3031 lines, `search_memories` still fusing six retrieval
+strategies. Removing the deprecated prosody fields from `ChatOutput` turned out
+**not** to be small: the Rust `contracts` crate declares the same fields, so it
+is a coordinated cross-language wire change needing a `setup_nats_streams.py`
+re-run and a deploy ordering where old consumers still receive messages without
+those keys. Neo4j entities the subconscious agent may derive *from* seeded
+memories are still not cleared by a reset — nothing tracks the derivation, so
+there is no query that finds them. `identity_summary` prompt cost remains
+unmeasured.

--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -3910,3 +3910,43 @@ those keys. Neo4j entities the subconscious agent may derive *from* seeded
 memories are still not cleared by a reset — nothing tracks the derivation, so
 there is no query that finds them. `identity_summary` prompt cost remains
 unmeasured.
+
+### 2026-07-19 — PR #81 review round: three findings, two of them real bugs
+
+CodeRabbit's review of #81 landed three findings and all three were valid. Two
+changed behaviour.
+
+**A failed scan silently orphaned a passage forever.** `prune_biography`
+`continue`d past a database error, then returned `list(stale)` — so a
+fingerprint whose scan raised was dropped from the ledger while its memory row
+survived. The ledger entry is the *only* record that a fingerprint was ever
+seeded, so nothing would ever look for that row again: a passage the user
+deleted would keep being recalled, with no remaining trace pointing at why. A
+transient error, permanent consequence. Failed marks are now held back and
+retried on the next boot; scanned marks still leave the ledger even when they
+matched no row, so one permanently-broken entry cannot pin the whole prune.
+
+**A rejected persona file still counted as seeded.** `seeded_from_file` and
+`authored_keys` were assigned *before* `PersonaProfile(**merged)` validated. On
+`ValidationError` the agent fell back to schema defaults while still believing
+the author had chosen them — stamping the one-time seed marker and applying the
+*default* relationship as if it had been written down. Given seed-once
+semantics, that spends the single seeding opportunity on a persona whose
+contents never took effect, recoverable only by a reset. This is the same class
+of bug as the relationship-default regression caught mid-#81, in a sibling path
+— which is the signal worth recording: the first fix addressed the instance,
+not the pattern, and the pattern had a second instance one function away.
+
+Third finding was cosmetic: `show_persona.py` printed
+`len(evolved_learnings)` — a `TEXT` column, so a *character* count — in a
+column of item counts. Now labelled `N chars`.
+
+Five mutations, five caught, including two asymmetric ones (hold back
+everything on any failure; stop recording authored keys on the success path) to
+confirm the new tests pin both directions rather than just the bug.
+
+**639 tests pass**, `ruff check .` clean.
+
+**NOT done:** unchanged from the #81 entry above — F1, the cross-language
+prosody wire change, Neo4j reset residue, and the unmeasured `identity_summary`
+prompt cost all remain open.

--- a/backend/app/agents/brain_agent.py
+++ b/backend/app/agents/brain_agent.py
@@ -18,8 +18,6 @@ from ..contracts import (
     AudioResume,
     AudioStop,
     ChatInput,
-    ChatOutput,
-    ChatOutputAffect,
     Topics,
     UserVoiceProperties,
 )
@@ -695,28 +693,21 @@ class BrainAgent(BaseAgent):
         if not text:
             return
 
-        state_snap = self.cognitive_core.state.get_context_snapshot()
-
-        # Full §5.3 Affect Metadata Contract. Prosody is not attached here: the
-        # voice agent derives it from `affect` via `contracts::vad_to_prosody`
-        # and never read what Python sent. See SpeechCoordinator's docstring.
-        payload = ChatOutput(
-            content=text,
-            done=False,
+        # Built by the coordinator, which is where every other chunk on this
+        # subject is built. This method used to re-derive the affect vector
+        # inline — the same eight `state_snap.get(...)` lines with the same
+        # defaults — so the wire contract had two implementations and a change
+        # to one silently produced streams whose chunks disagreed with their own
+        # `done` message. Exactly the drift that put prosody in this state to
+        # begin with, one layer up.
+        payload = self.coordinator.create_chunk_payload(
+            words=words,
+            state_snap=self.cognitive_core.state.get_context_snapshot(),
             turn_id=turn_id,
-            affect=ChatOutputAffect(
-                valence=state_snap.get("valence", state_snap.get("mood", 0.0)),
-                arousal=state_snap.get("arousal", state_snap.get("energy", 0.5)),
-                dominance=state_snap.get("dominance", 0.5),
-                trust=state_snap.get("trust", 0.5),
-                attachment=state_snap.get("attachment", 0.1),
-                emotion=state_snap.get("emotion", "neutral"),
-                fatigue=state_snap.get("fatigue", 0.0),
-                user_distance=self.last_user_distance,
-            ),
-            metadata=incoming_metadata,
-            latency_metadata=incoming_latency_metadata,
+            user_distance=self.last_user_distance,
         )
+        payload.metadata = incoming_metadata
+        payload.latency_metadata = incoming_latency_metadata
         await self.publish(Topics.CHAT_OUTPUT, payload.model_dump())
 
     async def stop(self):

--- a/backend/app/cognitive/core.py
+++ b/backend/app/cognitive/core.py
@@ -22,8 +22,10 @@ from .learning import ReflectionService
 from .identity import IdentityManager
 from ..persona.biography import (
     find_biography_file,
+    prune_biography,
     read_biography,
     seed_biography,
+    stale_fingerprints,
 )
 from ..persona.history_migration import migrate_history_memories
 from .pipeline import CognitivePipeline
@@ -149,14 +151,49 @@ class CognitiveService:
         try:
             entries = read_biography(path or find_biography_file())
             if not entries:
+                # No file, or an unreadable one. Deliberately *not* treated as
+                # "every passage was deleted" — a biography that failed to parse
+                # would otherwise erase the whole seeded history on one bad
+                # edit, which is the most expensive possible reading of an
+                # ambiguous situation.
                 return 0
 
+            await self._prune_deleted_passages(entries)
             return await self._seed_once(
                 self.SEEDED_KEY, entries, seed_biography, "Biography"
             )
         except Exception as exc:
             logger.error("[Biography] Seeding failed (%s); continuing.", exc)
             return 0
+
+    async def _prune_deleted_passages(self, entries) -> int:
+        """Forget passages the user removed from the biography.
+
+        Seeding was one-directional: adding a paragraph created a memory, and
+        deleting one did nothing, so a passage removed because it was wrong —
+        or because the person it describes asked for it to go — kept surfacing
+        forever. The file read as the source of truth and was not.
+
+        Runs before seeding so an *edited* paragraph is pruned and re-seeded in
+        the same pass rather than briefly existing twice.
+        """
+        already = self.identity.history.get(self.SEEDED_KEY) or []
+        stale = stale_fingerprints(entries, already)
+        if not stale:
+            return 0
+
+        removed = await prune_biography(stale, self.memory_store)
+        if not removed:
+            return 0
+
+        gone = set(removed)
+        self.identity.history[self.SEEDED_KEY] = [
+            mark for mark in already if mark not in gone
+        ]
+        self.identity.save()
+        await self.identity.persist_to_config_store()
+        logger.info("[Biography] Forgot %d deleted passage(s).", len(removed))
+        return len(removed)
 
     MIGRATED_KEY = "history_memories_migrated"
 

--- a/backend/app/cognitive/identity.py
+++ b/backend/app/cognitive/identity.py
@@ -137,6 +137,7 @@ class IdentityManager:
         self.seeded_from_file = False
         self.persona = persona or self._profile_from_personality()
 
+        self._seed_relationship_from_profile()
         self._stamp_seed_marker()
 
         # CVS-3.5: Immutable Core Trait seeding
@@ -155,6 +156,43 @@ class IdentityManager:
         )
 
     SEED_MARKER = "persona_seeded_at"
+
+    def _seed_relationship_from_profile(self) -> None:
+        """Give `relationship` one owner, seeded from the file exactly once.
+
+        There were two: `PersonaProfile.relationship`, which `persona.toml` can
+        set, and `history["relationship"]`, which the prompt reads and
+        `evolve_persona` writes. Nothing connected them — grep for readers of
+        the profile field and there are none — so writing
+        `relationship = "New Acquaintance"` in the authored file did **nothing
+        at all**, silently. The authoring surface advertised a setting with no
+        effect.
+
+        The profile field is now the seed and the history entry is the live
+        value, which matches how every other adaptive field already works: the
+        file says where the relationship starts, living together decides where
+        it goes. Seeding only on the first boot is what keeps an edit from
+        resetting a friendship that has since moved.
+
+        Gated on the author having *written* `relationship`, not merely on it
+        being a first boot. The schema gives the field a default, so seeding
+        unconditionally would push `"Friend"` over whatever the durable store
+        holds — a hydrating agent whose store says `"Trusted Friend"` would be
+        demoted on every start by a value nobody chose. Seeding means applying
+        what someone wrote; applying a default is just overwriting.
+        """
+        # The two guards below are *not* independent, and a mutation that
+        # disables the first one is unobservable: `authored_overrides` returns
+        # `{}` on any later boot, so `authored_keys` is already empty by then
+        # and the second check alone would do the job. Kept anyway, because
+        # relying on that would couple this method to a detail of another
+        # module — if seed-once ever moves out of `authored_overrides`, the
+        # silent failure is a friendship reset on every restart.
+        if not self.first_boot:
+            return
+        if "relationship" not in getattr(self, "authored_keys", set()):
+            return
+        self.history["relationship"] = self.persona.relationship
 
     def _stamp_seed_marker(self) -> None:
         """Record that the authored file has now been consumed.
@@ -266,6 +304,11 @@ class IdentityManager:
         # exists but is empty or unparseable contributes nothing, so it must not
         # count as having seeded the agent.
         self.seeded_from_file = bool(authored)
+        # Which fields the author actually wrote, as opposed to which ones the
+        # schema supplies a default for. Seeding needs the difference: applying
+        # a *default* over a value the durable store already holds is not
+        # seeding, it is overwriting.
+        self.authored_keys = set(authored)
         merged.update({k: v for k, v in authored.items() if v is not None})
 
         try:
@@ -406,8 +449,9 @@ class IdentityManager:
                     self._sync_personality_from_profile()
 
             # A genuine first boot against a durable store seeds here rather
-            # than in `__init__`, so the marker lands in the history that is
-            # about to be persisted instead of in one already discarded.
+            # than in `__init__`, so the seed lands in the history that is about
+            # to be persisted instead of in one already discarded.
+            self._seed_relationship_from_profile()
             self._stamp_seed_marker()
 
             evolved = config.get("evolved_learnings")

--- a/backend/app/cognitive/identity.py
+++ b/backend/app/cognitive/identity.py
@@ -300,19 +300,10 @@ class IdentityManager:
         authored = authored_overrides(
             self.persona_file, first_boot=self.first_boot
         )
-        # Records that the file was read *and* had something to say. A file that
-        # exists but is empty or unparseable contributes nothing, so it must not
-        # count as having seeded the agent.
-        self.seeded_from_file = bool(authored)
-        # Which fields the author actually wrote, as opposed to which ones the
-        # schema supplies a default for. Seeding needs the difference: applying
-        # a *default* over a value the durable store already holds is not
-        # seeding, it is overwriting.
-        self.authored_keys = set(authored)
         merged.update({k: v for k, v in authored.items() if v is not None})
 
         try:
-            return PersonaProfile(**merged)
+            profile = PersonaProfile(**merged)
         except ValidationError as exc:
             logger.error(
                 "[Identity] %s could not be applied (%s); using defaults for the "
@@ -320,7 +311,26 @@ class IdentityManager:
                 self.personality_path,
                 exc,
             )
+            # Nothing was authored, because nothing was applied. Recording the
+            # keys anyway would let seeding treat schema *defaults* as the
+            # author's choices and stamp the one-time seed marker for a persona
+            # that was rejected — spending the single seed opportunity on a file
+            # whose contents never took effect.
+            self.seeded_from_file = False
+            self.authored_keys = set()
             return PersonaProfile.from_config()
+
+        # Set only once the profile validates. Records that the file was read
+        # *and* had something to say — a file that exists but is empty or
+        # unparseable contributes nothing, so it must not count as having
+        # seeded the agent.
+        self.seeded_from_file = bool(authored)
+        # Which fields the author actually wrote, as opposed to which ones the
+        # schema supplies a default for. Seeding needs the difference: applying
+        # a *default* over a value the durable store already holds is not
+        # seeding, it is overwriting.
+        self.authored_keys = set(authored)
+        return profile
 
     def _sync_personality_from_profile(self) -> None:
         """Project the profile back onto the raw dict `save()` writes.

--- a/backend/app/cognitive/pipeline.py
+++ b/backend/app/cognitive/pipeline.py
@@ -356,17 +356,11 @@ class CognitivePipeline:
         full_response = ""
         done_chunk = None
         is_spec = plan.payload.get("speculative", False)
-        async for chunk in self.action.execute(plan):
-            if is_spec:
-                chunk["speculative"] = True
-            if chunk["type"] == "content":
-                full_response += chunk["data"]
-            if chunk["type"] == "done":
-                done_chunk = chunk
-                continue
-            if await self._consume_internal_chunk(chunk):
-                continue
+        pass_result = {"response": "", "done": None}
+        async for chunk in self._stream_action_pass(plan, is_spec, pass_result):
             yield chunk
+        full_response = pass_result["response"]
+        done_chunk = pass_result["done"]
         stage_times["stage_8_action_execution_ms"] = (
             time.perf_counter() - t_start
         ) * 1000.0
@@ -384,22 +378,13 @@ class CognitivePipeline:
                 plan.payload["identity_prompt"] += (
                     f"\n\nCRITICAL FIX: Your previous response was rejected for: {reason}. Correct this immediately."
                 )
-                full_response = ""
-                done_chunk = None
-                async for chunk in self.action.execute(plan):
-                    if chunk["type"] == "content":
-                        full_response += chunk["data"]
-                    if chunk["type"] == "done":
-                        done_chunk = chunk
-                        continue
-                    # The retry is the likeliest place to trip a second
-                    # metacognitive violation, since it runs with a hardened
-                    # prompt after one rejection. Skipping the filter here would
-                    # leak `self_correction` to the transport *and* swallow the
-                    # cortisol release on the one path that most deserves it.
-                    if await self._consume_internal_chunk(chunk):
-                        continue
+                retry_result = {"response": "", "done": None}
+                async for chunk in self._stream_action_pass(
+                    plan, is_spec, retry_result
+                ):
                     yield chunk
+                full_response = retry_result["response"]
+                done_chunk = retry_result["done"]
         stage_times["stage_9_validation_ms"] = (time.perf_counter() - t_start) * 1000.0
 
         # 10. Learning + Episodic Memory (§6.1)
@@ -435,6 +420,37 @@ class CognitivePipeline:
             yield done_chunk
         else:
             yield {"type": "done", "data": "finished", "speculative": is_spec}
+
+    async def _stream_action_pass(self, plan, is_spec: bool, result: dict):
+        """Run one generation pass, yielding what the transport should see.
+
+        The first pass and the self-correction retry were two copies of this
+        loop, and they had already drifted: the retry never tagged its chunks
+        with `speculative`, so a speculative turn that got self-corrected
+        emitted a stream whose chunks disagreed with the plan that produced
+        them. Nothing downstream reported it, because a missing key just reads
+        as "not speculative".
+
+        Accumulated output goes into `result` rather than a return value —
+        this is an async generator, so it cannot both yield chunks and hand
+        back the assembled response.
+        """
+        async for chunk in self.action.execute(plan):
+            if is_spec:
+                chunk["speculative"] = True
+            if chunk["type"] == "content":
+                result["response"] += chunk["data"]
+            if chunk["type"] == "done":
+                result["done"] = chunk
+                continue
+            # The retry is the likeliest place to trip a second metacognitive
+            # violation, since it runs with a hardened prompt after one
+            # rejection. Skipping the filter would leak `self_correction` to
+            # the transport *and* swallow the cortisol release on the one path
+            # that most deserves it.
+            if await self._consume_internal_chunk(chunk):
+                continue
+            yield chunk
 
     async def _consume_internal_chunk(self, chunk) -> bool:
         """Handle chunks meant for the pipeline itself. True = do not forward.

--- a/backend/app/persona/biography.py
+++ b/backend/app/persona/biography.py
@@ -215,7 +215,10 @@ async def prune_biography(
         return []
 
     is_sqlite = bool(getattr(memory_store, "is_sqlite", False))
-    removed: List[str] = []
+    # Fingerprints whose scan raised. They are held back from the ledger so the
+    # next boot tries again — dropping one on a transient database error would
+    # orphan its row permanently, since nothing would ever look for it after.
+    unscanned: set[str] = set()
 
     logger.info("[Biography] Pruning %d deleted passage(s) from memory.", len(stale))
 
@@ -245,6 +248,7 @@ async def prune_biography(
                         mark[:12],
                         exc,
                     )
+                    unscanned.add(mark)
                     continue
 
                 ids = [str(dict(r)["id"]) for r in rows or ()]
@@ -255,10 +259,17 @@ async def prune_biography(
                 await conn.execute(f"DELETE FROM {table} WHERE id IN ({marks})", *ids)
                 await _drop_vectors(memory_store, ids)
 
-    # Every stale fingerprint leaves the ledger, including ones that matched no
-    # row. Keeping them would mean re-running this scan on every single boot for
-    # a memory that no longer exists.
-    removed = list(stale)
+    # Every *scanned* fingerprint leaves the ledger, including ones that matched
+    # no row. Keeping those would mean re-running this scan on every single boot
+    # for a memory that no longer exists. A fingerprint whose scan failed is a
+    # different case: there we do not know whether a row is still out there, and
+    # the ledger entry is the only thing that will ever make us look again.
+    removed = [mark for mark in stale if mark not in unscanned]
+    if unscanned:
+        logger.warning(
+            "[Biography] %d passage(s) could not be scanned; retrying next boot.",
+            len(unscanned),
+        )
     return removed
 
 

--- a/backend/app/persona/biography.py
+++ b/backend/app/persona/biography.py
@@ -180,6 +180,112 @@ def pending_entries(
     return [entry for entry in entries if entry.fingerprint not in seen]
 
 
+def stale_fingerprints(
+    entries: Sequence[BiographyEntry], already_seeded: Iterable[str]
+) -> List[str]:
+    """Seeded passages the biography no longer contains.
+
+    The counterpart to `pending_entries`. Adding a paragraph seeded it; deleting
+    one did nothing, so a passage removed because it was wrong — or because the
+    person it described asked for it to go — stayed in memory forever and kept
+    surfacing. The file looked like the source of truth and was not.
+
+    Editing a paragraph shows up here as one stale fingerprint plus one pending
+    entry, which is the correct reading: the fingerprint covers heading and
+    text, so an edited passage is a different passage.
+    """
+    current = {entry.fingerprint for entry in entries}
+    return [mark for mark in (already_seeded or ()) if mark not in current]
+
+
+async def prune_biography(
+    stale: Sequence[str], memory_store: Any
+) -> List[str]:
+    """Delete memories for passages no longer in the biography.
+
+    Returns the fingerprints actually removed, for the caller to drop from the
+    ledger. A fingerprint whose row is already gone still counts as removed —
+    the ledger is a record of what was seeded, and leaving an entry for a
+    memory that does not exist means retrying the delete on every boot forever.
+    """
+    if memory_store is None or not stale:
+        return []
+    pool = getattr(memory_store, "pool", None)
+    if pool is None:
+        return []
+
+    is_sqlite = bool(getattr(memory_store, "is_sqlite", False))
+    removed: List[str] = []
+
+    logger.info("[Biography] Pruning %d deleted passage(s) from memory.", len(stale))
+
+    async with pool.acquire() as conn:
+        for table in ("memories", "archived_memories"):
+            for mark in stale:
+                try:
+                    if is_sqlite:
+                        # `metadata` is TEXT here, so the JSON has to be parsed
+                        # by the query rather than indexed into. json1 ships
+                        # with the stdlib build.
+                        rows = await conn.fetch(
+                            f"SELECT id FROM {table} WHERE "
+                            "json_extract(metadata, '$.biography_fingerprint') = ?",
+                            mark,
+                        )
+                    else:
+                        rows = await conn.fetch(
+                            f"SELECT id FROM {table} WHERE "
+                            "metadata->>'biography_fingerprint' = $1",
+                            mark,
+                        )
+                except Exception as exc:
+                    logger.warning(
+                        "[Biography] Could not scan %s for %s (%s); skipping.",
+                        table,
+                        mark[:12],
+                        exc,
+                    )
+                    continue
+
+                ids = [str(dict(r)["id"]) for r in rows or ()]
+                if not ids:
+                    continue
+
+                marks = ",".join("?" if is_sqlite else f"${i + 1}" for i in range(len(ids)))
+                await conn.execute(f"DELETE FROM {table} WHERE id IN ({marks})", *ids)
+                await _drop_vectors(memory_store, ids)
+
+    # Every stale fingerprint leaves the ledger, including ones that matched no
+    # row. Keeping them would mean re-running this scan on every single boot for
+    # a memory that no longer exists.
+    removed = list(stale)
+    return removed
+
+
+async def _drop_vectors(memory_store: Any, ids: Sequence[str]) -> None:
+    """Remove the vectors for deleted memories.
+
+    Retrieval fuses Qdrant hits with SQL rows, so a vector left behind after
+    its row is gone means the pruned passage keeps being *found* — the search
+    returns a candidate that no longer exists.
+    """
+    store = getattr(memory_store, "qdrant_store", None)
+    if not store or not getattr(store, "client", None) or not ids:
+        return
+    try:
+        import asyncio
+
+        from qdrant_client.http import models
+
+        await asyncio.to_thread(
+            store.client.delete,
+            collection_name=store.collection_name,
+            points_selector=models.PointIdsList(points=list(ids)),
+        )
+    except Exception as exc:
+        logger.error("[Biography] Could not delete %d vector(s): %s", len(ids), exc)
+
+
 async def seed_biography(
     entries: Sequence[BiographyEntry],
     memory_store: Any,

--- a/backend/scripts/show_persona.py
+++ b/backend/scripts/show_persona.py
@@ -77,7 +77,10 @@ def _render(identity: IdentityManager) -> str:
     out.append(
         _line("migrated memories", len(history.get("history_memories_migrated") or []))
     )
-    out.append(_line("evolved learnings", len(history.get("evolved_learnings") or "")))
+    # A free-text blob, not a list. Printed as characters and labelled as such,
+    # because an unlabelled number in a column of item counts reads as one.
+    learned = len(history.get("evolved_learnings") or "")
+    out.append(_line("evolved learnings", f"{learned} chars"))
     out.append("")
     return "\n".join(out)
 

--- a/backend/scripts/show_persona.py
+++ b/backend/scripts/show_persona.py
@@ -1,0 +1,132 @@
+"""
+Show who your humanoid currently is.
+
+    cd backend
+    ../.venv/Scripts/python.exe -m scripts.show_persona
+    ../.venv/Scripts/python.exe -m scripts.show_persona --json
+
+Once the durable store became authoritative, `config/persona.toml` stopped
+describing the running agent — it is a seed, read once, and everything after
+that lives in `agent_configs` and evolves. That left no way to answer the most
+basic question there is: who is my friend right now? This is that answer.
+
+Read-only by construction. It opens the store, prints, and exits; nothing here
+writes, so it is safe to run against a live agent. Editing what it shows is a
+different act with a different tool (`scripts/reset_persona.py` to start over
+from the file, or simply talking to them).
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from app.cognitive.identity import IdentityManager  # noqa: E402
+from app.state.conversation_store import ConversationHistoryStore  # noqa: E402
+
+
+def _line(label: str, value) -> str:
+    return f"  {label:<22} {value}"
+
+
+def _render(identity: IdentityManager) -> str:
+    persona = identity.persona
+    history = identity.history
+    core = identity.immutable_core
+
+    out = [f"\n{persona.name}", "=" * max(len(persona.name), 40), ""]
+
+    out.append("IMMUTABLE — fixed in code, not editable anywhere")
+    out.append(_line("values", ", ".join(core["values"])))
+    out.append(_line("boundaries", ", ".join(core["boundaries"])))
+    out.append("")
+
+    out.append("CONSTITUTIONAL — seeded once, held steady")
+    out.append(_line("base_tone", core["base_tone"]))
+    out.append(_line("traits", ", ".join(persona.traits) or "—"))
+    out.append(_line("speech_patterns", ", ".join(persona.speech_patterns) or "—"))
+    out.append(_line("avoid", ", ".join(persona.avoid) or "—"))
+    out.append("")
+
+    out.append("ADAPTIVE — seeded once, then theirs")
+    out.append(_line("relationship", history.get("relationship", "—")))
+    out.append(_line("adaptive_traits", ", ".join(persona.adaptive_traits) or "—"))
+    out.append(
+        _line("speaking_style", persona.speaking_style.get("style_description") or "—")
+    )
+    out.append(_line("initial_trust", persona.initial_trust))
+    out.append(_line("baseline_valence", persona.baseline_valence))
+    out.append("")
+
+    summary = (persona.identity_summary or "").strip()
+    if summary:
+        out.append("WHO THEY ARE")
+        out.extend(f"  {ln}" for ln in summary.splitlines())
+        out.append("")
+
+    out.append("PROVENANCE")
+    seeded = history.get(IdentityManager.SEED_MARKER)
+    # The distinction that matters most on this screen: a persona that was never
+    # seeded is running on defaults, and someone looking at an authored file
+    # wondering why it had no effect needs to see that stated, not inferred.
+    out.append(_line("seeded from file", seeded or "never — running on defaults"))
+    out.append(_line("biography passages", len(history.get("biography_seeded") or [])))
+    out.append(
+        _line("migrated memories", len(history.get("history_memories_migrated") or []))
+    )
+    out.append(_line("evolved learnings", len(history.get("evolved_learnings") or "")))
+    out.append("")
+    return "\n".join(out)
+
+
+async def _run(as_json: bool) -> int:
+    store = ConversationHistoryStore()
+    await store.initialize()
+
+    if store.pool is None:
+        print("❌ No database reachable, so there is no stored persona to show.")
+        print("   The agent would be running on its shipped defaults.")
+        return 1
+
+    identity = IdentityManager()
+    await identity.hydrate_from_config_store(store)
+
+    if identity.config_store is None:
+        # Hydration failed rather than returned nothing. Printing the defaults
+        # here would show a persona that is not the stored one and give no hint
+        # that the real answer was never retrieved.
+        print("❌ Could not read the stored persona; showing nothing rather than")
+        print("   a default that would look like your friend and is not.")
+        return 1
+
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "persona": identity.persona.model_dump(),
+                    "immutable_core": identity.immutable_core,
+                    "history": identity.history,
+                },
+                indent=2,
+                default=str,
+            )
+        )
+    else:
+        print(_render(identity))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json", action="store_true", help="machine-readable output"
+    )
+    args = parser.parse_args()
+    return asyncio.run(_run(args.json))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_small_followups.py
+++ b/backend/tests/test_small_followups.py
@@ -1,0 +1,328 @@
+"""
+Five small follow-ups, three of which change behaviour.
+
+- `relationship` had two owners and the authored one was read by nobody.
+- Deleting a biography passage left its memory in place forever.
+- The self-correction retry never tagged speculative chunks.
+- `_publish_speech_chunk` re-derived the affect vector instead of using the
+  coordinator that exists to build it.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from app.cognitive.identity import IdentityManager
+from app.persona.biography import (
+    BiographyEntry,
+    prune_biography,
+    stale_fingerprints,
+)
+
+# --------------------------------------------------------------------------
+# relationship has one owner
+# --------------------------------------------------------------------------
+
+AUTHORED = """
+name = "Written"
+relationship = "New Acquaintance"
+"""
+
+
+def _persona_file(tmp_path):
+    path = tmp_path / "persona.toml"
+    path.write_text(AUTHORED, encoding="utf-8")
+    return path
+
+
+def test_an_authored_relationship_actually_takes_effect(tmp_path):
+    """It used to do nothing at all, silently.
+
+    `PersonaProfile.relationship` is what `persona.toml` sets; the prompt reads
+    `history["relationship"]`. Nothing connected them — grep for readers of the
+    profile field and there were none — so someone writing
+    `relationship = "New Acquaintance"` got "Friend" and no warning that their
+    setting had been discarded.
+    """
+    agent = IdentityManager(base_path=str(tmp_path), persona_file=_persona_file(tmp_path))
+
+    assert agent.first_boot is True
+    assert agent.history["relationship"] == "New Acquaintance"
+    assert "New Acquaintance" in agent.get_persona_prompt("")
+
+
+def test_an_unwritten_relationship_never_overwrites_a_stored_one(tmp_path):
+    """Seeding applies what someone wrote, not what the schema defaults to.
+
+    `relationship` has a default of "Friend". Seeding it unconditionally on a
+    first boot pushed that default over whatever the durable store held, so an
+    agent hydrating from a store that said "Trusted Friend" was demoted on
+    every start by a value nobody chose. Caught by an existing regression test,
+    not by this file — the first version of this feature shipped that bug.
+    """
+    silent = tmp_path / "persona.toml"
+    silent.write_text('name = "Written"\n', encoding="utf-8")
+
+    agent = IdentityManager(base_path=str(tmp_path), persona_file=silent)
+    agent.history["relationship"] = "Trusted Friend"
+    agent._seed_relationship_from_profile()
+
+    assert agent.history["relationship"] == "Trusted Friend"
+
+
+def test_a_lived_relationship_is_not_reset_by_the_file(tmp_path):
+    """The seed-once rule, applied to the field that most needs it.
+
+    Trust and closeness are exactly what months of conversation build. If an
+    edit to the authored file reset the relationship, the friendship would be
+    worth nothing.
+    """
+    (tmp_path / "personality.json").write_text(
+        json.dumps({"name": "Lived"}), encoding="utf-8"
+    )
+    (tmp_path / "history.json").write_text(
+        json.dumps({"memories": ["we met in October"], "relationship": "Close Friend"}),
+        encoding="utf-8",
+    )
+    agent = IdentityManager(base_path=str(tmp_path), persona_file=_persona_file(tmp_path))
+
+    assert agent.first_boot is False
+    assert agent.history["relationship"] == "Close Friend"
+
+
+# --------------------------------------------------------------------------
+# deleting a passage forgets it
+# --------------------------------------------------------------------------
+
+
+def _entry(heading, text):
+    return BiographyEntry(heading=heading, text=text)
+
+
+def test_a_removed_passage_is_reported_stale():
+    """Seeding was one-directional: adding created, deleting did nothing."""
+    kept = _entry("Her sister", "They text every morning.")
+    gone = _entry("Work", "She quit in March.")
+
+    stale = stale_fingerprints([kept], [kept.fingerprint, gone.fingerprint])
+    assert stale == [gone.fingerprint]
+
+
+def test_an_edited_passage_counts_as_removed_and_added():
+    """The fingerprint covers heading and text, so an edit is a new passage.
+
+    It has to show up on both sides — stale *and* pending — or an edited
+    paragraph would leave the old wording in memory alongside the new one, and
+    the agent would recall a version of the story the file no longer tells.
+    """
+    before = _entry("Work", "She quit in March.")
+    after = _entry("Work", "She quit in April.")
+
+    assert stale_fingerprints([after], [before.fingerprint]) == [before.fingerprint]
+    assert after.fingerprint != before.fingerprint
+
+
+def test_nothing_is_stale_when_the_file_is_unchanged():
+    """The common case must be a no-op, or every boot rewrites the ledger."""
+    entry = _entry("Her sister", "They text every morning.")
+    assert stale_fingerprints([entry], [entry.fingerprint]) == []
+
+
+class FakeConn:
+    def __init__(self, rows):
+        self.rows = rows
+        self.executed = []
+
+    async def fetch(self, query, *args):
+        if "archived_memories" in query:
+            return []
+        return [{"id": i} for i, mark in self.rows if mark in args]
+
+    async def execute(self, query, *args):
+        self.executed.append((query, args))
+
+
+class FakePool:
+    def __init__(self, conn):
+        self.conn = conn
+
+    def acquire(self):
+        pool = self
+
+        class _Ctx:
+            async def __aenter__(self):
+                return pool.conn
+
+            async def __aexit__(self, *exc):
+                return False
+
+        return _Ctx()
+
+
+@pytest.mark.asyncio
+async def test_pruning_deletes_the_row_for_a_removed_passage():
+    gone = _entry("Work", "She quit in March.")
+    conn = FakeConn([("mem-1", gone.fingerprint)])
+    store = SimpleNamespace(pool=FakePool(conn), is_sqlite=True, qdrant_store=None)
+
+    removed = await prune_biography([gone.fingerprint], store)
+
+    assert removed == [gone.fingerprint]
+    assert any("DELETE FROM memories" in q for q, _ in conn.executed)
+    assert any("mem-1" in str(a) for _, a in conn.executed)
+
+
+@pytest.mark.asyncio
+async def test_a_fingerprint_with_no_row_still_leaves_the_ledger():
+    """Otherwise the scan is retried on every boot, forever.
+
+    A passage whose memory was already pruned by decay has nothing to delete.
+    Keeping its fingerprint would mean re-running the query for a row that
+    cannot exist, on every single start.
+    """
+    conn = FakeConn([])
+    store = SimpleNamespace(pool=FakePool(conn), is_sqlite=True, qdrant_store=None)
+
+    assert await prune_biography(["orphan-fingerprint"], store) == [
+        "orphan-fingerprint"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_biography_never_prunes_everything(tmp_path):
+    """The most expensive possible misreading of an ambiguous situation.
+
+    A biography that fails to parse yields no entries. Treating that as "every
+    passage was deleted" would erase the entire seeded history on one bad edit.
+    """
+    from app.cognitive.core import CognitiveService
+
+    class Store:
+        def __init__(self):
+            self.added = []
+
+        async def add_memory(self, **kw):
+            self.added.append(kw)
+
+    # A store with a real `pool`, so pruning would genuinely run if it were
+    # reached. Without one, `prune_biography` bails on the first line and this
+    # test passes no matter what the code does — which is exactly how the first
+    # version of it passed against a mutant that pruned everything.
+    conn = FakeConn([("mem-1", "some-old-fingerprint")])
+    store = Store()
+    store.pool = FakePool(conn)
+    store.is_sqlite = True
+    store.qdrant_store = None
+
+    service = CognitiveService(
+        llm_service=None, memory_store=store, graph_db=None,
+        base_path=str(tmp_path),
+    )
+    service.identity.history[CognitiveService.SEEDED_KEY] = ["some-old-fingerprint"]
+
+    missing = tmp_path / "nope.md"
+    assert await service.seed_biography_once(missing) == 0
+    assert service.identity.history[CognitiveService.SEEDED_KEY] == [
+        "some-old-fingerprint"
+    ], "an unreadable file must not erase the seeded history"
+
+
+# --------------------------------------------------------------------------
+# one affect vector, one action loop
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_streamed_chunks_carry_the_same_affect_as_the_coordinator_builds():
+    """Two implementations of a wire contract drift, and this one already had.
+
+    `_publish_speech_chunk` re-derived the same eight `state_snap.get(...)`
+    defaults that `create_chunk_payload` already applies, so a change to one
+    produced streams whose chunks disagreed with their own `done` message.
+
+    Asserted behaviourally rather than by reading the source: a test that greps
+    for a call name passes for any refactor that keeps the name, including one
+    that reintroduces a second construction beside it.
+    """
+    from app.agents.brain_agent import BrainAgent
+    from app.utils.speech import SpeechCoordinator
+
+    agent = object.__new__(BrainAgent)
+    snapshot = {
+        "valence": 0.42,
+        "arousal": 0.31,
+        "dominance": 0.77,
+        "trust": 0.66,
+        "attachment": 0.55,
+        "emotion": "fond",
+        "fatigue": 0.12,
+    }
+    agent.coordinator = SpeechCoordinator(segmenter=None)
+    agent.cognitive_core = SimpleNamespace(
+        state=SimpleNamespace(get_context_snapshot=lambda: snapshot)
+    )
+    agent.last_user_distance = 1.5
+
+    published = []
+
+    async def capture(subject, payload):
+        published.append(payload)
+
+    agent.publish = capture
+    await agent._publish_speech_chunk(["hello", "you"], turn_id="t1")
+
+    expected = agent.coordinator.create_chunk_payload(
+        words=["hello", "you"],
+        state_snap=snapshot,
+        turn_id="t1",
+        user_distance=1.5,
+    )
+    assert published[0]["affect"] == expected.affect.model_dump()
+    assert published[0]["content"] == "hello you"
+
+    # Pinned against the snapshot as well as against the coordinator. Comparing
+    # the two alone is tautological — both read the same mapping, so a mapping
+    # that drops a field still makes them agree with each other while the
+    # voice agent receives an affect vector the state never had.
+    affect = published[0]["affect"]
+    assert affect["valence"] == 0.42
+    assert affect["arousal"] == 0.31
+    assert affect["dominance"] == 0.77
+    assert affect["trust"] == 0.66
+    assert affect["attachment"] == 0.55
+    assert affect["emotion"] == "fond"
+    assert affect["fatigue"] == 0.12
+    assert affect["user_distance"] == 1.5
+
+
+@pytest.mark.asyncio
+async def test_the_self_correction_retry_still_tags_speculative_chunks():
+    """The drift the collapsed loop fixes.
+
+    Stage 9's retry was a second copy of stage 8's loop that never applied the
+    `speculative` tag. A speculative turn that got self-corrected emitted chunks
+    disagreeing with the plan that produced them, and nothing downstream noticed
+    because a missing key just reads as "not speculative".
+    """
+    from app.cognitive.pipeline import CognitivePipeline
+
+    pipeline = object.__new__(CognitivePipeline)
+
+    async def fake_execute(_plan):
+        yield {"type": "content", "data": "hi"}
+        yield {"type": "done"}
+
+    pipeline.action = SimpleNamespace(execute=fake_execute)
+
+    async def no_internal(_chunk):
+        return False
+
+    pipeline._consume_internal_chunk = no_internal
+
+    result = {"response": "", "done": None}
+    chunks = [c async for c in pipeline._stream_action_pass(None, True, result)]
+
+    assert all(c.get("speculative") for c in chunks)
+    assert result["response"] == "hi"
+    assert result["done"] is not None

--- a/backend/tests/test_small_followups.py
+++ b/backend/tests/test_small_followups.py
@@ -189,6 +189,73 @@ async def test_a_fingerprint_with_no_row_still_leaves_the_ledger():
     ]
 
 
+class ExplodingConn(FakeConn):
+    """A connection whose scans fail, as a database under load does."""
+
+    async def fetch(self, query, *args):
+        raise RuntimeError("connection reset")
+
+
+@pytest.mark.asyncio
+async def test_a_passage_whose_scan_failed_stays_in_the_ledger():
+    """A transient database error must not orphan the row permanently.
+
+    The ledger entry is the only record that a fingerprint was ever seeded. If
+    a failed scan still counted as removed, the entry would be dropped while
+    its memory row survived, and nothing would ever look for that row again —
+    the passage would be recalled by a friend who was told to forget it, with
+    no remaining trace pointing at why.
+    """
+    store = SimpleNamespace(
+        pool=FakePool(ExplodingConn([])), is_sqlite=True, qdrant_store=None
+    )
+
+    assert await prune_biography(["unlucky-fingerprint"], store) == []
+
+
+@pytest.mark.asyncio
+async def test_a_scanned_passage_leaves_the_ledger_even_when_a_sibling_failed():
+    """One bad fingerprint must not hold back the others.
+
+    Otherwise a single permanently-unscannable entry would re-run the whole
+    prune on every boot forever.
+    """
+
+    class HalfBroken(FakeConn):
+        async def fetch(self, query, *args):
+            if "bad" in args:
+                raise RuntimeError("connection reset")
+            return []
+
+    store = SimpleNamespace(
+        pool=FakePool(HalfBroken([])), is_sqlite=True, qdrant_store=None
+    )
+
+    assert await prune_biography(["good", "bad"], store) == ["good"]
+
+
+def test_a_rejected_persona_file_does_not_count_as_seeded(tmp_path):
+    """A file that failed validation applied nothing, so it seeded nothing.
+
+    `seeded_from_file` and `authored_keys` used to be set before the profile
+    was validated. When validation then failed, the agent fell back to schema
+    defaults while still believing the author had chosen them — so the seed
+    marker was stamped and the *default* relationship was applied as if it had
+    been written down. That spends the single, one-time seed opportunity on a
+    persona whose contents never took effect, and only a reset gets it back.
+    """
+    bad = tmp_path / "persona.toml"
+    # Out of bounds by design: mood decay of zero is a permanent mood lock, and
+    # the schema rejects it rather than clamping.
+    bad.write_text('relationship = "New Acquaintance"\nmood_decay_rate = 0.0\n', encoding="utf-8")
+
+    agent = IdentityManager(base_path=str(tmp_path), persona_file=bad)
+
+    assert agent.seeded_from_file is False
+    assert agent.authored_keys == set()
+    assert agent.history["relationship"] == "Friend"
+
+
 @pytest.mark.asyncio
 async def test_an_unreadable_biography_never_prunes_everything(tmp_path):
     """The most expensive possible misreading of an ambiguous situation.


### PR DESCRIPTION
Cleanup batch after #80. Three change behaviour, two remove a duplicated implementation. **Excludes** the `memory_store.py` decomposition (F1), which is its own project.

## Two of these were dead features

**`relationship` had two owners and the authored one was read by nobody.** `PersonaProfile.relationship` is what `config/persona.toml` sets; `history["relationship"]` is what the prompt reads and `evolve_persona` writes. Nothing connected them — grep for readers of the profile field returned none — so writing `relationship = "New Acquaintance"` in the authored file did **nothing at all**, silently.

**Deleting a biography passage did nothing.** Adding a paragraph created a memory; removing one left it in place forever. A passage deleted because it was wrong, or because the person it describes asked for it to go, kept surfacing. The file read as the source of truth while not being one.

## The rest

- **Self-correction retry was a divergent copy** of stage 8's loop that never applied the `speculative` tag, so a speculative turn that self-corrected emitted chunks disagreeing with its own plan. Nothing reported it — a missing key reads as "not speculative". One `_stream_action_pass` now serves both.
- **`_publish_speech_chunk` re-derived the affect vector** that `create_chunk_payload` already builds. Same class of defect as the prosody drift one layer down.
- **`scripts/show_persona.py`** — answers "who is my friend right now", which became unanswerable once the durable store took over from `persona.toml`.

## A bug I shipped and then caught

The first version of the relationship fix seeded on any first boot, so an agent hydrating from a store that said `"Trusted Friend"` was demoted to the schema default `"Friend"` on every start. Caught by an **existing regression test**, not a new one. Seeding is now gated on the author having *written* the field: applying a default is not seeding, it is overwriting.

Pruning also refuses to treat an empty parse as "everything was deleted" — a biography that fails to parse would otherwise erase the whole seeded history on one bad edit.

## Verification

`tests/test_small_followups.py` (11 tests). **9 mutations, 8 caught.**

M2 (dropping the `first_boot` guard on relationship seeding) survives and is **expected to**: `authored_overrides` returns `{}` on later boots, so `authored_keys` is already empty and the second guard alone suffices. The conditions aren't independent. The redundant check is kept and commented, because relying on that coupling would tie this method to a detail of another module.

**Two tests initially passed for the wrong reason** and were rewritten after mutation exposed them — the prune test used a fake store with no `pool`, so `prune_biography` bailed on line one and it passed against a mutant that pruned everything; and the affect test compared two callers of the same mapping, which is tautological.

**618 non-benchmark tests pass**, `ruff check .` clean, working tree clean.

## Not in this PR

**F1** — `memory_store.py` decomposition, 3031 lines.

**Deprecated prosody fields on `ChatOutput`** — I had scoped this as small and it isn't. The Rust `contracts` crate declares the same fields, so removing them is a coordinated cross-language wire change needing a `setup_nats_streams.py` re-run and a deploy ordering where old consumers still receive messages without those keys.

**Neo4j reset residue** — nothing tracks which graph entities were derived from seeded memories, so no query finds them. Needs design.

**`identity_summary` prompt cost** — a measurement task against real infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only command to view the active persona, identity summary, and provenance details in human-readable or JSON format.
  - Biography updates now remove memories associated with passages deleted from the biography.

- **Bug Fixes**
  - Authored relationship settings now apply correctly without overwriting existing lived state.
  - Self-correction retries consistently preserve speculative streaming markers.
  - Speech output now reports affect data consistently across streaming and standard responses.
  - Unreadable biography files no longer erase previously seeded information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->