### PR TITLE
refactor(memory): share the one dual-backend pattern that is actually shared (F1)

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -4188,3 +4188,55 @@ removes ordering with it*. The tests written alongside the original change
 asserted that the loop stayed responsive and that a single call wrote correct
 values -- neither could see a two-call ordering property, and nothing prompted
 writing that test until review did.
+
+### 2026-07-19 — F1, finally scoped: only 5 of 17 dual-backend branches were duplication
+
+F1 was written against a `memory_store.py` that no longer exists. Measured
+before starting: `ActionService.execute` is **23** lines (the finding said
+~470), `search_memories` **251** (~1000), and `add_memory`'s "eight
+near-identical INSERTs" are **two**. The god-functions were decomposed by
+earlier work and nobody updated the finding.
+
+What remains is dual-backend duplication, so that is what was examined. There
+are 17 `is_sqlite` branch sites, and they fall into three groups:
+
+1. **Genuine duplication (5 sites)** -- the two dialects spell set membership
+   differently and nothing else differs: SQLite needs one placeholder per value,
+   Postgres takes the list as one array via `= ANY($n)`.
+2. **Real dialect differences** -- boolean literals (`0`/`1` vs `FALSE`/`TRUE`),
+   date arithmetic (`datetime('now', '-24 hours')` vs `NOW() - INTERVAL`), and
+   `datetime()` normalisation SQLite needs because it stores timestamps as text
+   and raw string comparison across ISO formats is unreliable.
+3. **Capability differences** -- `executemany` on Postgres versus a loop,
+   because the SQLite fallback does not provide it.
+
+Only group 1 is duplication. `_in_predicate(column, values, param_index)` now
+returns the clause and its arguments, and three of the five call sites use it;
+the other two carry additional structure (a conditional timestamp parameter, and
+an `INSERT ... SELECT`) where the branch is not just the predicate.
+
+The helper deliberately returns each backend's own idiom rather than a lowest
+common denominator: flattening Postgres to N placeholders would work and would
+throw away the array form the planner handles better. Mutation V1 is exactly
+that flattening, and it is caught.
+
+**Groups 2 and 3 were left alone, and that is the finding.** Collapsing them
+would invent a sameness that is not there -- a shared spelling of
+`consolidated = 1` fails on a Postgres boolean column, and a shared timestamp
+comparison silently returns wrong rows on SQLite. The remaining 12 branches are
+not debt.
+
+Five mutations, five caught -- but V5 (`truth = "1"` unconditionally) **survived
+the first version of these tests**. The predicate was covered and the dialect
+literal sitting beside it was not, so a change that breaks Postgres and only
+Postgres passed everything. That gap is now covered by asserting the emitted SQL
+per backend. Writing that test also caught a mistake of my own: swapping in a
+capturing pool dropped `pool.connection.conn` and silently flipped the store to
+Postgres, because `is_sqlite` is derived from the pool (A5) rather than stored.
+
+**658 tests pass**, `ruff check .` clean.
+
+**NOT done:** `memory_store.py` is still 3031 lines and is not split into
+modules. That was offered and not chosen, and on this evidence it would be
+motion rather than progress -- the file is long because the domain is, not
+because one function is doing five jobs. F1 is closed.

--- a/backend/app/state/memory_store.py
+++ b/backend/app/state/memory_store.py
@@ -24,7 +24,7 @@ import sqlite3
 import uuid
 from collections import OrderedDict
 from datetime import datetime, timezone, timedelta
-from typing import Iterable
+from typing import Any, Iterable, List, Sequence, Tuple
 from ..config import Config
 
 logger = logging.getLogger(__name__)
