### PR TITLE
fix(barge-in): keep the reply intact rather than guessing where speech stopped (A4)

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -4188,3 +4188,50 @@ removes ordering with it*. The tests written alongside the original change
 asserted that the loop stayed responsive and that a single call wrote correct
 values -- neither could see a two-call ordering property, and nothing prompted
 writing that test until review did.
+
+### 2026-07-19 — A4: the barge-in transcript no longer guesses
+
+When the user interrupts, `_on_audio_stop` rewrites the stored assistant reply
+to what was actually heard. With real playback progress it uses
+`character_offset`, which is accurate. Without it, it estimated
+`int(elapsed * 15)` -- a hardcoded 15 characters per second -- and cut there.
+
+Two things were wrong. The rate was invented and unbounded in error: real speech
+rate varies with prosody, pauses and the synthesiser, so the cut landed wherever
+the arithmetic said. And `assistant_response_start_time` was stamped on only one
+of the two streaming paths -- the other assigns `last_assistant_response`
+without it -- so `elapsed` could be measured from a previous turn entirely.
+
+This matters more than a logging bug because the stored message is not a log.
+Memory reads it and the persona prompt reads it back, so a wrong cut point does
+not misreport history, it *becomes* what the agent believes it said.
+
+Decision (maintainer): keep the full text when progress is unknown and log that
+truncation was skipped. That is also imperfect -- the agent may believe it said
+more than was heard -- but it is wrong honestly and visibly rather than by
+fabrication. The estimate is removed rather than tuned, and
+`assistant_response_start_time` with it, since nothing else read it.
+
+Also fixed while there: `last_audio_progress` was cleared only on the branch
+that truncated, so a stop matching none of the guards left the marker in place
+for the *next* interrupt to cut against -- a stale offset from a reply that had
+already ended.
+
+**An existing test was inverted, deliberately.**
+`test_dialogue_truncation_via_estimation_fallback` asserted the old estimate
+(cutting "…buy a coffee, but I forgot my wallet." to "…buy a coffee" because
+2.0s had passed). It is renamed
+`test_dialogue_is_not_rewritten_when_playback_progress_is_unknown` and asserts
+the opposite, with the reasoning in its docstring. Recording it here because
+"a test changed to match the code" is normally a smell: this one is a behaviour
+decision, and the accurate `character_offset` path is still covered and still
+truncates.
+
+Five mutations, five caught, including reinstating the estimate and accepting an
+out-of-range offset.
+
+**657 tests pass**, `ruff check .` clean.
+
+**NOT verified:** none of this was exercised against live audio. The accurate
+path depends on `AudioPlaybackProgress` arriving before the stop, which only a
+real barge-in can confirm.

--- a/backend/app/agents/brain_agent.py
+++ b/backend/app/agents/brain_agent.py
@@ -414,7 +414,11 @@ class BrainAgent(BaseAgent):
 
         if not is_subconscious:
             self.last_assistant_response = ""
