### PR TITLE
fix(persona): bound the one prompt field reflection can grow without limit

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -3950,3 +3950,68 @@ confirm the new tests pin both directions rather than just the bug.
 **NOT done:** unchanged from the #81 entry above — F1, the cross-language
 prosody wire change, Neo4j reset residue, and the unmeasured `identity_summary`
 prompt cost all remain open.
+
+### 2026-07-19 — Neo4j reset residue does not exist; the prompt had one unbounded field
+
+Two items were queued: tag graph writes with the seeded memory they derive from
+(3a), and measure the persona prompt's per-turn cost (4a). Investigating the
+first disproved it, and investigating the second found a bug rather than a
+number.
+
+**There is no seed-derived graph residue, because there is no derivation.**
+Traced every writer of `:Entity` nodes. `TripleExtractor.extract_and_store`
+(`state/triple_extractor.py`) has **zero callers** — dead code. The one live
+writer is `learning.py:220`, reached from two reflection entry points, and both
+are fed by live turns: `subconscious_agent` reads
+`get_recent_unconsolidated_episodes`, which is `SELECT ... FROM messages`
+(`memory_store.py:2727`), and `pipeline.py:393` builds its episode from
+`event.raw_content` plus `full_response`. Seeded biography passages are written
+to `memories` — a different table, which is exactly what `prune_biography`
+scans. Nothing reads `memories` into graph extraction, so a reset leaves no
+orphaned entities.
+
+The one path by which a seeded fact can reach the graph is indirect: the agent
+retrieves a passage, says something about it, and *that turn's transcript* is
+reflected. By then it is a conversation artifact, which the chosen reset scope
+(persona + biography, keep conversation memories) deliberately preserves. So
+the indirect path is correct as-is, not a gap.
+
+3a is therefore **not built**: threading provenance through `create_triplet`
+would be machinery with no user. Recorded here rather than left open, because
+the next person to read "Neo4j residue" in a TODO would re-derive this.
+
+**`style_description` was the only unbounded field in the per-turn prompt.**
+Every other narrative field declares a ceiling — `identity_summary` 1200,
+`speech_patterns` 20, `adaptive_traits` 5, `relationship` 64, and the immutable
+core is constant. But `speaking_style` is `Dict[str, Any]`, which cannot bound
+its own values, and `evolve_persona` assigned `suggestions["speaking_style"]`
+straight from reflection output with no limit.
+
+That field compounds in a way the others cannot: it is the only part of the
+prompt the agent rewrites *by itself*, so a reflection model that returns a
+paragraph instead of a phrase permanently enlarges every subsequent turn — and
+the next reflection reads the enlarged prompt and can grow it again. Nothing in
+the loop pulls it back. Now capped at 400 characters (`MAX_STYLE_DESCRIPTION`,
+declared in `profile.py` beside the other tier bounds), truncated rather than
+rejected, and truncated at *assignment* so the stored column is bounded too —
+clipping only on render would let the value grow forever while hiding that it
+had.
+
+This is the honest answer to "measure the prompt cost": the reason nobody could
+state it was that one field had no ceiling. Fully saturated the prompt is ~5900
+characters, pinned by a test at a 7000 budget. The budget is deliberately slack
+— a tight one fails on template rewording, while an unbounded field overshoots
+by an order of magnitude.
+
+Five mutations, five caught, including two asymmetric ones (bound raised to
+uselessness; bound tightened until it trims ordinary text) so the tests pin a
+range rather than one side.
+
+**643 tests pass**, `ruff check .` clean.
+
+**NOT done:** 4b — latency of the assembled prompt against the 120s stream
+ceiling — is **dropped, not deferred**, per the standing decision not to run
+real-infrastructure benchmarks. No latency figure is claimed. F1
+(`memory_store.py` decomposition) and the cross-language prosody wire change
+remain open. `TripleExtractor` is dead code and was left in place rather than
+removed as an unrelated drive-by.

--- a/backend/app/cognitive/identity.py
+++ b/backend/app/cognitive/identity.py
@@ -540,11 +540,19 @@ class IdentityManager:
         # 1. Update Adaptive Styles (Vocabulary, preferences)
         if "speaking_style" in suggestions:
             style = dict(self.persona.speaking_style)
-            style["style_description"] = suggestions["speaking_style"]
+            # Truncated, not rejected. This value arrives from the reflection
+            # model at runtime, and the same asymmetry that governs
+            # `from_config()` applies: a running friend should degrade rather
+            # than fail to evolve because a model was verbose once. Bounding it
+            # here rather than in the prompt builder keeps the stored value
+            # bounded too -- clipping only on read would let the column grow
+            # without limit while hiding that it had.
+            described = str(suggestions["speaking_style"])[
+                : PersonaProfile.MAX_STYLE_DESCRIPTION
+            ]
+            style["style_description"] = described
             self.persona.speaking_style = style
