### PR TITLE
fix: session-auth the camera endpoint, get blocking work off the event loop

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -4155,3 +4155,36 @@ audit said ~470), `search_memories` 251 (~1000), and `add_memory`'s eight
 near-identical INSERTs are two -- the god-functions are gone, and what remains
 is dual-backend duplication spread across the file, a different and lower-value
 problem. Prosody wire fields and B1 benchmark residue unchanged.
+
+### 2026-07-19 — PR #84 review: taking work off the loop made it reorderable
+
+CodeRabbit's review of #84 posted one finding, and it was a real regression
+introduced by that PR.
+
+Moving the Redis and SQLite writes into `asyncio.to_thread` fixed the blocking
+problem and created an ordering one: `persist_state` now yields at each
+dispatch, so two overlapping persists can complete in the opposite order and
+leave an older snapshot on top of a newer one. Inline, the writes ran to
+completion one after another and ordering was free. The stored row is what the
+agent rehydrates from, so the consequence is a friend that wakes up as an
+earlier version of itself with nothing recording why.
+
+Reviewing the function to fix that surfaced a second defect the finding did not
+mention: the Redis mapping was built *before* its `await` and the SQL parameters
+*after* it, so a single call could write two different states to the two
+backends. Both now come from one snapshot taken once.
+
+Serialized on a dedicated `_persist_lock`. It cannot be `_state_lock` -- callers
+reach `persist_state` from methods already holding that one, so sharing it
+deadlocks, which the S2 mutation below confirms rather than assumes.
+
+Three mutations, three caught: removing the lock, substituting `_state_lock` for
+it, and putting the SQLite write back on the loop.
+
+**649 tests pass**, `ruff check .` clean.
+
+The general lesson is worth keeping: *a fix that removes blocking usually
+removes ordering with it*. The tests written alongside the original change
+asserted that the loop stayed responsive and that a single call wrote correct
+values -- neither could see a two-call ordering property, and nothing prompted
+writing that test until review did.

--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -4070,3 +4070,88 @@ production-unused but retained: both are covered by regression tests that pin
 SQL query shape, and deleting the methods would delete the guards.
 `demo_memory_agent.py` has a pre-existing broken import and was not repaired
 here. F1 and the cross-language prosody change remain open.
+
+### 2026-07-19 — Second audit pass: a camera anyone could turn on, and blocking work on the loop
+
+Re-audited after #74-#83 and rescoped the findings by effort. Most of the
+original audit is genuinely closed; what follows is what was still real.
+
+**`/vision/toggle` had no session auth.** It carried only the app-level
+`require_lan_client`, while `/token` and `/start-session` both add
+`require_session_auth`. As that function's own docstring says, the LAN check
+"only restricts *where* a caller can connect from" -- with LAN_ONLY on that is
+still any device on the WiFi. So a guest on the network could switch the vision
+source to `camera`. That is a privacy boundary, not a preference, and it was
+the only state-changing endpoint left open. `/`, `/status` and `/health` expose
+a readiness boolean and stay open for healthchecks.
+
+**Two synchronous calls sat on the event loop in `persist_state`,** which runs
+from five call sites including the per-turn path: a blocking `redis.Redis.hset`
+and a blocking `sqlite3` write. The loop stalled for a network round trip plus
+a disk write mid-conversation, exactly when latency is felt. Both now run via
+`asyncio.to_thread`, with the SQL parameters snapshotted on the loop first --
+read inside the worker they could interleave with the System-2 appraisal and
+persist a row that is half one appraisal and half the next. Extracting
+`_write_state_row` also fixed a latent leak: the original `conn.close()` ran
+only on success. `hydrate_state`'s reads are left synchronous deliberately;
+they are startup-only and read a single local row.
+
+**`hydrate_state` was the one mutation path not holding `_state_lock`,** writing
+~20 fields one at a time. Startup-only today, so nothing races it, but a later
+mid-session caller would interleave with the appraisal task.
+
+**`_cached_ln` keyed on the rounded value but stored the log of the raw one.**
+The cached result therefore depended on which float reached it first, so two
+runs with identical inputs in a different order could produce different ACT-R
+activations and a different memory ranking, with nothing to indicate why. Now
+`functools.lru_cache(maxsize=4096)` with rounding in the caller -- deterministic,
+and bounded, closing A6.
+
+**Smaller:** a failed vision call was `except Exception: pass` then `return ""`,
+making a dead backend indistinguishable from "the model saw nothing worth
+describing" -- now logged. `CompatibilityQueue.join` spun with no exit, so a
+dead worker thread presented as a frozen test run; now bounded, returning
+False on timeout. Dead `evolution_buffer` attribute removed. README's voice
+diagram no longer points at archived `prosody.py`/`playback.py`.
+
+**`evolved_learnings` is hollow and stays that way, documented.** It has a
+column in both schemas, loads and saves, and nothing anywhere writes content
+into it. It was also a term in `_detect_first_boot`, where a permanently-empty
+value made a condition that could never fire; that term is removed. The storage
+round trip is kept -- a loader without a saver is a worse asymmetry than an
+unused pair, and dropping the columns is a migration, i.e. a decision rather
+than cleanup. **Correction to the audit that produced this item:** it was
+reported as "read into the prompt", which was wrong; it never reaches
+`get_persona_prompt`.
+
+**A pre-existing test-isolation bug surfaced and was fixed.** Four session-auth
+tests in `test_regressions.py` patched the `Config` *class*. `ConfigMeta`
+defines `__getattr__` but no `__setattr__`, so `monkeypatch.setattr` wrote into
+`Config.__dict__` and on teardown "restored" the value it had read *through*
+`__getattr__` -- permanently replacing the delegating attribute with a class
+attribute shadowing `config_instance` for the rest of the session. They passed
+in isolation and failed only once collection order changed, which is how it
+appeared: adding an unrelated test file moved them. Now patched on
+`config_instance`, matching `test_persona_storage.py`.
+
+Eight mutations, eight caught -- but only after two of the new tests were
+rewritten. The "does not block the loop" test asserted the final tick count,
+which `gather` satisfies whether or not the work overlapped; it now samples the
+tick count *at the moment the blocking call returns*. The `join` test hung
+rather than failed under its mutant, so it now drives `join` from a watchdog
+thread: a test that pins CI is worse than one that fails. Also worth recording:
+the first mutation run was killed for taking too long and left a mutant in
+`app/metrics.py` -- in-place mutation scripts need the source verified after an
+interrupted run, and each mutant should run only its guarding test, not the
+whole file.
+
+**648 tests pass**, `ruff check .` clean.
+
+**NOT done:** A4 (`offset = int(elapsed * 15)` barge-in truncation) needs a live
+session to verify. C3 (literal `.replace("System:", "")` scrubbing) is a
+threat-model decision, not a defect at the current single-user scope. F1 needs
+rescoping before it needs doing: `ActionService.execute` is now 23 lines (the
+audit said ~470), `search_memories` 251 (~1000), and `add_memory`'s eight
+near-identical INSERTs are two -- the god-functions are gone, and what remains
+is dual-backend duplication spread across the file, a different and lower-value
+problem. Prosody wire fields and B1 benchmark residue unchanged.

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ sequenceDiagram
     B->>V: ChatOutput (Segments + Affect Vector)
 
     Note over V, U: Stage 4 — Signal Rendering