@@ -297,6 +297,35 @@ class MemoryStore:
         """
         conn = getattr(self.pool, "connection", None)
         return isinstance(getattr(conn, "conn", None), sqlite3.Connection)
+
+    def _in_predicate(
+        self, column: str, values: Sequence[Any], param_index: int = 1
+    ) -> Tuple[str, List[Any]]:
+        """Build a `column IN (...)` predicate and its arguments for this backend.
+
+        The two dialects express set membership differently and neither is
+        wrong: SQLite wants one placeholder per value, Postgres takes the whole
+        list as a single array parameter via `= ANY($n)`. Spelling that out at
+        each call site produced the same eight-line if/else repeatedly, where
+        the only real content was a column name.
+
+        Returns the clause and the argument list to splat, so callers keep each
+        backend's idiom rather than being forced onto a lowest common
+        denominator -- flattening Postgres to N placeholders would work but
+        would throw away the array form the query planner handles better.
+
+        Deliberately *not* applied to every dual-backend branch in this file.
+        Most of them differ for real reasons -- boolean literals (`0`/`1` vs
+        `FALSE`/`TRUE`), date arithmetic (`datetime('now', '-24 hours')` vs
+        `NOW() - INTERVAL`), `datetime()` normalisation that SQLite needs
+        because it stores timestamps as text, and `executemany` which the
+        SQLite fallback does not provide. Those are genuine differences between
+        the backends, not duplication, and collapsing them would invent a
+        sameness that is not there.
+        """
+        if self.is_sqlite:
+            return f"{column} IN ({','.join('?' * len(values))})", list(values)
+        return f"{column} = ANY(${param_index})", [list(values)]
 
     @staticmethod
     def _is_missing_column_error(exc: BaseException) -> bool:
@@ -1159,17 +1188,12 @@ class MemoryStore:
             cand_ids = [c["id"] for c in candidates if c.get("id")]
             if cand_ids:
                 async with self.pool.acquire() as conn:
-                    if self.is_sqlite:
-                        placeholders = ",".join("?" for _ in cand_ids)
-                        rows = await conn.fetch(
-                            f"SELECT id, importance_score, emotional_weight, valence, recall_count, last_recalled_at FROM memories WHERE id IN ({placeholders})",
-                            *cand_ids,
-                        )
-                    else:
-                        rows = await conn.fetch(
-                            "SELECT id, importance_score, emotional_weight, valence, recall_count, last_recalled_at FROM memories WHERE id = ANY($1)",
-                            cand_ids,
-                        )
+                    where, args = self._in_predicate("id", cand_ids)
+                    rows = await conn.fetch(
+                        "SELECT id, importance_score, emotional_weight, valence, "
+                        f"recall_count, last_recalled_at FROM memories WHERE {where}",
+                        *args,
+                    )
                     for r in rows:
                         db_metadata[str(r["id"])] = r
         except Exception as db_err:
@@ -2754,17 +2778,15 @@ class MemoryStore:
             return
         try:
             async with self.pool.acquire() as conn:
-                if self.is_sqlite:
-                    placeholders = ",".join("?" for _ in message_ids)
-                    await conn.execute(
-                        f"UPDATE messages SET consolidated = 1 WHERE id IN ({placeholders})",
-                        *message_ids,
-                    )
-                else:
-                    await conn.execute(
-                        "UPDATE messages SET consolidated = TRUE WHERE id = ANY($1)",
-                        message_ids,
-                    )
+                where, args = self._in_predicate("id", message_ids)
+                # `1` vs `TRUE` stays a dialect literal: a Postgres boolean
+                # column will not accept the integer, so this is a real
+                # difference rather than noise the helper should absorb.
+                truth = "1" if self.is_sqlite else "TRUE"
+                await conn.execute(
+                    f"UPDATE messages SET consolidated = {truth} WHERE {where}",
+                    *args,
+                )
         except Exception as e:
             logger.error(f"Failed to mark episodes consolidated: {e}")
 
@@ -2781,17 +2803,12 @@ class MemoryStore:
 
             async with self.pool.acquire() as conn:
                 # 1. Fetch matching memories
-                if self.is_sqlite:
-                    placeholders = ",".join("?" for _ in unique_contents)
-                    rows = await conn.fetch(
-                        f"SELECT id, content, recall_count, created_at, metadata, importance_score FROM memories WHERE content IN ({placeholders})",
-                        *unique_contents,
-                    )
-                else:
-                    rows = await conn.fetch(
-                        "SELECT id, content, recall_count, created_at, metadata, importance_score FROM memories WHERE content = ANY($1)",
-                        unique_contents,
-                    )
+                where, args = self._in_predicate("content", unique_contents)
+                rows = await conn.fetch(
+                    "SELECT id, content, recall_count, created_at, metadata, "
+                    f"importance_score FROM memories WHERE {where}",
+                    *args,
+                )
 
                 if not rows:
                     return

--- a/backend/tests/test_dual_backend_predicate.py
+++ b/backend/tests/test_dual_backend_predicate.py
@@ -32,7 +32,7 @@ def _store(is_sqlite: bool) -> MemoryStore:
     return store
 
 
-def test_sqlite_gets_one_placeholder_per_value():
+def test_sqlite_cannot_be_given_a_postgres_array_parameter():
     """SQLite has no array parameter; it needs `IN (?,?,?)`."""
     where, args = _store(True)._in_predicate("id", ["a", "b", "c"])
 
@@ -40,7 +40,7 @@ def test_sqlite_gets_one_placeholder_per_value():
     assert args == ["a", "b", "c"]
 
 
-def test_postgres_gets_a_single_array_parameter():
+def test_postgres_is_not_flattened_to_one_placeholder_per_value():
     """`= ANY($1)` passes the whole list as one argument.
 
     Flattening Postgres to N placeholders would also work, which is exactly why