-            logger.info(
-                f"[Identity] Adaptive style evolved: {style['style_description']}"
-            )
+            logger.info(f"[Identity] Adaptive style evolved: {described}")
 
         if "new_traits" in suggestions:
             # The cap lives on the profile now, not restated here.

--- a/backend/app/persona/profile.py
+++ b/backend/app/persona/profile.py
@@ -60,7 +60,7 @@ import json
 import logging
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
@@ -194,6 +194,20 @@ class PersonaProfile(BaseModel):
     # entire narrative persona down with it — name, tone and traits discarded
     # over a vocabulary entry.
     speaking_style: Dict[str, Any] = _adaptive(default_factory=dict)
+
+    # The one field in the per-turn prompt that reflection writes *free text*
+    # into. `Dict[str, Any]` cannot bound its own values, so the ceiling has to
+    # be applied where the value is assigned -- see
+    # `IdentityManager.evolve_persona`. Without it, `style_description` is the
+    # only part of the persona prompt with no upper size, and it is the part the
+    # agent rewrites by itself: an LLM that returns a paragraph instead of a
+    # phrase permanently enlarges every subsequent turn's prompt, and the next
+    # reflection reads that bloated prompt and can grow it again.
+    #
+    # 400 characters is a sentence or two -- the register the friend adopts with
+    # you, which is what this field is for. Anything longer is the reflection
+    # model explaining itself rather than describing a voice.
+    MAX_STYLE_DESCRIPTION: ClassVar[int] = 400
 
     # -- tier introspection -------------------------------------------------
 

--- a/backend/tests/test_persona_prompt_bounds.py
+++ b/backend/tests/test_persona_prompt_bounds.py
@@ -1,0 +1,114 @@
+"""
+The persona prompt is paid for on every single turn.
+
+Everything in `get_persona_prompt` is assembled from persona fields, and the
+whole block is prepended to each request. So an unbounded field there is not a
+storage question — it is a per-turn latency and context-budget question, and it
+compounds: reflection reads the prompt and can write back into it.
+
+Every narrative field had a declared ceiling except `style_description`, which
+reflection writes free text into. These tests pin the ceilings so a later field
+cannot quietly remove one.
+"""
+
+import pytest
+
+from app.cognitive.identity import IdentityManager
+from app.persona.profile import PersonaProfile
+
+# Deliberately in characters rather than tokens: a real tokenizer would make
+# this test depend on a model, and the point is to catch an unbounded *field*,
+# not to predict a token count to the unit.
+#
+# Fully saturated the prompt measures ~5900 characters. The budget is set above
+# that with room to spare on purpose. A tight budget would fail every time
+# someone rewords a static line of the template — noise, not signal — whereas
+# the failure this exists to catch is a field with no ceiling at all, and that
+# overshoots by an order of magnitude rather than a few percent (the verbose
+# reflection below would contribute ~40,000 characters unbounded).
+WORST_CASE_PROMPT_CHARS = 7000
+
+
+def _saturated(tmp_path) -> IdentityManager:
+    """An agent with every bounded narrative field pushed to its limit."""
+    agent = IdentityManager(base_path=str(tmp_path), persona_file=None)
+    p = agent.persona
+    p.name = "N" * 64
+    p.identity_summary = "S" * 1200
+    p.speech_patterns = ["P" * 80 for _ in range(20)]
+    p.adaptive_traits = ["T" * 80 for _ in range(5)]
+    p.relationship = "R" * 64
+    p.speaking_style = {
+        "style_description": "D" * PersonaProfile.MAX_STYLE_DESCRIPTION,
+        "common_vocabulary": ["V" * 40 for _ in range(200)],
+    }
+    return agent
+
+
+def test_the_persona_prompt_has_a_ceiling(tmp_path):
+    """Every field saturated must still fit a budget stated in advance.
+
+    If this fails after a new field is added, the field is unbounded or its
+    bound is too loose — the prompt is not the place to discover that, because
+    the cost is paid on every turn by every user before anyone notices.
+    """
+    prompt = _saturated(tmp_path).get_persona_prompt("mood directive")
+
+    assert len(prompt) < WORST_CASE_PROMPT_CHARS, (
+        f"persona prompt reached {len(prompt)} chars; a field is unbounded "
+        "or its ceiling was raised without raising this budget deliberately"
+    )
+
+
+def test_vocabulary_cannot_grow_the_prompt_without_limit(tmp_path):
+    """`common_vocabulary` has no item cap in the schema, only a read-time slice.
+
+    The slice is what bounds it. If someone removes the `[:30]` believing the
+    schema constrains the list, the prompt grows with every word the agent ever
+    learns.
+    """
+    agent = _saturated(tmp_path)
+    agent.persona.speaking_style = {
+        "style_description": "",
+        "common_vocabulary": ["word" for _ in range(5000)],
+    }
+
+    prompt = agent.get_persona_prompt("")
+
+    assert prompt.count("word") <= 30
+
+
+@pytest.mark.asyncio
+async def test_a_verbose_reflection_cannot_permanently_enlarge_every_turn(tmp_path):
+    """The compounding case, and the reason this field needed a bound at all.
+
+    `style_description` is the one part of the per-turn prompt that the agent
+    rewrites by itself, straight from reflection output. An LLM that returns a
+    paragraph instead of a phrase would enlarge every subsequent prompt — and
+    the next reflection reads that larger prompt, so it can grow again. Nothing
+    in the loop pulls it back down.
+    """
+    agent = IdentityManager(base_path=str(tmp_path), persona_file=None)
+
+    await agent.evolve_persona({"speaking_style": "verbose " * 5000})
+
+    stored = agent.persona.speaking_style["style_description"]
+    assert len(stored) == PersonaProfile.MAX_STYLE_DESCRIPTION
+    # Bounded in storage, not merely on read: clipping at render time would let
+    # the durable column grow forever while hiding that it had.
+    assert len(agent.get_persona_prompt("")) < WORST_CASE_PROMPT_CHARS
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_style_is_left_exactly_as_written(tmp_path):
+    """The bound must be invisible at normal length.
+
+    A ceiling that trims typical output would silently reword the agent's own
+    description of its voice.
+    """
+    agent = IdentityManager(base_path=str(tmp_path), persona_file=None)
+    voice = "Warm and unhurried, with a habit of asking one question too many."
+
+    await agent.evolve_persona({"speaking_style": voice})
+
+    assert agent.persona.speaking_style["style_description"] == voice