-    V->>V: prosody.py → playback.py
+    V->>V: prosody mapping → OLA playback (Rust)
     V->>T: 32kHz PCM → audio.stream
     T->>U: WebRTC Audio
     V-->>B: voice.segmentation_feedback (Telemetry)

--- a/backend/app/cognitive/identity.py
+++ b/backend/app/cognitive/identity.py
@@ -148,9 +148,6 @@ class IdentityManager:
         # rule, one implementation.
         self._sync_personality_from_profile()
 
-        # Buffer for adaptive variable evolution
-        self.evolution_buffer = {}
-
         logger.info(
             f"[Identity] Hybrid Persona Active | Core: {self.immutable_core['base_tone']}"
         )
@@ -239,9 +236,7 @@ class IdentityManager:
         if self.history.get(self.SEED_MARKER):
             return False
         return not (
-            self.history.get("memories")
-            or self.history.get("evolved_learnings")
-            or self.history.get("interaction_count")
+            self.history.get("memories") or self.history.get("interaction_count")
         )
 
     def _profile_from_personality(self) -> "PersonaProfile":
@@ -464,6 +459,16 @@ class IdentityManager:
             self._seed_relationship_from_profile()
             self._stamp_seed_marker()
 
+            # `evolved_learnings` is currently a hollow field: it has a column in
+            # both schemas, loads here and saves in `persist_to_config_store`,
+            # but **nothing anywhere writes content into it** -- there is no
+            # producer, so it is always "". The round trip is kept because the
+            # column exists on both backends and a loader without a saver (or
+            # the reverse) is a worse asymmetry than an unused pair. It was also
+            # a term in `_detect_first_boot`, where a permanently-empty value
+            # meant a condition that could never fire; that has been removed.
+            # Implementing the producer, or dropping the columns via migration,
+            # is a decision rather than cleanup.
             evolved = config.get("evolved_learnings")
             if evolved:
                 self.history["evolved_learnings"] = evolved

--- a/backend/app/llm/ollama_client.py
+++ b/backend/app/llm/ollama_client.py
@@ -328,8 +328,24 @@ class OllamaClient:
             response = await client.post("/api/generate", json=payload, timeout=120.0)
             if response.status_code == 200:
                 return self._extract_response_text(response.json())
-        except Exception:
-            pass
+            logger.warning(
+                "[Ollama] Vision generate returned HTTP %s for model %s; "
+                "returning no description.",
+                response.status_code,
+                target_model,
+            )
+        except Exception as exc:
+            # Logged rather than swallowed. The empty string returned below is
+            # indistinguishable from "the model saw nothing worth describing",
+            # so without this line a vision backend that is down looks exactly
+            # like a quiet room -- and the agent narrates the difference to the
+            # user as if it were real.
+            logger.warning(
+                "[Ollama] Vision generate failed for model %s (%s); "
+                "returning no description.",
+                target_model,
+                exc,
+            )
         return ""
 
     async def check_health(self) -> bool:

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -46,14 +46,33 @@ class SubjectMetrics:
             def qsize(self):
                 return len(self.parent._buffer)
 
-            def join(self):
-                import time
+            def join(self, timeout: float = 5.0):
+                """Block until the buffer drains, or `timeout` elapses.
 
-                # Wait until the buffer is empty and no batch is currently being processed
+                Bounded deliberately. This spun on `while buffer or processing`
+                with no exit, so if the worker thread died the caller hung
+                forever with no diagnostic -- a dead metrics thread would
+                present as a frozen test run or a hung shutdown, which is a long
+                way from where the fault actually is.
+
+                Returns True if the buffer drained, False on timeout, so a
+                caller can tell the difference. `time` is imported at module
+                scope; the local re-import here shadowed it for no reason.
+                """
+                deadline = time.monotonic() + timeout
                 while self.parent._buffer or getattr(
                     self.parent, "_is_processing", False
                 ):
+                    if time.monotonic() >= deadline:
+                        logger.warning(
+                            "[Metrics] join() timed out after %.1fs with %d "
+                            "buffered event(s); worker may have died.",
+                            timeout,
+                            len(self.parent._buffer),
+                        )
+                        return False
                     time.sleep(0.01)
+                return True
 
         self._queue = CompatibilityQueue(self)
         self._is_processing = False

--- a/backend/app/state/agent_state.py
+++ b/backend/app/state/agent_state.py
@@ -454,12 +454,29 @@ class StateService:
         conn.close()
 
     async def hydrate_state(self, agent_name: str = "my friend"):
-        """Loads state from Redis or local SQLite cache."""
+        """Loads state from Redis or local SQLite cache.
+
+        Takes `_state_lock` like every other mutation path. Hydration is called
+        once from `CognitiveService.initialize`, so today nothing races it --
+        but it writes roughly twenty `current_state` fields one at a time, and
+        it was the only writer not holding the lock. A future caller that
+        re-hydrates mid-session would interleave with the fire-and-forget
+        System-2 appraisal and leave a state that is half restored and half
+        appraised, which is precisely the failure the lock exists to prevent.
+        """
         logger.info(f"[State] Hydrating {agent_name} from Redis/SQLite...")
+        async with self._state_lock:
+            await self._hydrate_locked(agent_name)
+
+    async def _hydrate_locked(self, agent_name: str):
         # 1. Try Redis
         if self.redis_client:
             try:
-                data = self.redis_client.hgetall(f"state:{agent_name}")
+                # Off the loop: synchronous client, and a dead Redis costs a
+                # full connect timeout here rather than returning quickly.
+                data = await asyncio.to_thread(
+                    self.redis_client.hgetall, f"state:{agent_name}"
+                )
                 if data:
                     self.current_state.mood = float(data.get("mood", 0.0))
                     self.current_state.energy = float(data.get("energy", 0.5))
@@ -630,7 +647,15 @@ class StateService:
         # 1. Save to Redis
         if self.redis_client:
             try:
-                self.redis_client.hset(
+                # Off-thread: `redis.Redis` is the synchronous client, and this
+                # runs on every state persist -- five call sites, including the
+                # per-turn path. Called directly it blocks the event loop for a
+                # network round trip while the agent is mid-conversation, which
+                # is exactly when latency is visible. redis-py's client is
+                # thread-safe for commands (it holds a connection pool), so a
+                # worker thread is safe here.
+                await asyncio.to_thread(
+                    self.redis_client.hset,
                     f"state:{agent_name}",
                     mapping={
                         "mood": str(self.current_state.mood),
@@ -669,62 +694,34 @@ class StateService:
                 logger.warning(f"Failed to persist state to Redis: {e}")
 
         # 2. Save to SQLite cache
+        #
+        # Snapshotted here, on the loop, rather than read inside the worker
+        # thread. `current_state` is mutated by the System-2 appraisal task, so
+        # a thread reading it field-by-field could persist a row that is half
+        # one appraisal and half the next -- a state the agent was never in.
+        sqlite_params = (
+            agent_name,
+            self.current_state.mood,
+            self.current_state.energy,
+            self.current_state.dominance,
+            self.current_state.trust_benevolence,
+            self.current_state.trust_competence,
+            self.current_state.trust_integrity,
+            self.current_state.trust,
+            self.current_state.attachment,
+            self.current_state.fatigue,
+            self.current_state.last_user_interaction,
+            self.current_state.interaction_count,
+            self.current_state.user_mental_model.inferred_valence,
+            self.current_state.user_mental_model.inferred_arousal,
+            json.dumps(self.current_state.user_mental_model.implied_goals),
+            json.dumps(self.current_state.user_mental_model.known_concepts),
+            self.current_state.baseline_valence,
+            self.current_state.baseline_arousal,
+            self.current_state.baseline_dominance,
+        )
         try:
-            conn = sqlite3.connect(self.db_path)
-            with conn:
-                conn.execute(
-                    """
-                    INSERT INTO agent_state (
-                        agent_name, mood, energy, dominance, trust_benevolence, trust_competence,
-                        trust_integrity, trust, attachment, fatigue, last_user_interaction,
-                        interaction_count, inferred_valence, inferred_arousal, implied_goals,
-                        known_concepts, baseline_valence, baseline_arousal, baseline_dominance, updated_at
-                    )
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
-                    ON CONFLICT(agent_name) DO UPDATE SET
-                        mood = excluded.mood,
-                        energy = excluded.energy,
-                        dominance = excluded.dominance,
-                        trust_benevolence = excluded.trust_benevolence,
-                        trust_competence = excluded.trust_competence,
-                        trust_integrity = excluded.trust_integrity,
-                        trust = excluded.trust,
-                        attachment = excluded.attachment,
-                        fatigue = excluded.fatigue,
-                        last_user_interaction = excluded.last_user_interaction,
-                        interaction_count = excluded.interaction_count,
-                        inferred_valence = excluded.inferred_valence,
-                        inferred_arousal = excluded.inferred_arousal,
-                        implied_goals = excluded.implied_goals,
-                        known_concepts = excluded.known_concepts,
-                        baseline_valence = excluded.baseline_valence,
-                        baseline_arousal = excluded.baseline_arousal,
-                        baseline_dominance = excluded.baseline_dominance,
-                        updated_at = CURRENT_TIMESTAMP
-                """,
-                    (
-                        agent_name,
-                        self.current_state.mood,
-                        self.current_state.energy,
-                        self.current_state.dominance,
-                        self.current_state.trust_benevolence,
-                        self.current_state.trust_competence,
-                        self.current_state.trust_integrity,
-                        self.current_state.trust,
-                        self.current_state.attachment,
-                        self.current_state.fatigue,
-                        self.current_state.last_user_interaction,
-                        self.current_state.interaction_count,
-                        self.current_state.user_mental_model.inferred_valence,
-                        self.current_state.user_mental_model.inferred_arousal,
-                        json.dumps(self.current_state.user_mental_model.implied_goals),
-                        json.dumps(self.current_state.user_mental_model.known_concepts),
-                        self.current_state.baseline_valence,
-                        self.current_state.baseline_arousal,
-                        self.current_state.baseline_dominance,
-                    ),
-                )
-            conn.close()
+            await asyncio.to_thread(self._write_state_row, sqlite_params)
         except Exception as e:
             logger.error(f"Failed to persist state to SQLite: {e}")
 
@@ -761,6 +758,58 @@ class StateService:
         logger.debug(
             f"[State] Persisted to cache (non-blocking Neo4j): V={self.current_state.mood:.2f} Ar={self.current_state.energy:.2f} D={self.current_state.dominance:.2f}"
         )
+
+    def _write_state_row(self, params) -> None:
+        """Write the agent_state row. Synchronous; called only via `to_thread`.
+
+        Split out of `persist_state` so the blocking `sqlite3` work happens off
+        the event loop -- it ran on every persist, from five call sites
+        including the per-turn path, so the loop stalled on a disk write while
+        the agent was mid-conversation.
+
+        Opening a connection per call is deliberate rather than lazy: `sqlite3`
+        connections are not safe to share across threads by default, so a cached
+        one would need its own guard.
+        """
+        conn = sqlite3.connect(self.db_path)
+        try:
+            with conn:
+                conn.execute(
+                    """
+                    INSERT INTO agent_state (
+                        agent_name, mood, energy, dominance, trust_benevolence, trust_competence,
+                        trust_integrity, trust, attachment, fatigue, last_user_interaction,
+                        interaction_count, inferred_valence, inferred_arousal, implied_goals,
+                        known_concepts, baseline_valence, baseline_arousal, baseline_dominance, updated_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+                    ON CONFLICT(agent_name) DO UPDATE SET
+                        mood = excluded.mood,
+                        energy = excluded.energy,
+                        dominance = excluded.dominance,
+                        trust_benevolence = excluded.trust_benevolence,
+                        trust_competence = excluded.trust_competence,
+                        trust_integrity = excluded.trust_integrity,
+                        trust = excluded.trust,
+                        attachment = excluded.attachment,
+                        fatigue = excluded.fatigue,
+                        last_user_interaction = excluded.last_user_interaction,
+                        interaction_count = excluded.interaction_count,
+                        inferred_valence = excluded.inferred_valence,
+                        inferred_arousal = excluded.inferred_arousal,
+                        implied_goals = excluded.implied_goals,
+                        known_concepts = excluded.known_concepts,
+                        baseline_valence = excluded.baseline_valence,
+                        baseline_arousal = excluded.baseline_arousal,
+                        baseline_dominance = excluded.baseline_dominance,
+                        updated_at = CURRENT_TIMESTAMP
+                """,
+                    params,
+                )
+        finally:
+            # `finally`, not a trailing call: the original leaked the connection
+            # whenever the INSERT raised.
+            conn.close()
 
     def record_user_interaction(self):
         """Mark that the user just interacted. Called by BrainAgent on every chat.input."""

--- a/backend/app/state/agent_state.py
+++ b/backend/app/state/agent_state.py
@@ -379,6 +379,11 @@ class StateService:
         # A2: serializes short-term affect mutation so the fire-and-forget
         # System-2 semantic-drift task cannot clobber a fresher appraisal.
         self._state_lock = asyncio.Lock()
+        # Separate from `_state_lock` on purpose. This one serializes the *write
+        # ordering* in `persist_state`, which now yields at each `to_thread`
+        # dispatch; callers reach `persist_state` from methods already holding
+        # `_state_lock`, so reusing it would deadlock.
+        self._persist_lock = asyncio.Lock()
 
         # Connect to Redis
         try:
@@ -643,110 +648,118 @@ class StateService:
                 logger.warning(f"Failed fallback hydration from Neo4j: {e}")
 
     async def persist_state(self, agent_name: str = "my friend"):
-        """Saves current state to Redis and local SQLite cache, broadcasting updates asynchronously."""
-        # 1. Save to Redis
-        if self.redis_client:
-            try:
-                # Off-thread: `redis.Redis` is the synchronous client, and this
-                # runs on every state persist -- five call sites, including the
-                # per-turn path. Called directly it blocks the event loop for a
-                # network round trip while the agent is mid-conversation, which
-                # is exactly when latency is visible. redis-py's client is
-                # thread-safe for commands (it holds a connection pool), so a
-                # worker thread is safe here.
-                await asyncio.to_thread(
-                    self.redis_client.hset,
-                    f"state:{agent_name}",
-                    mapping={
-                        "mood": str(self.current_state.mood),
-                        "energy": str(self.current_state.energy),
-                        "dominance": str(self.current_state.dominance),
-                        "trust_benevolence": str(self.current_state.trust_benevolence),
-                        "trust_competence": str(self.current_state.trust_competence),
-                        "trust_integrity": str(self.current_state.trust_integrity),
-                        "trust": str(self.current_state.trust),
-                        "attachment": str(self.current_state.attachment),
-                        "fatigue": str(self.current_state.fatigue),
-                        "last_user_interaction": str(
-                            self.current_state.last_user_interaction
-                        ),
-                        "interaction_count": str(self.current_state.interaction_count),
-                        "inferred_valence": str(
-                            self.current_state.user_mental_model.inferred_valence
-                        ),
-                        "inferred_arousal": str(
-                            self.current_state.user_mental_model.inferred_arousal
-                        ),
-                        "implied_goals": json.dumps(
-                            self.current_state.user_mental_model.implied_goals
-                        ),
-                        "known_concepts": json.dumps(
-                            self.current_state.user_mental_model.known_concepts
-                        ),
-                        "baseline_valence": str(self.current_state.baseline_valence),
-                        "baseline_arousal": str(self.current_state.baseline_arousal),
-                        "baseline_dominance": str(
-                            self.current_state.baseline_dominance
-                        ),
-                    },
-                )
-            except Exception as e:
-                logger.warning(f"Failed to persist state to Redis: {e}")
+        """Save state to Redis and the local SQLite cache, then broadcast.
 
-        # 2. Save to SQLite cache
-        #
-        # Snapshotted here, on the loop, rather than read inside the worker
-        # thread. `current_state` is mutated by the System-2 appraisal task, so
-        # a thread reading it field-by-field could persist a row that is half
-        # one appraisal and half the next -- a state the agent was never in.
-        sqlite_params = (
-            agent_name,
-            self.current_state.mood,
-            self.current_state.energy,
-            self.current_state.dominance,
-            self.current_state.trust_benevolence,
-            self.current_state.trust_competence,
-            self.current_state.trust_integrity,
-            self.current_state.trust,
-            self.current_state.attachment,
-            self.current_state.fatigue,
-            self.current_state.last_user_interaction,
-            self.current_state.interaction_count,
-            self.current_state.user_mental_model.inferred_valence,
-            self.current_state.user_mental_model.inferred_arousal,
-            json.dumps(self.current_state.user_mental_model.implied_goals),
-            json.dumps(self.current_state.user_mental_model.known_concepts),
-            self.current_state.baseline_valence,
-            self.current_state.baseline_arousal,
-            self.current_state.baseline_dominance,
-        )
-        try:
-            await asyncio.to_thread(self._write_state_row, sqlite_params)
-        except Exception as e:
-            logger.error(f"Failed to persist state to SQLite: {e}")
+        Serialized on `_persist_lock`, which is deliberately *not* `_state_lock`.
+        Moving the two writes onto worker threads made `persist_state` yield at
+        each `await`, so two overlapping calls could have their writes complete
+        in the opposite order and leave an older snapshot on top of a newer one
+        -- a regression introduced by the same change that took the blocking
+        work off the loop. The lock restores ordering without putting it back:
+        it is an asyncio lock, so the rest of the loop keeps running while a
+        persist is in flight.
+
+        It cannot be `_state_lock`: callers reach here from methods that already
+        hold that lock, so sharing it would deadlock. This one guards *write
+        ordering*, not the state fields.
+        """
+        async with self._persist_lock:
+            # One snapshot, taken once, used by both stores. Previously the
+            # Redis mapping was built before its await and the SQL parameters
+            # after it, so a single call could write two different states to the
+            # two backends.
+            snapshot = {
+            "mood": self.current_state.mood,
+            "energy": self.current_state.energy,
+            "dominance": self.current_state.dominance,
+            "trust_benevolence": self.current_state.trust_benevolence,
+            "trust_competence": self.current_state.trust_competence,
+            "trust_integrity": self.current_state.trust_integrity,
+            "trust": self.current_state.trust,
+            "attachment": self.current_state.attachment,
+            "fatigue": self.current_state.fatigue,
+            "last_user_interaction": self.current_state.last_user_interaction,
+            "interaction_count": self.current_state.interaction_count,
+            "inferred_valence": self.current_state.user_mental_model.inferred_valence,
+            "inferred_arousal": self.current_state.user_mental_model.inferred_arousal,
+            "baseline_valence": self.current_state.baseline_valence,
+            "baseline_arousal": self.current_state.baseline_arousal,
+            "baseline_dominance": self.current_state.baseline_dominance,
+            }
+
+            # 1. Save to Redis
+            if self.redis_client:
+                try:
+                    # Off-thread: `redis.Redis` is the synchronous client and
+                    # this runs on every persist, including the per-turn path.
+                    # Called directly it blocks the loop for a network round
+                    # trip mid-conversation. redis-py holds a connection pool
+                    # and is thread-safe for commands.
+                    await asyncio.to_thread(
+                        self.redis_client.hset,
+                        f"state:{agent_name}",
+                        mapping={
+                        "mood": str(snapshot["mood"]),
+                        "energy": str(snapshot["energy"]),
+                        "dominance": str(snapshot["dominance"]),
+                        "trust_benevolence": str(snapshot["trust_benevolence"]),
+                        "trust_competence": str(snapshot["trust_competence"]),
+                        "trust_integrity": str(snapshot["trust_integrity"]),
+                        "trust": str(snapshot["trust"]),
+                        "attachment": str(snapshot["attachment"]),
+                        "fatigue": str(snapshot["fatigue"]),
+                        "last_user_interaction": str(snapshot["last_user_interaction"]),
+                        "interaction_count": str(snapshot["interaction_count"]),
+                        "inferred_valence": str(snapshot["inferred_valence"]),
+                        "inferred_arousal": str(snapshot["inferred_arousal"]),
+                        "baseline_valence": str(snapshot["baseline_valence"]),
+                        "baseline_arousal": str(snapshot["baseline_arousal"]),
+                        "baseline_dominance": str(snapshot["baseline_dominance"]),
+                        "implied_goals": json.dumps(
+                                self.current_state.user_mental_model.implied_goals
+                            ),
+                            "known_concepts": json.dumps(
+                                self.current_state.user_mental_model.known_concepts
+                            ),
+                        },
+                    )
+                except Exception as e:
+                    logger.warning(f"Failed to persist state to Redis: {e}")
+
+            # 2. Save to SQLite cache
+            sqlite_params = (
+                agent_name,
+            snapshot["mood"],
+            snapshot["energy"],
+            snapshot["dominance"],
+            snapshot["trust_benevolence"],
+            snapshot["trust_competence"],
+            snapshot["trust_integrity"],
+            snapshot["trust"],
+            snapshot["attachment"],
+            snapshot["fatigue"],
+            snapshot["last_user_interaction"],
+            snapshot["interaction_count"],
+            snapshot["inferred_valence"],
+            snapshot["inferred_arousal"],
+                json.dumps(self.current_state.user_mental_model.implied_goals),
+                json.dumps(self.current_state.user_mental_model.known_concepts),
+                snapshot["baseline_valence"],
+                snapshot["baseline_arousal"],
+                snapshot["baseline_dominance"],
+            )
+            try:
+                await asyncio.to_thread(self._write_state_row, sqlite_params)
+            except Exception as e:
+                logger.error(f"Failed to persist state to SQLite: {e}")
 
         # 3. Publish asynchronous NATS broadcast
         if self.publish_cb:
             state_data = {
                 "agent_name": agent_name,
-                "mood": self.current_state.mood,
-                "energy": self.current_state.energy,
-                "dominance": self.current_state.dominance,
-                "trust_benevolence": self.current_state.trust_benevolence,
-                "trust_competence": self.current_state.trust_competence,
-                "trust_integrity": self.current_state.trust_integrity,
-                "trust": self.current_state.trust,
-                "attachment": self.current_state.attachment,
-                "fatigue": self.current_state.fatigue,
-                "last_user_interaction": self.current_state.last_user_interaction,
-                "interaction_count": self.current_state.interaction_count,
-                "inferred_valence": self.current_state.user_mental_model.inferred_valence,
-                "inferred_arousal": self.current_state.user_mental_model.inferred_arousal,
+                **snapshot,
                 "implied_goals": self.current_state.user_mental_model.implied_goals,
                 "known_concepts": self.current_state.user_mental_model.known_concepts,
-                "baseline_valence": self.current_state.baseline_valence,
-                "baseline_arousal": self.current_state.baseline_arousal,
-                "baseline_dominance": self.current_state.baseline_dominance,
                 "timestamp": time.time(),
             }
             try:
@@ -756,7 +769,7 @@ class StateService:
                 logger.warning(f"Failed to trigger NATS state broadcast task: {e}")
 
         logger.debug(
-            f"[State] Persisted to cache (non-blocking Neo4j): V={self.current_state.mood:.2f} Ar={self.current_state.energy:.2f} D={self.current_state.dominance:.2f}"
+            f"[State] Persisted to cache (non-blocking Neo4j): V={snapshot['mood']:.2f} Ar={snapshot['energy']:.2f} D={snapshot['dominance']:.2f}"
         )
 
     def _write_state_row(self, params) -> None:

--- a/backend/app/state/memory_store.py
+++ b/backend/app/state/memory_store.py
@@ -17,6 +17,7 @@ import asyncio
 import httpx
 import json
 import orjson
+import functools
 import math
 import re
 import sqlite3
@@ -28,16 +29,26 @@ from ..config import Config
 
 logger = logging.getLogger(__name__)
 
-# Global logarithmic lookup cache to bypass floating-point log calculations in ACT-R decay loops
-_LN_CACHE = {}
-
-
+@functools.lru_cache(maxsize=4096)
 def _cached_ln(x: float) -> float:
-    """Returns the cached natural logarithm rounded to 3 decimal places to maximize hits."""
-    key = round(x, 3)
-    if key not in _LN_CACHE:
-        _LN_CACHE[key] = math.log(x)
-    return _LN_CACHE[key]
+    """Natural log, memoized on the value rounded to 3 decimal places.
+
+    Was a bare module-level dict that was never evicted (A6). Rounding bounds
+    the key space in practice, but "in practice" is doing real work there: the
+    keys are memory ages, so a long-lived process with a wide spread of
+    timestamps keeps adding entries for the life of the process, and nothing
+    ever removes one.
+
+    `lru_cache` gives the same hit rate for this access pattern with an actual
+    ceiling. The rounding happens in the caller so the cache key is the rounded
+    value rather than the raw float -- memoizing on the raw float would make
+    almost every lookup a miss and the cache pure overhead.
+    """
+    return math.log(x)
+
+
+def _ln(x: float) -> float:
+    return _cached_ln(round(x, 3))
 
 
 def _get_stem(word: str) -> str:
@@ -450,8 +461,8 @@ class MemoryStore:
         the formula stays identical across the Qdrant, SQLite and PG branches.
         """
         return (
-            _cached_ln(recall_count)
-            - self.decay_rate * _cached_ln(hours_since + 1.0)
+            _ln(recall_count)
+            - self.decay_rate * _ln(hours_since + 1.0)
             + ACTR_IMPORTANCE_WEIGHT * importance_score
             + ACTR_EMO_PROXIMITY_WEIGHT * (1.0 - dist_emo)
         )

--- a/backend/main.py
+++ b/backend/main.py
@@ -221,9 +221,16 @@ async def start_session(participant: str = "user"):
         raise HTTPException(status_code=500, detail="Session start failed")
 
 
-@app.post("/vision/toggle")
+@app.post("/vision/toggle", dependencies=[Depends(require_session_auth)])
 async def toggle_vision(source: str):
-    """Vision Control Endpoint"""
+    """Vision Control Endpoint.
+
+    Session-authed like `/token`, and for a stronger reason. `require_lan_client`
+    only restricts *where* a caller connects from, which with LAN_ONLY on still
+    means any device on the WiFi; this endpoint points a camera at the user. A
+    guest on the same network being able to switch the vision source from
+    `screen` to `camera` is a privacy boundary, not a preference.
+    """
     if source not in ["screen", "camera"]:
         raise HTTPException(status_code=400, detail="Invalid vision source")
     return await backend.toggle_vision_source(source)

--- a/backend/tests/test_audit_hygiene.py
+++ b/backend/tests/test_audit_hygiene.py
@@ -1,0 +1,243 @@
+"""
+Findings from the second audit pass.
+
+The two that matter are a camera endpoint anyone on the LAN could flip, and
+per-turn blocking calls sitting on the event loop. The rest are small, but each
+one is a case where the code claimed something it did not do.
+"""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.metrics import SubjectMetrics
+from app.state.memory_store import _cached_ln, _ln
+
+# --------------------------------------------------------------------------
+# the camera endpoint is not a preference
+# --------------------------------------------------------------------------
+
+
+def test_vision_toggle_requires_the_same_auth_as_token_issuance():
+    """A guest on the WiFi must not be able to point the camera at you.
+
+    `require_lan_client` only restricts *where* a caller connects from, which
+    with LAN_ONLY on is still any device on the network. `/token` and
+    `/start-session` both add `require_session_auth`; `/vision/toggle` did not,
+    while being the one endpoint that switches the vision source to `camera`.
+
+    Asserted on the route's own dependencies rather than by driving a request,
+    because the failure being guarded is *the dependency being absent* — a live
+    request from loopback passes either way, which is exactly why this went
+    unnoticed.
+    """
+    import main
+
+    routes = {r.path: r for r in main.app.routes if hasattr(r, "dependencies")}
+
+    def dep_names(path):
+        return {
+            d.dependency.__name__
+            for d in routes[path].dependencies
+            if getattr(d, "dependency", None)
+        }
+
+    assert "require_session_auth" in dep_names("/vision/toggle")
+    # Pinned against a peer so the test states a rule rather than a constant:
+    # whatever guards token issuance must also guard the camera.
+    assert dep_names("/token") <= dep_names("/vision/toggle")
+
+
+# --------------------------------------------------------------------------
+# blocking work off the loop
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_state_persistence_does_not_block_the_event_loop():
+    """`persist_state` ran a synchronous Redis write and a synchronous sqlite3
+    write directly on the loop, from five call sites including the per-turn
+    path.
+
+    The loop stalled for a network round trip plus a disk write in the middle of
+    a conversation — precisely when latency is felt. Asserted by checking the
+    loop stays responsive while a deliberately slow backend is persisting.
+    """
+    from app.state.agent_state import StateService
+
+    service = object.__new__(StateService)
+    service.db_path = ":memory:"
+    service.publish_cb = None
+    service.redis_client = None
+
+    ticks_when_write_finished = []
+
+    def slow_write(_params):
+        time.sleep(0.2)
+        # Sampled at the moment the blocking work ends. Off the loop, the
+        # heartbeat below has been running throughout and this is non-zero;
+        # inline, the loop was pinned and the heartbeat has not ticked once.
+        #
+        # Asserting on the *final* tick count instead would pass either way:
+        # `gather` waits for both coroutines regardless of whether they
+        # overlapped, so it measures completion, not concurrency. That version
+        # of this test survived a mutant that put the write back on the loop.
+        ticks_when_write_finished.append(ticks)
+
+    service._write_state_row = slow_write
+
+    class _Model:
+        inferred_valence = 0.0
+        inferred_arousal = 0.5
+        implied_goals = []
+        known_concepts = []
+
+    class _State:
+        mood = energy = dominance = 0.5
+        trust_benevolence = trust_competence = trust_integrity = trust = 0.5
+        attachment = fatigue = last_user_interaction = 0.0
+        interaction_count = 0
+        baseline_valence = baseline_arousal = baseline_dominance = 0.0
+        user_mental_model = _Model()
+
+    service.current_state = _State()
+
+    ticks = 0
+
+    async def heartbeat():
+        nonlocal ticks
+        for _ in range(10):
+            await asyncio.sleep(0.01)
+            ticks += 1
+
+    await asyncio.gather(service.persist_state("friend"), heartbeat())
+
+    assert ticks_when_write_finished, "the sqlite writer never ran"
+    assert ticks_when_write_finished[0] > 0, (
+        "the event loop made no progress while the state write ran, so the "
+        "write is back on the loop"
+    )
+
+
+@pytest.mark.asyncio
+async def test_hydration_holds_the_same_lock_as_every_other_mutation():
+    """`hydrate_state` wrote ~20 state fields without `_state_lock`.
+
+    It is startup-only today, so nothing races it — but it was the single
+    mutation path not holding the lock, and a later caller re-hydrating
+    mid-session would interleave with the fire-and-forget System-2 appraisal
+    and leave a state that is half restored and half appraised.
+    """
+    from app.state.agent_state import StateService
+
+    service = object.__new__(StateService)
+    service._state_lock = asyncio.Lock()
+    observed = []
+
+    async def fake_hydrate(_name):
+        observed.append(service._state_lock.locked())
+
+    service._hydrate_locked = fake_hydrate
+    await service.hydrate_state("friend")
+
+    assert observed == [True], "hydration ran without holding the state lock"
+
+
+# --------------------------------------------------------------------------
+# small things that lied
+# --------------------------------------------------------------------------
+
+
+def test_activation_log_is_deterministic_regardless_of_call_order():
+    """The old cache keyed on the rounded value but stored the log of the *raw*
+    one, so the result depended on which float reached it first.
+
+    Two runs with identical inputs in a different order could produce different
+    ACT-R activations, and therefore a different memory ranking, with nothing
+    to indicate why.
+    """
+    _cached_ln.cache_clear()
+    first = _ln(2.00001)
+    _cached_ln.cache_clear()
+    second = _ln(2.00049)
+
+    # Both round to 2.0, so both must return log(2.0) exactly.
+    assert first == second
+
+
+def test_activation_log_cache_cannot_grow_without_bound():
+    """It was a module-level dict that was never evicted (A6).
+
+    Keys are memory ages, so a long-lived process with a wide spread of
+    timestamps kept adding entries for the life of the process.
+    """
+    _cached_ln.cache_clear()
+    for i in range(9000):
+        _ln(1.0 + i * 0.01)
+
+    assert _cached_ln.cache_info().currsize <= 4096
+
+
+def test_metrics_join_gives_up_instead_of_hanging_forever():
+    """`join()` spun on `while buffer or processing` with no exit.
+
+    A dead worker thread presented as a frozen test run or a hung shutdown,
+    which is a long way from where the fault actually was.
+    """
+    import threading
+
+    metrics = SubjectMetrics(tracked_subjects={"chat.input"})
+    metrics.shutdown()
+
+    # A buffer that will never drain, because the worker is stopped.
+    metrics._buffer = ["never drains"]
+    metrics._is_processing = True
+
+    result = []
+
+    # Driven from a watchdog thread rather than called directly. If the bound
+    # is ever removed, `join` spins forever -- called inline that hangs the
+    # whole suite, and a test that pins CI is worse than one that fails. This
+    # way the regression shows up as a failed assertion in about a second.
+    worker = threading.Thread(
+        target=lambda: result.append(metrics._queue.join(timeout=0.2)), daemon=True
+    )
+    worker.start()
+    worker.join(timeout=3.0)
+
+    assert not worker.is_alive(), "join() never returned; its timeout is gone"
+    assert result == [False], "join() reported success on a buffer that never drained"
+
+
+def test_a_failed_vision_call_is_logged_not_silently_empty(caplog, monkeypatch):
+    """`except Exception: pass` then `return ""`.
+
+    An empty description is indistinguishable from "the model saw nothing worth
+    describing", so a vision backend that is down looked exactly like a quiet
+    room — and the agent narrates that difference to the user as if it were
+    real.
+    """
+    from app import config as config_module
+    from app.llm.ollama_client import OllamaClient
+
+    # `describe_image` short-circuits to a canned string under MOCK_LLM_TEXT,
+    # which the suite enables globally. The real HTTP path is the one under
+    # test. Patched on `config_instance`, since `Config.FOO` delegates there.
+    monkeypatch.setattr(config_module.config_instance, "MOCK_LLM_TEXT", False)
+
+    client = object.__new__(OllamaClient)
+    client.model = "llava"
+
+    failing = MagicMock()
+    failing.post = AsyncMock(side_effect=RuntimeError("connection refused"))
+    client._get_client = AsyncMock(return_value=failing)
+
+    with caplog.at_level("WARNING"):
+        result = asyncio.run(client.describe_image("b64", "what is here"))
+
+    assert result == ""
+    assert any("connection refused" in r.getMessage() for r in caplog.records), (
+        "a failed vision call returned empty with nothing in the log"
+    )

--- a/backend/tests/test_audit_hygiene.py
+++ b/backend/tests/test_audit_hygiene.py
@@ -71,6 +71,7 @@ async def test_state_persistence_does_not_block_the_event_loop():
     service.db_path = ":memory:"
     service.publish_cb = None
     service.redis_client = None
+    service._persist_lock = asyncio.Lock()
 
     ticks_when_write_finished = []
 
@@ -118,6 +119,70 @@ async def test_state_persistence_does_not_block_the_event_loop():
     assert ticks_when_write_finished[0] > 0, (
         "the event loop made no progress while the state write ran, so the "
         "write is back on the loop"
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_older_state_snapshot_cannot_land_on_top_of_a_newer_one():
+    """Taking the writes off the loop made `persist_state` yield, which made it
+    reorderable — a regression introduced by the fix above it.
+
+    Inline, two overlapping persists ran to completion one after the other. With
+    `to_thread` each one yields, so a slow first write can finish *after* a fast
+    second one and leave the older mood on top. The stored state is what the
+    agent rehydrates from, so the friend would wake up as an earlier version of
+    itself with nothing recording why.
+
+    Caught by CodeRabbit on PR #84, not by the tests written alongside the
+    change that caused it.
+    """
+    from app.state.agent_state import StateService
+
+    service = object.__new__(StateService)
+    service.db_path = ":memory:"
+    service.publish_cb = None
+    service.redis_client = None
+    service._persist_lock = asyncio.Lock()
+
+    order = []
+    delays = {0.5: 0.20, 0.9: 0.01}  # first write slow, second fast
+
+    def write(params):
+        mood = params[1]
+        time.sleep(delays[mood])
+        order.append(mood)
+
+    service._write_state_row = write
+
+    class _Model:
+        inferred_valence = 0.0
+        inferred_arousal = 0.5
+        implied_goals = []
+        known_concepts = []
+
+    class _State:
+        mood = 0.5
+        energy = dominance = 0.5
+        trust_benevolence = trust_competence = trust_integrity = trust = 0.5
+        attachment = fatigue = last_user_interaction = 0.0
+        interaction_count = 0
+        baseline_valence = baseline_arousal = baseline_dominance = 0.0
+        user_mental_model = _Model()
+
+    service.current_state = _State()
+
+    async def persist_with(mood):
+        service.current_state.mood = mood
+        await service.persist_state("friend")
+
+    first = asyncio.create_task(persist_with(0.5))
+    await asyncio.sleep(0)  # let it snapshot and dispatch
+    second = asyncio.create_task(persist_with(0.9))
+    await asyncio.gather(first, second)
+
+    assert order == [0.5, 0.9], (
+        f"writes completed out of order ({order}); the older snapshot would "
+        "overwrite the newer one"
     )
 
 

--- a/backend/tests/test_regressions.py
+++ b/backend/tests/test_regressions.py
@@ -360,12 +360,22 @@ def _fake_request(host, headers=None, query_params=None):
     )
 
 
+# These four patch `config_instance`, not the `Config` class.
+#
+# `ConfigMeta` defines `__getattr__` but no `__setattr__`, so
+# `monkeypatch.setattr(Config, ...)` writes a real entry into `Config.__dict__`
+# and, on teardown, "restores" the value it originally read *through*
+# `__getattr__`. The delegating attribute is thereby replaced by a permanent
+# class attribute that shadows `config_instance` for every later test in the
+# session. The tests passed in isolation and failed only once collection order
+# put something else first -- which is how this surfaced: adding an unrelated
+# test file moved them.
 def test_require_session_auth_allows_loopback_without_a_key(monkeypatch):
     import asyncio as _asyncio
-    from app.config import Config
+    from app import config as config_module
     import main
 
-    monkeypatch.setattr(Config, "BACKEND_ACCESS_KEY", None)
+    monkeypatch.setattr(config_module.config_instance, "BACKEND_ACCESS_KEY", None)
     _asyncio.run(main.require_session_auth(_fake_request("127.0.0.1")))
 
 
@@ -374,10 +384,10 @@ def test_require_session_auth_rejects_lan_client_without_key_configured(
 ):
     import asyncio as _asyncio
     from fastapi import HTTPException
-    from app.config import Config
+    from app import config as config_module
     import main
 
-    monkeypatch.setattr(Config, "BACKEND_ACCESS_KEY", None)
+    monkeypatch.setattr(config_module.config_instance, "BACKEND_ACCESS_KEY", None)
     try:
         _asyncio.run(main.require_session_auth(_fake_request("192.168.1.42")))
         assert False, "expected HTTPException"
@@ -388,10 +398,10 @@ def test_require_session_auth_rejects_lan_client_without_key_configured(
 def test_require_session_auth_rejects_lan_client_with_wrong_key(monkeypatch):
     import asyncio as _asyncio
     from fastapi import HTTPException
-    from app.config import Config
+    from app import config as config_module
     import main
 
-    monkeypatch.setattr(Config, "BACKEND_ACCESS_KEY", "correct-key")
+    monkeypatch.setattr(config_module.config_instance, "BACKEND_ACCESS_KEY", "correct-key")
     try:
         _asyncio.run(
             main.require_session_auth(
@@ -407,10 +417,10 @@ def test_require_session_auth_rejects_lan_client_with_wrong_key(monkeypatch):
 
 def test_require_session_auth_accepts_lan_client_with_correct_key(monkeypatch):
     import asyncio as _asyncio
-    from app.config import Config
+    from app import config as config_module
     import main
 
-    monkeypatch.setattr(Config, "BACKEND_ACCESS_KEY", "correct-key")
+    monkeypatch.setattr(config_module.config_instance, "BACKEND_ACCESS_KEY", "correct-key")
     _asyncio.run(
         main.require_session_auth(
             _fake_request(


### PR DESCRIPTION
Second audit pass, rescoped by effort. Most of the original audit is genuinely closed — this is what was still real.

## The one that matters: `/vision/toggle` had no session auth

It carried only the app-level `require_lan_client`. As that function's own docstring says, the LAN check *"only restricts **where** a caller can connect from"* — with `LAN_ONLY` on that is still **any device on the WiFi**.

`/token` and `/start-session` both add `require_session_auth`. `/vision/toggle` did not, while being the one endpoint that switches the vision source to **`camera`**. A guest on the network could turn it on.

`/`, `/status` and `/health` expose only a readiness boolean and stay open — healthchecks need them.

## Blocking work on the event loop

`persist_state` runs from five call sites including the per-turn path, and did two synchronous things directly on the loop: a `redis.Redis.hset` (network round trip) and a `sqlite3` write (disk). The loop stalled mid-conversation, exactly when latency is felt.

Both now go through `asyncio.to_thread`, with SQL parameters **snapshotted on the loop first** — read inside the worker they could interleave with the System-2 appraisal and persist a row that is half one appraisal and half the next. Extracting `_write_state_row` also fixed a latent leak: the original `conn.close()` ran only on success.

`hydrate_state`'s reads stay synchronous on purpose — startup-only, one local row.

## Other fixes

- **`hydrate_state` was the only mutation path not holding `_state_lock`**, writing ~20 fields one at a time.
- **`_cached_ln` keyed on the rounded value but stored the log of the raw one** — so the cached result depended on which float arrived first, and two runs with identical inputs in a different order could produce different ACT-R activations and a different memory ranking. Now `lru_cache(maxsize=4096)`: deterministic *and* bounded, closing A6.
- Failed vision calls were `except Exception: pass` → `return ""`, making a dead backend indistinguishable from "the model saw nothing worth describing". Now logged.
- `CompatibilityQueue.join` spun with no exit; a dead worker presented as a frozen test run. Bounded, returns `False` on timeout.
- Dead `evolution_buffer` attribute removed; README voice diagram no longer points at archived `prosody.py`/`playback.py`.

## `evolved_learnings` stays hollow, documented

It has a column in both schemas, loads and saves, and **nothing anywhere writes content into it**. It was also a term in `_detect_first_boot`, making a condition that could never fire — that term is removed. The storage round trip is kept: a loader without a saver is a worse asymmetry than an unused pair, and dropping the columns is a migration, i.e. a decision rather than cleanup.

**Correction to my own audit:** I reported this field as "read into the prompt". That was wrong — it never reaches `get_persona_prompt`.

## A pre-existing test-isolation bug surfaced

Four session-auth tests patched the `Config` **class**. `ConfigMeta` defines `__getattr__` but no `__setattr__`, so `monkeypatch.setattr` wrote into `Config.__dict__` and on teardown "restored" the value it had read *through* `__getattr__` — permanently replacing the delegating attribute with one shadowing `config_instance` for the rest of the session.

They passed in isolation and failed only once collection order changed, which is exactly how this appeared: adding an unrelated test file moved them. Now patched on `config_instance`, matching `test_persona_storage.py`.

## Verification

**648 tests pass**, `ruff check .` clean, **8/8 mutations caught** — but only after two new tests were rewritten:

- the "does not block the loop" test asserted the *final* tick count, which `gather` satisfies whether or not the work overlapped. It now samples the tick count **at the moment the blocking call returns**.
- the `join` test **hung** rather than failed under its mutant. It now drives `join` from a watchdog thread — a test that pins CI is worse than one that fails.

## Not done

- **A4** (`offset = int(elapsed * 15)` barge-in truncation) needs a live session to verify.
- **C3** (literal `.replace("System:", "")` scrubbing) is a threat-model decision at the current single-user scope, not a defect.
- **F1 needs rescoping before it needs doing.** `ActionService.execute` is now **23** lines (the audit said ~470), `search_memories` **251** (~1000), and `add_memory`'s eight near-identical INSERTs are **two**. The god-functions are gone; what remains is dual-backend duplication spread across the file — a different and lower-value problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Vision source switching now requires session authentication, preventing unauthorized camera or screen changes.

* **Reliability**
  * State saving and restoration are more responsive and safer during concurrent activity.
  * Background metrics processing now exits gracefully instead of waiting indefinitely.
  * Memory scoring uses bounded caching for more predictable performance.

* **Bug Fixes**
  * Vision service failures now produce diagnostic warnings instead of failing silently.

* **Documentation**
  * Updated the perceptual interruption diagram to reflect the current voice and playback pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->