### PR TITLE
chore(contracts): remove the deprecated ChatOutput prosody fields

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -4188,3 +4188,49 @@ removes ordering with it*. The tests written alongside the original change
 asserted that the loop stayed responsive and that a single call wrote correct
 values -- neither could see a two-call ordering property, and nothing prompted
 writing that test until review did.
+
+### 2026-07-19 — Prosody fields removed from the wire, in one PR
+
+The deprecated `ChatOutput` prosody block -- `confidence`, `intensity`,
+`speaking_rate`, `pause_bias`, `paralinguistic_tags` -- is gone from both
+`app/contracts.py` and `crates/contracts/src/lib.rs`. Prosody has one source:
+the voice agent derives it from `affect` via `vad_to_prosody`. Python used to
+populate these with a formula that disagreed with the Rust one, and nothing read
+them.
+
+**This was previously deferred as needing a rollout plan. It did not.** Four
+checks, verified before touching anything, show removal is safe in both
+directions at once:
+
+- the Rust structs set no `deny_unknown_fields`, so a message from an older
+  Python producer still carrying the keys deserializes and they are ignored;
+- every Rust field is `#[serde(default)]`, so an older Rust build receiving a
+  message *without* them fills defaults;
+- Python's `ChatOutput` is `extra: "allow"`, so an old message validates against
+  the new model;
+- nothing constructs them. Python never passed them; Rust never builds
+  `ChatOutput` at all, only deserializes it.
+
+So there is no deploy ordering constraint and no mixed-version window to manage.
+`setup_nats_streams.py` configures stream subjects, not message schemas, and
+needs no re-run for a field removal.
+
+`cargo check --workspace` passes. `default_one()` became unused with the last
+field that referenced it and was removed too. Note `contracts::Prosody` has its
+own `pause_bias` -- a different struct, untouched.
+
+**The compatibility claim is demonstrated rather than asserted.**
+`test_rust_contract_fixtures.py` parses a Rust-generated fixture that still
+contains all five old fields, and it passes unchanged: `extra: "allow"` carries
+them through. Mutation U3 flips that to `extra: "forbid"` and the fixture test
+fails, which is what pins the property.
+
+Two tests in `test_phase4_features.py` asserted the fields sat at their
+*defaults*; they now assert the names are absent from `model_fields` and from
+the published payload. Deliberately checked against declared fields rather than
+attribute access -- `extra: "allow"` means reading `payload.speaking_rate` on an
+instance built from an older message still succeeds, so attribute access cannot
+distinguish "removed" from "carried through".
+
+**649 tests pass**, `ruff check .` clean, `cargo check --workspace` clean,
+3/3 mutations caught.

--- a/backend/app/contracts.py
+++ b/backend/app/contracts.py
@@ -93,25 +93,18 @@ class ChatOutput(BaseModel):
     turn_id: Optional[str] = None
     affect: Optional[ChatOutputAffect] = None
 
-    # Prosody & Signals
+    # The deprecated prosody block (confidence, intensity, speaking_rate,
+    # pause_bias, paralinguistic_tags) was removed here. Prosody has a single
+    # source: the voice agent derives it from `affect` above via
+    # `contracts::vad_to_prosody` (Rust). Python used to populate these with a
+    # formula that disagreed with the Rust one, and nothing ever read them.
     #
-    # DEPRECATED, and no longer written by any producer. Prosody has a single
-    # source: the voice agent computes it from `affect` above via
-    # `contracts::vad_to_prosody` (Rust). Python used to populate these too,
-    # with a formula that disagreed with the Rust one, and nothing ever read
-    # them -- see SpeechCoordinator's docstring.
-    #
-    # Retained at their defaults rather than removed, so an older consumer
-    # deserializing a new message still finds the fields it expects. They carry
-    # no information: do not read them, and do not repopulate them. Removing
-    # them is a wire-contract change and needs `setup_nats_streams.py` re-run.
-    confidence: float = 1.0
-    intensity: float = 0.0
-    speaking_rate: float = 1.0
-    pause_bias: float = 0.0
-    paralinguistic_tags: List[str] = Field(
-        default_factory=list
-    )  # [laughs], [sighs], etc.
+    # Safe to remove in both rollout directions, which is why they went rather
+    # than staying deprecated forever: this model is `extra: "allow"`, so a
+    # message from an older producer still carrying them validates; and the
+    # Rust struct sets `#[serde(default)]` on every field with no
+    # `deny_unknown_fields`, so a new message missing them deserializes there
+    # too. No deploy ordering is required.
 
     # Metadata
     timestamp: float = Field(default_factory=time.time)