### PR DESCRIPTION
Queued as two items: tag graph writes with their originating seeded memory (3a), and measure the persona prompt's per-turn cost (4a). Investigating the first **disproved** it; investigating the second found a **bug** rather than a number. So this PR is smaller than planned in one place and larger in another.

## The Neo4j reset residue does not exist

There is no seed-derived graph residue because there is no derivation path.

- `TripleExtractor.extract_and_store` has **zero callers** — dead code.
- The one live writer of `:Entity` relationships is `learning.py:220`, reached from two reflection entry points.
- Both are fed by **live turns**: `subconscious_agent` reads `get_recent_unconsolidated_episodes` → `SELECT ... FROM messages` (`memory_store.py:2727`); `pipeline.py:393` builds its episode from `event.raw_content` + `full_response`.
- Seeded biography passages are written to `memories` — the table `prune_biography` scans. Nothing reads it into graph extraction.

The only way a seeded fact reaches the graph is indirect: the agent retrieves a passage, talks about it, and *that transcript* is reflected. By then it's a conversation artifact, which the chosen reset scope deliberately keeps.

**3a is not built** — threading provenance through `create_triplet` would be machinery with no user. The finding is in the ledger so the next reader of "Neo4j residue" doesn't re-derive it.

## `style_description` was unbounded, and it compounds

Every narrative field in the per-turn prompt declares a ceiling — `identity_summary` 1200, `speech_patterns` 20, `adaptive_traits` 5, `relationship` 64, immutable core constant. But `speaking_style` is `Dict[str, Any]`, which cannot bound its own values, and `evolve_persona` assigned reflection output straight in.

It is also the only prompt field **the agent rewrites by itself**. A reflection model returning a paragraph instead of a phrase permanently enlarges every subsequent turn, and the next reflection reads the enlarged prompt and can grow it again. Nothing pulls it back.

Now capped at 400 chars (`MAX_STYLE_DESCRIPTION`, declared in `profile.py` beside the other tier bounds):
- **Truncated, not rejected** — same asymmetry as `from_config()`: a running friend should degrade rather than fail to evolve.
- **Truncated at assignment**, so the stored column is bounded too. Clipping only on render would let the value grow forever while hiding that it had.

This is the honest answer to "measure the prompt cost": nobody could state it because one field had no ceiling. Saturated, the prompt is ~5900 chars, pinned at a 7000 budget — deliberately slack, since a tight budget fails on template rewording while an unbounded field overshoots by an order of magnitude.

## Verification

- **643 tests pass**, `ruff check .` clean.
- **5/5 mutations caught**, including two asymmetric ones (bound raised to uselessness; bound tightened until it trims ordinary text) so the tests pin a range rather than one side.

## Not done

- **4b — prompt latency against the 120s ceiling: dropped, not deferred**, per the standing decision not to run real-infrastructure benchmarks. No latency figure is claimed anywhere.
- F1 (`memory_store.py` decomposition) and the cross-language prosody wire change remain open.
- `TripleExtractor` is dead code, left in place rather than removed as an unrelated drive-by.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Capped persona style descriptions at 400 characters to prevent excessive prompt growth.
  * Preserved normal-length style descriptions without modification.
  * Limited vocabulary included in prompts to keep rendered prompt sizes within defined bounds.

* **Tests**
  * Added coverage validating prompt size limits and persona evolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->