@@ -53,7 +53,7 @@ def test_postgres_gets_a_single_array_parameter():
     assert args == [["a", "b", "c"]]
 
 
-def test_the_postgres_parameter_index_is_honoured():
+def test_a_hardcoded_parameter_index_would_bind_the_wrong_argument():
     """The predicate is rarely the first parameter in a real query.
 
     Hardcoding `$1` would silently bind against whatever argument happened to be
@@ -65,13 +65,13 @@ def test_the_postgres_parameter_index_is_honoured():
 
 
 @pytest.mark.parametrize("backend", [True, False])
-def test_the_column_name_reaches_the_clause(backend):
+def test_a_hardcoded_column_name_would_query_the_wrong_field(backend):
     """Both call sites use a different column, so it cannot be hardcoded."""
     where, _ = _store(backend)._in_predicate("content", ["x"])
     assert where.startswith("content ")
 
 
-def test_a_single_value_still_produces_valid_syntax():
+def test_a_one_element_list_does_not_emit_broken_syntax():
     """The one-element case is the common one for a targeted lookup.
 
     `",".join("?" * 1)` is a place where a plausible-looking implementation
@@ -121,7 +121,7 @@ def _pool_returning(conn, is_sqlite: bool):
 @pytest.mark.parametrize(
     "is_sqlite,expected_literal", [(True, "consolidated = 1"), (False, "consolidated = TRUE")]
 )