--- a/backend/crates/contracts/src/lib.rs
+++ b/backend/crates/contracts/src/lib.rs
@@ -139,16 +139,16 @@ pub struct ChatOutput {
     pub turn_id: Option<String>,
     #[serde(default)]
     pub affect: Option<ChatOutputAffect>,
-    #[serde(default = "default_one")]
-    pub confidence: f64,
-    #[serde(default)]
-    pub intensity: f64,
-    #[serde(default = "default_one")]
-    pub speaking_rate: f64,
-    #[serde(default)]
-    pub pause_bias: f64,
-    #[serde(default)]
-    pub paralinguistic_tags: Vec<String>,
+    // The deprecated prosody block (confidence, intensity, speaking_rate,
+    // pause_bias, paralinguistic_tags) was removed. Prosody has one source:
+    // `vad_to_prosody` derives it from `affect` above. Nothing read these, and
+    // the Python side populated them with a different formula.
+    //
+    // Removal is safe both ways round: this struct has no
+    // `deny_unknown_fields`, so a message from an older producer still
+    // carrying them deserializes and they are ignored. Note that
+    // `contracts::Prosody` has its own `pause_bias` -- a different type, not
+    // affected by this.
     #[serde(default)]
     pub timestamp: f64,
     #[serde(default)]
@@ -159,10 +159,6 @@ pub struct ChatOutput {
     pub proactive: bool,
     #[serde(default)]
     pub latency_metadata: Option<LatencyMetadata>,
-}
-
-fn default_one() -> f64 {
-    1.0
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/backend/tests/test_phase4_features.py
+++ b/backend/tests/test_phase4_features.py
@@ -96,22 +96,33 @@ def test_an_absent_state_snapshot_produces_neutral_affect_not_a_crash():
     assert payload.affect.emotion == "neutral"
 
 
-def test_prosody_fields_stay_at_their_defaults_on_the_wire():
-    """The deprecated fields must be inert, not carry a stale second opinion.
+def test_the_brain_declares_no_prosody_fields_at_all():
+    """Strengthened from asserting the deprecated fields sat at their defaults.
 
-    They are kept for deserialization compatibility with older consumers. If a
-    producer starts filling them again a reader could reasonably believe them,
-    and they would disagree with what the voice agent actually does.
+    They used to be kept, inert, for deserialization compatibility. They are now
+    removed outright, which is a stronger guarantee than "present but default":
+    a field that does not exist cannot be quietly repopulated with a second
+    opinion that disagrees with what the voice agent computes from `affect`.
+
+    Asserted on the model's declared fields rather than on attribute access,
+    because `ChatOutput` is `extra: "allow"` -- reading `payload.speaking_rate`
+    on an instance built from an *older* message would still succeed, so
+    attribute access cannot tell "removed" from "carried through".
     """
     coordinator = SpeechCoordinator(segmenter=HybridSegmenter(target_size=8))
     payload = coordinator.create_chunk_payload(
         words=["hi"], state_snap={"valence": 0.9, "arousal": 0.9, "fatigue": 0.9}
     )
-    defaults = ChatOutput()
-    assert payload.speaking_rate == defaults.speaking_rate
-    assert payload.pause_bias == defaults.pause_bias
-    assert payload.intensity == defaults.intensity
-    assert payload.confidence == defaults.confidence
+
+    gone = {
+        "confidence",
+        "intensity",
+        "speaking_rate",
+        "pause_bias",
+        "paralinguistic_tags",
+    }
+    assert gone.isdisjoint(ChatOutput.model_fields)
+    assert gone.isdisjoint(payload.model_dump())
 
 
 @pytest.mark.asyncio
@@ -167,11 +178,16 @@ async def test_brain_agent_publishes_the_affect_vector_to_chat_output():
     # losing it here silently flattens how the agent projects.
     assert parsed.affect.user_distance == 1.8
 
-    # The brain must not attach a second opinion on prosody. All four, not the
-    # two that happen to be most visible — a repopulated `intensity` would be
-    # believed by a reader and disagree with what the voice agent computes.
-    defaults = ChatOutput()
-    assert parsed.speaking_rate == defaults.speaking_rate
-    assert parsed.pause_bias == defaults.pause_bias
-    assert parsed.intensity == defaults.intensity
-    assert parsed.confidence == defaults.confidence
+    # The brain must not attach a second opinion on prosody. The deprecated
+    # fields are gone from the contract entirely now, so the check is that the
+    # published payload carries no key by those names -- a producer that
+    # reintroduced one would be shipping a value the voice agent never asked
+    # for and would disagree with.
+    published = parsed.model_dump()
+    assert {
+        "confidence",
+        "intensity",
+        "speaking_rate",
+        "pause_bias",
+        "paralinguistic_tags",
+    }.isdisjoint(published)


### PR DESCRIPTION
`confidence`, `intensity`, `speaking_rate`, `pause_bias` and `paralinguistic_tags` are removed from **both** `app/contracts.py` and `crates/contracts/src/lib.rs`.

Prosody has one source: the voice agent derives it from `affect` via `vad_to_prosody`. Python used to populate these with a formula that disagreed with the Rust one, and nothing read them.

## I was wrong that this needed a rollout plan

I'd deferred this repeatedly as a risky cross-language wire change. Checking it properly, removal is safe in **both directions simultaneously**:

| Direction | Why it's safe |
|---|---|
| Old Python producer → new Rust consumer | Rust sets no `deny_unknown_fields`; extra keys are ignored |
| New Python producer → old Rust consumer | Every Rust field is `#[serde(default)]`; absence fills defaults |
| Old message → new Python model | `ChatOutput` is `extra: "allow"` |
| Any writer | Nothing constructs them. Python never passed them; Rust never builds `ChatOutput` at all |

So there is **no deploy ordering constraint and no mixed-version window**. `setup_nats_streams.py` configures stream *subjects*, not message schemas, so a field removal needs no re-run.

## The compatibility is demonstrated, not asserted

`test_rust_contract_fixtures.py` parses a Rust-generated fixture that still contains all five old fields — and it **passes unchanged**. `extra: "allow"` carries them through.

Mutation U3 flips that to `extra: "forbid"` and the fixture test fails. That's what pins the property, rather than my say-so.

## Test changes

Two tests in `test_phase4_features.py` asserted the fields sat at their *defaults*. They now assert the names are absent from `model_fields` and from the published payload — a stronger guarantee than "present but default", since a field that doesn't exist can't be quietly repopulated.

Deliberately checked against **declared fields** rather than attribute access: `extra: "allow"` means reading `payload.speaking_rate` on an instance built from an older message still succeeds, so attribute access cannot distinguish "removed" from "carried through".

## Verification

- **649 tests pass**, `ruff check .` clean
- **`cargo check --workspace` clean** — `default_one()` became unused with the last field referencing it and was removed
- **3/3 mutations caught**

Note `contracts::Prosody` has its own `pause_bias` — a different struct, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)