-            self.assistant_response_start_time = time.time()
+            # `assistant_response_start_time` used to be stamped here, read only
+            # by the character-rate truncation guess in `_on_audio_stop`. That
+            # guess is gone, and it was set on this path only -- the other
+            # streaming path assigns `last_assistant_response` without it, which
+            # is how elapsed time could be measured from an earlier turn.
 
         full_response = await self._stream_to_speech(
             wrapped_generator,
@@ -500,27 +504,40 @@ class BrainAgent(BaseAgent):
                             await self.conversation_store.update_last_assistant_message(
                                 truncated_text
                             )
-                        self.last_audio_progress = None
-                elif (
-                    not progress
-                    and self.last_assistant_response
-                    and hasattr(self, "assistant_response_start_time")
-                ):
-                    # Fallback: estimate progress using average word/character duration
-                    elapsed = time.time() - self.assistant_response_start_time
-                    # Average speech rate: ~15 characters per second (approx 150 WPM)
-                    offset = int(elapsed * 15)
-                    if 0 < offset < len(self.last_assistant_response):
-                        truncated_text = self.last_assistant_response[:offset].strip()
-                        original_length = len(self.last_assistant_response)
-                        truncated_length = len(truncated_text)
-                        logger.info(
-                            f"Truncating history (via estimation): original_length={original_length}, truncated_length={truncated_length}, offset={offset}, elapsed={elapsed:.2f}s"
-                        )
-                        if self.conversation_store:
-                            await self.conversation_store.update_last_assistant_message(
-                                truncated_text
-                            )
+                elif not progress and self.last_assistant_response:
+                    # No real playback progress, so we do not know how much of
+                    # the reply was actually heard -- and we no longer guess.
+                    #
+                    # This used to estimate `int(elapsed * 15)`, a hardcoded
+                    # 15 characters per second, and rewrite the stored reply at
+                    # that offset. Two things were wrong with it. The rate was
+                    # invented and unbounded in error: real speech rate varies
+                    # with prosody, pauses and the synthesiser, so the cut
+                    # landed wherever the arithmetic said. And
+                    # `assistant_response_start_time` is only set on one of the
+                    # two streaming paths, so `elapsed` could be measured from a
+                    # *previous* turn entirely.
+                    #
+                    # The transcript is not a log; it is what memory and the
+                    # persona prompt read back later. A wrong cut point puts
+                    # words in the agent's mouth that it never said, or deletes
+                    # ones it did, and nothing downstream can tell that the
+                    # sentence was reconstructed. Keeping the full text is also
+                    # wrong -- the agent may believe it said more than was heard
+                    # -- but it is wrong in a way that is honest and visible in
+                    # the log, rather than silently fabricated.
+                    logger.info(
+                        "Interrupted with no playback progress; keeping the full "
+                        "reply (%d chars) rather than guessing a cut point.",
+                        len(self.last_assistant_response),
+                    )
+
+                # Cleared however this turn resolved. It was previously reset
+                # only on the branch that actually truncated, so a stop that
+                # matched none of the guards left the progress marker in place
+                # for the *next* interrupt to truncate against -- a stale offset
+                # from a reply that had already ended.
+                self.last_audio_progress = None
         except Exception as e:
             logger.error(f"Error handling audio stop truncation: {e}")
 

--- a/backend/tests/test_barge_in_truncation.py
+++ b/backend/tests/test_barge_in_truncation.py
@@ -1,0 +1,130 @@
+"""
+What the transcript records when the user interrupts.
+
+The stored assistant message is not a log. Memory reads it, and the persona
+prompt reads it back, so a wrong cut point does not merely misreport history --
+it becomes what the agent believes it said.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.agents.brain_agent import BrainAgent
+
+REPLY = "I looked it up and the museum opens at ten, so we have plenty of time."
+
+
+def _agent(progress=None, response=REPLY):
+    agent = object.__new__(BrainAgent)
+    agent.last_audio_progress = progress
+    agent.last_assistant_response = response
+    agent.conversation_store = SimpleNamespace(
+        update_last_assistant_message=AsyncMock()
+    )
+    return agent
+
+
+def _stop(speculative=False):
+    return {
+        "interrupt": True,
+        "speculative": speculative,
+        "reason": "confirmed_command",
+        "command_text": "stop",
+        "keywords": ["stop"],
+        "utterance_id": "u1",
+        "turn_id": None,
+    }
+
+
+def test_real_playback_progress_still_truncates_where_it_says():
+    """The accurate path must keep working; it is the only one that knows."""
+    progress = SimpleNamespace(completed=False, character_offset=26)
+    agent = _agent(progress)
+
+    asyncio.run(agent._on_audio_stop(_stop()))
+
+    agent.conversation_store.update_last_assistant_message.assert_awaited_once()
+    stored = agent.conversation_store.update_last_assistant_message.await_args.args[0]
+    assert stored == REPLY[:26].strip()
+
+
+def test_an_interruption_without_progress_does_not_invent_a_cut_point(caplog):
+    """This replaces a hardcoded 15 characters/second estimate.
+
+    Real speech rate varies with prosody, pauses and the synthesiser, so the
+    estimate cut wherever the arithmetic landed and nothing downstream could
+    tell the sentence had been reconstructed. Keeping the full text is also
+    imperfect — the agent may believe it said more than was heard — but it is
+    wrong honestly and visibly rather than by fabrication.
+    """
+    agent = _agent(progress=None)
+
+    with caplog.at_level("INFO"):
+        asyncio.run(agent._on_audio_stop(_stop()))
+
+    agent.conversation_store.update_last_assistant_message.assert_not_awaited()
+    assert any("keeping the full" in r.getMessage() for r in caplog.records)
+
+
+def test_a_speculative_stop_never_rewrites_history():
+    """Speculative stops are guesses about the user, not confirmed interrupts.
+
+    Truncating on one would edit the transcript because the agent *thought* it
+    heard the user start talking.
+    """
+    progress = SimpleNamespace(completed=False, character_offset=26)
+    agent = _agent(progress)
+
+    asyncio.run(agent._on_audio_stop(_stop(speculative=True)))
+
+    agent.conversation_store.update_last_assistant_message.assert_not_awaited()
+
+
+def test_progress_is_cleared_even_when_nothing_was_truncated():
+    """Otherwise a stale offset survives into the next interruption.
+
+    The reset lived only on the branch that truncated, so a stop matching none
+    of the guards left the marker in place — and the *next* barge-in would cut
+    the new reply at an offset measured against a reply that had already ended.
+    """
+    progress = SimpleNamespace(completed=True, character_offset=26)  # completed
+    agent = _agent(progress)
+
+    asyncio.run(agent._on_audio_stop(_stop()))
+
+    agent.conversation_store.update_last_assistant_message.assert_not_awaited()
+    assert agent.last_audio_progress is None
+
+
+def test_the_response_start_timestamp_is_gone():
+    """It was written on one streaming path and read only by the estimate.
+
+    Leaving it would be a field that looks like turn state, is set on one of the
+    two paths that produce a reply, and is read by nothing — the exact shape of
+    the bug it enabled, where elapsed time could be measured from an earlier
+    turn.
+    """
+    import inspect
+
+    from app.agents import brain_agent
+
+    source = inspect.getsource(brain_agent)
+    assert "self.assistant_response_start_time = time.time()" not in source
+
+
+@pytest.mark.parametrize("offset", [0, len(REPLY), len(REPLY) + 50])
+def test_an_out_of_range_offset_leaves_the_reply_alone(offset):
+    """A zero or past-the-end offset means "nothing useful is known".
+
+    Zero would store an empty message; past-the-end would strip the trailing
+    whitespace off a reply that was heard in full and rewrite it for no reason.
+    """
+    progress = SimpleNamespace(completed=False, character_offset=offset)
+    agent = _agent(progress)
+
+    asyncio.run(agent._on_audio_stop(_stop()))
+
+    agent.conversation_store.update_last_assistant_message.assert_not_awaited()

--- a/backend/tests/test_embodied_feedback.py
+++ b/backend/tests/test_embodied_feedback.py
@@ -67,9 +67,27 @@ async def test_dialogue_truncation_on_interruption(
 
 
 @pytest.mark.asyncio
-async def test_dialogue_truncation_via_estimation_fallback(
-    mock_llm_service, mock_graph_db, mock_memory_store, monkeypatch
+async def test_dialogue_is_not_rewritten_when_playback_progress_is_unknown(
+    mock_llm_service, mock_graph_db, mock_memory_store
 ):
+    """Renamed and inverted from `test_dialogue_truncation_via_estimation_fallback`.
+
+    That test asserted the old behaviour: with no playback progress, estimate
+    the spoken length at 15 characters/second and rewrite the stored reply at
+    that offset. Here it cut "…buy a coffee, but I forgot my wallet." down to
+    "…buy a coffee" purely because 2.0 seconds had passed.
+
+    The estimate has been deliberately removed rather than tuned. The rate was
+    invented, real speech rate varies with prosody and pauses, and the
+    timestamp it measured against was set on only one of the two streaming
+    paths — so the cut point could be derived from an entirely different turn.
+    Since the stored message is what memory and the persona prompt read back,
+    a wrong cut makes the agent believe it said something it did not.
+
+    The assertion is therefore inverted on purpose: this documents a behaviour
+    change, not a weakened test. The accurate path — a real `character_offset`
+    from playback progress — is still covered above and still truncates.
+    """
     store = ConversationHistoryStore()
     await store.initialize()
 
@@ -85,13 +103,6 @@ async def test_dialogue_truncation_via_estimation_fallback(
     )
 
     agent.last_assistant_response = original_text
-    import time
-
-    fixed_time = 1713330000.0
-    monkeypatch.setattr(time, "time", lambda: fixed_time)
-
-    agent.assistant_response_start_time = fixed_time - 2.0
-
     assert agent.last_audio_progress is None
 
     stop_data = {
@@ -103,7 +114,9 @@ async def test_dialogue_truncation_via_estimation_fallback(
     await agent._on_audio_stop(stop_data)
 
     new_brief = await store.get_last_interaction_brief()
-    assert new_brief == "I was planning to buy a coffee"
+    assert new_brief == original_text, (
+        "the reply was rewritten despite nothing knowing how much was heard"
+    )
 
     await store.close()
 


### PR DESCRIPTION
When the user interrupts, `_on_audio_stop` rewrites the stored assistant reply to what was actually heard. With real playback progress it uses `character_offset`, which is accurate. Without it, it estimated `int(elapsed * 15)` — a hardcoded 15 characters per second — and cut there.

## Why that was worse than it looks

**The rate was invented and unbounded in error.** Real speech rate varies with prosody, pauses and the synthesiser, so the cut landed wherever the arithmetic said.

**The clock could belong to a different turn.** `assistant_response_start_time` was stamped on only one of the two streaming paths; the other assigns `last_assistant_response` without it. So `elapsed` could be measured from a previous turn entirely.

**And the stored message is not a log.** Memory reads it, and the persona prompt reads it back. A wrong cut point doesn't misreport history — it *becomes* what the agent believes it said.

## The change

Per your decision: keep the full text when progress is unknown, and log that truncation was skipped. That is also imperfect — the agent may believe it said more than was heard — but it is wrong *honestly and visibly* rather than by fabrication.

The estimate is removed rather than tuned, and `assistant_response_start_time` with it, since nothing else read it.

**Also fixed while there:** `last_audio_progress` was cleared only on the branch that truncated, so a stop matching none of the guards left the marker in place — and the *next* barge-in would cut a new reply at an offset measured against a reply that had already ended.

## One test was inverted, deliberately

`test_dialogue_truncation_via_estimation_fallback` asserted the old estimate — cutting *"…buy a coffee, but I forgot my wallet."* to *"…buy a coffee"* purely because 2.0 seconds had passed.

It is renamed `test_dialogue_is_not_rewritten_when_playback_progress_is_unknown` and asserts the opposite. Flagging it explicitly because "a test changed to match the code" is normally a smell — this one is a behaviour decision, and the accurate `character_offset` path is still covered and still truncates.

## Verification

**657 tests pass**, `ruff check .` clean, **5/5 mutations caught** — including reinstating the estimate, letting speculative stops truncate, and accepting an out-of-range offset.

## Not verified

None of this was exercised against live audio. The accurate path depends on `AudioPlaybackProgress` arriving before the stop, which only a real barge-in can confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)