-async def test_the_consolidated_flag_uses_each_backend_s_boolean(
+async def test_a_shared_boolean_literal_would_break_postgres(
     is_sqlite, expected_literal
 ):
     """Postgres will not accept the integer `1` for a boolean column.
@@ -144,7 +144,7 @@ async def test_the_consolidated_flag_uses_each_backend_s_boolean(
     assert expected_literal in conn.sql
 
 
-def test_the_two_dialects_do_not_produce_the_same_clause():
+def test_a_collapsed_branch_would_send_one_dialect_the_wrong_sql():
     """A guard against the helper collapsing to one branch.
 
     If a refactor made `is_sqlite` always false (or the branch unreachable),

--- a/backend/tests/test_dual_backend_predicate.py
+++ b/backend/tests/test_dual_backend_predicate.py
@@ -1,0 +1,157 @@
+"""
+Set-membership predicates across the two SQL backends.
+
+`memory_store.py` carries a Postgres branch and a SQLite branch for nearly every
+query. Most of those differ for real reasons. A handful differed only in how the
+dialect spells `IN`, and that handful is what `_in_predicate` absorbs.
+
+These tests pin both dialects explicitly rather than testing "whatever the
+current backend is" — a helper that silently emits SQLite syntax to Postgres
+fails at the database, far from the code that chose it.
+"""
+
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+
+from app.state.memory_store import MemoryStore
+
+
+def _store(is_sqlite: bool) -> MemoryStore:
+    """A store forced onto one backend.
+
+    `is_sqlite` is a read-only property that inspects the pool (A5), so the
+    backend is selected by giving the pool the right shape rather than by
+    assigning to it — assignment raises, which is the point of the property.
+    """
+    store = object.__new__(MemoryStore)
+    conn = sqlite3.connect(":memory:") if is_sqlite else object()
+    store.pool = SimpleNamespace(connection=SimpleNamespace(conn=conn))
+    assert store.is_sqlite is is_sqlite
+    return store
+
+
+def test_sqlite_gets_one_placeholder_per_value():
+    """SQLite has no array parameter; it needs `IN (?,?,?)`."""
+    where, args = _store(True)._in_predicate("id", ["a", "b", "c"])
+
+    assert where == "id IN (?,?,?)"
+    assert args == ["a", "b", "c"]
+
+
+def test_postgres_gets_a_single_array_parameter():
+    """`= ANY($1)` passes the whole list as one argument.
+
+    Flattening Postgres to N placeholders would also work, which is exactly why
+    this is asserted: it would be an easy and invisible regression, and it
+    discards the array form the planner handles better.
+    """
+    where, args = _store(False)._in_predicate("id", ["a", "b", "c"])
+
+    assert where == "id = ANY($1)"
+    assert args == [["a", "b", "c"]]
+
+
+def test_the_postgres_parameter_index_is_honoured():
+    """The predicate is rarely the first parameter in a real query.
+
+    Hardcoding `$1` would silently bind against whatever argument happened to be
+    first — a query that runs and returns the wrong rows, which is worse than
+    one that errors.
+    """
+    where, _ = _store(False)._in_predicate("content", ["x"], param_index=4)
+    assert where == "content = ANY($4)"
+
+
+@pytest.mark.parametrize("backend", [True, False])
+def test_the_column_name_reaches_the_clause(backend):
+    """Both call sites use a different column, so it cannot be hardcoded."""
+    where, _ = _store(backend)._in_predicate("content", ["x"])
+    assert where.startswith("content ")
+
+
+def test_a_single_value_still_produces_valid_syntax():
+    """The one-element case is the common one for a targeted lookup.
+
+    `",".join("?" * 1)` is a place where a plausible-looking implementation
+    yields `""` or `"?,"` instead of `"?"`.
+    """
+    assert _store(True)._in_predicate("id", ["only"])[0] == "id IN (?)"
+
+
+class _CapturingConn:
+    def __init__(self):
+        self.sql = None
+        self.args = None
+
+    async def execute(self, sql, *args):
+        self.sql = sql
+        self.args = args
+
+    async def fetch(self, sql, *args):
+        self.sql = sql
+        self.args = args
+        return []
+
+
+def _pool_returning(conn, is_sqlite: bool):
+    """A pool that both hands out `conn` and still answers `is_sqlite`.
+
+    The backend is read off `pool.connection.conn` (A5), so a pool built only to
+    capture SQL would silently flip the store to Postgres — which is how the
+    first version of this test failed while the code was correct.
+    """
+
+    class _Ctx:
+        async def __aenter__(self):
+            return conn
+
+        async def __aexit__(self, *exc):
+            return False
+
+    backing = sqlite3.connect(":memory:") if is_sqlite else object()
+    return SimpleNamespace(
+        acquire=lambda: _Ctx(),
+        connection=SimpleNamespace(conn=backing),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "is_sqlite,expected_literal", [(True, "consolidated = 1"), (False, "consolidated = TRUE")]
+)
+async def test_the_consolidated_flag_uses_each_backend_s_boolean(
+    is_sqlite, expected_literal
+):
+    """Postgres will not accept the integer `1` for a boolean column.
+
+    This is the one dialect literal left inline beside the shared predicate, so
+    it is the one most likely to be "simplified" into a single spelling later.
+    Doing so fails at the database rather than in the code that chose it, and
+    only on the backend that is not being run locally.
+
+    Added because a mutation collapsing this to `"1"` survived the first version
+    of these tests: the predicate was covered and the literal beside it was not.
+    """
+    store = _store(is_sqlite)
+    conn = _CapturingConn()
+    store.pool = _pool_returning(conn, is_sqlite)
+    assert store.is_sqlite is is_sqlite  # the swap must not change the backend
+
+    await MemoryStore.mark_episodes_consolidated(store, ["m1", "m2"])
+
+    assert expected_literal in conn.sql
+
+
+def test_the_two_dialects_do_not_produce_the_same_clause():
+    """A guard against the helper collapsing to one branch.
+
+    If a refactor made `is_sqlite` always false (or the branch unreachable),
+    every test above that checks a single backend would still pass while the
+    other dialect silently received the wrong SQL.
+    """
+    sqlite_where, _ = _store(True)._in_predicate("id", ["a", "b"])
+    pg_where, _ = _store(False)._in_predicate("id", ["a", "b"])
+
+    assert sqlite_where != pg_where


### PR DESCRIPTION
## F1 was written against a file that no longer exists

Measured before starting anything:

| | finding said | actual |
|---|---|---|
| `ActionService.execute` | ~470 lines | **23** |
| `search_memories` | ~1000 lines | **251** |
| `add_memory` INSERT branches | 8 | **2** |

The god-functions were decomposed by earlier work and nobody updated the finding. So I looked at what actually remains — dual-backend duplication — and that turned out to be a smaller and more interesting problem than "17 duplicated branches".

## Only 5 of 17 branches are duplication

**Group 1 — genuine duplication (5 sites).** The dialects spell set membership differently and nothing else differs: SQLite needs one placeholder per value, Postgres takes the list as a single array via `= ANY($n)`.

**Group 2 — real dialect differences.** Boolean literals (`0`/`1` vs `FALSE`/`TRUE`), date arithmetic (`datetime('now', '-24 hours')` vs `NOW() - INTERVAL`), and `datetime()` normalisation that SQLite needs because it stores timestamps as text, where raw string comparison across ISO formats is unreliable.

**Group 3 — capability differences.** `executemany` on Postgres versus a loop, because the SQLite fallback doesn't provide it.

## What changed

`_in_predicate(column, values, param_index)` returns the clause and its arguments. Three of the five sites use it; the other two carry extra structure (a conditional timestamp parameter, an `INSERT ... SELECT`) where the branch isn't just the predicate.

It deliberately returns **each backend's own idiom** rather than a lowest common denominator — flattening Postgres to N placeholders would work, and would discard the array form the planner handles better. Mutation V1 is exactly that flattening, and it's caught.

## Groups 2 and 3 were left alone, and that is the result

Collapsing them would invent a sameness that isn't there. A shared `consolidated = 1` fails on a Postgres boolean column; a shared timestamp comparison silently returns wrong rows on SQLite. **The remaining 12 branches are not debt.**

## The mutation that mattered

**V5 survived the first version of these tests.** Setting the consolidated literal to `"1"` unconditionally — which breaks Postgres and only Postgres — passed everything, because the predicate was covered and the dialect literal sitting beside it wasn't. Now covered by asserting the emitted SQL per backend.

Writing that test also caught a mistake of mine: swapping in a capturing pool dropped `pool.connection.conn` and silently flipped the store to Postgres, since `is_sqlite` is derived from the pool (A5) rather than stored. The test failed while the code was correct.

## Verification

**658 tests pass**, `ruff check .` clean, **5/5 mutations caught**.

## Not done

`memory_store.py` is still 3031 lines and is not split into modules. That option was offered and not chosen, and on this evidence it would be motion rather than progress — the file is long because the domain is, not because one function is doing five jobs. **F1 is closed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database compatibility for filtering records across SQLite and PostgreSQL.
  * Corrected backend-specific handling of consolidated status updates and membership queries.

* **Tests**
  * Added coverage to verify correct query behavior for both supported database backends, including single-value and multi-value filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->