### PR TITLE
refactor(contracts): make StateUpdate the single source for the state.update broadcast

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -4629,3 +4629,53 @@ multi-backend schema change for zero behavioural gain; the existing symmetric
 loader/saver is a defensible resting point. Also not done: the same drift check
 for `README.md`, `CONTRIBUTING.md` and `docs/**`, which name far more paths and
 would need triage before the assertion could be turned on.
+
+### 2026-07-21 — StateUpdate: the orphan wire model was shadowing a duplicated literal
+
+The prior audit listed `StateUpdate` as a dead contract — "no publisher in
+Python, Rust, or the frontend" — and the #83 ledger left it alone as a wire
+model that Python-only evidence could not clear. Looked closer before deleting,
+and the real shape of it changes the fix.
+
+`state.update` **is** a live subject. It carries two shapes: a lifecycle message
+from `BaseAgent.set_state` (`{agent, state, timestamp}`) and the full affect
+broadcast from `CognitivePipeline`, consumed by `SurfacingAgent._on_agent_state`
+for mood-congruent recall and APRA vocal modulation. The affect broadcast's
+fields are **exactly** `StateUpdate`'s — because the pipeline built them as an
+11-field dict literal, duplicated verbatim across its two publish sites, while
+`StateUpdate` sat unused describing the same thing. Two definitions of one wire
+contract, and the model was the one nothing referenced.
+
+So deleting the model would have removed a symbol and left the actual smell —
+the duplicated literal — in place. Wired it up instead: added
+`StateUpdate.from_snapshot(snapshot)`, which pulls only modelled fields (so
+`valence`/`arousal`, which the snapshot also carries, stay dropped exactly as the
+literal dropped them) and lets the model's own defaults fill anything the
+snapshot omits. Both pipeline sites now publish
+`StateUpdate.from_snapshot(state_snapshot).model_dump()`. The item is resolved by
+the model *gaining* a publisher, not by removal.
+
+Confirmed safe before changing anything: no Rust or frontend consumer of
+`state.update` (grepped both), and the sole Python consumer duck-types with
+`.get(...)` defaults, so it tolerated the lifecycle shape before and is
+unaffected now. Verified byte-identical output against the old literal for a
+populated snapshot (extras dropped), a partial snapshot, and an empty one — the
+model defaults were already equal to the literal's hardcoded defaults,
+field-for-field, so the wire bytes do not move.
+
+Net −22 lines in `pipeline.py`. **700 tests pass** (696 before), `ruff check .`
+clean. New `tests/test_state_update_contract.py`: `from_snapshot` field mapping,
+default fallback from a partial snapshot, out-of-schema key dropping, and an
+end-to-end pipeline test asserting the emitted `state.update` equals
+`StateUpdate.from_snapshot(...)` — driven with a deliberately partial snapshot so
+the model defaults have to fill ten fields, which is what makes it catch a
+reverted literal. Four mutations (drop a field in `from_snapshot`; leak extras;
+a pipeline site reverting to a divergent literal; a changed model default) —
+four caught.
+
+**NOT done:** the lifecycle payload from `set_state` (`{agent, state,
+timestamp}`) is still unmodelled. It is a genuinely different message sharing the
+subject, and modelling it would mean either a second contract or a union the
+duck-typing consumer does not need. Left as is; the consumer reading affect
+fields with defaults is what makes one subject carrying two shapes safe, and that
+is worth keeping simple.

--- a/backend/app/cognitive/pipeline.py
+++ b/backend/app/cognitive/pipeline.py
@@ -2,6 +2,8 @@ import logging
 import math
 from typing import Dict, Any, AsyncGenerator, List
 
+from ..contracts import StateUpdate
+
 logger = logging.getLogger(__name__)
 
 # --- Endocrine channels ---------------------------------------------------
@@ -252,19 +254,7 @@ class CognitivePipeline:
             yield {
                 "type": "mesh_signal",
                 "subject": "state.update",
-                "data": {
-                    "mood": state_snapshot.get("mood", 0.0),
-                    "energy": state_snapshot.get("energy", 0.5),
-                    "dominance": state_snapshot.get("dominance", 0.5),
-                    "trust": state_snapshot.get("trust", 0.5),
-                    "attachment": state_snapshot.get("attachment", 0.1),
-                    "emotion": state_snapshot.get("emotion", "neutral"),
-                    "interaction_count": state_snapshot.get("interaction_count", 0),
-                    "cortisol": state_snapshot.get("cortisol", 0.0),
-                    "dopamine": state_snapshot.get("dopamine", 0.0),
-                    "fatigue": state_snapshot.get("fatigue", 0.0),
-                    "user_mental_model": state_snapshot.get("user_mental_model"),
-                },
+                "data": StateUpdate.from_snapshot(state_snapshot).model_dump(),
             }
         else:
             stage_times["stage_5_state_update_ms"] = (
@@ -297,19 +287,7 @@ class CognitivePipeline:
                 yield {
                     "type": "mesh_signal",
                     "subject": "state.update",
-                    "data": {
-                        "mood": state_snapshot.get("mood", 0.0),
-                        "energy": state_snapshot.get("energy", 0.5),
-                        "dominance": state_snapshot.get("dominance", 0.5),
-                        "trust": state_snapshot.get("trust", 0.5),
-                        "attachment": state_snapshot.get("attachment", 0.1),
-                        "emotion": state_snapshot.get("emotion", "neutral"),
-                        "interaction_count": state_snapshot.get("interaction_count", 0),
-                        "cortisol": state_snapshot.get("cortisol", 0.0),
-                        "dopamine": state_snapshot.get("dopamine", 0.0),
-                        "fatigue": state_snapshot.get("fatigue", 0.0),
-                        "user_mental_model": state_snapshot.get("user_mental_model"),
-                    },
+                    "data": StateUpdate.from_snapshot(state_snapshot).model_dump(),
                 }
         stage_times["stage_6_decision_ms"] = (time.perf_counter() - t_start) * 1000.0
 

--- a/backend/app/contracts.py
+++ b/backend/app/contracts.py
@@ -211,7 +211,20 @@ class VisionDescription(BaseModel):
 
 # ─── state.update ────────────────────────────────────────────
 class StateUpdate(BaseModel):
-    """Published on `state.update` when agent state changes."""
+    """The affect broadcast published on `state.update` when agent state changes.
+
+    This is the single definition of that payload. `CognitivePipeline` builds it
+    with `from_snapshot` at its two publish sites, and `SurfacingAgent` reads the
+    same fields off the wire to drive mood-congruent recall and APRA vocal
+    modulation. The subject also carries a separate lifecycle message from
+    `BaseAgent.set_state` (`{agent, state, timestamp}` — "thinking"/"idle"); that
+    one is deliberately *not* modelled here, and the consumer tolerates it because
+    it reads affect fields with defaults rather than validating a fixed shape.
+
+    Before this was wired up the payload lived as an 11-field dict literal
+    duplicated across both pipeline sites, and this model shadowed it unused —
+    two definitions of one wire contract, free to drift apart silently.
+    """
 
     model_config = {"extra": "allow"}
 
@@ -226,6 +239,17 @@ class StateUpdate(BaseModel):
     dopamine: float = 0.0
     fatigue: float = 0.0
     user_mental_model: Optional[Dict[str, Any]] = None
+
+    @classmethod
+    def from_snapshot(cls, snapshot: Dict[str, Any]) -> "StateUpdate":
+        """Build the broadcast from a `StateService.get_context_snapshot()` dict.
+
+        Only the modelled fields are pulled; a key the snapshot omits falls back
+        to this model's default, so the defaults live here and nowhere else.
+        Snapshot keys outside the schema (`valence`, `arousal`, …) are dropped,
+        exactly as the previous hand-written literal dropped them.
+        """
+        return cls(**{k: snapshot[k] for k in cls.model_fields if k in snapshot})
 
 
 # ─── user.voice.properties ───────────────────────────────────

--- a/backend/tests/test_state_update_contract.py
+++ b/backend/tests/test_state_update_contract.py
@@ -1,0 +1,163 @@
+"""`StateUpdate` is the single definition of the `state.update` affect broadcast.
+
+It used to be an orphan: the model existed in `contracts.py` while the payload
+it described lived as an 11-field dict literal duplicated across both publish
+sites in `CognitivePipeline`. Two definitions of one wire contract, free to
+drift — add a field to the broadcast and the model silently no longer matches
+what `SurfacingAgent` reads to drive mood-congruent recall and vocal modulation.
+
+These tests pin the wiring that removed the duplication: the pipeline builds the
+broadcast *through* the model, and the model is the sole owner of the field set
+and its defaults.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from app.cognitive.appraisal import AppraisalVector
+from app.cognitive.decision import ActionPlan
+from app.cognitive.pipeline import CognitivePipeline
+from app.contracts import StateUpdate
+
+
+# ---------------------------------------------------------------- from_snapshot
+
+
+def test_from_snapshot_maps_every_modelled_field():
+    """A value the snapshot supplies must reach the wire. Dropping one silently
+    flattens that dimension of affect for every downstream consumer."""
+    snapshot = {
+        "mood": 0.4,
+        "energy": 0.7,
+        "dominance": 0.6,
+        "trust": 0.8,
+        "attachment": 0.3,
+        "emotion": "happy",
+        "interaction_count": 5,
+        "cortisol": 0.2,
+        "dopamine": 0.5,
+        "fatigue": 0.1,
+        "user_mental_model": {"guess": "curious"},
+    }
+    dumped = StateUpdate.from_snapshot(snapshot).model_dump()
+    assert dumped == snapshot
+
+
+def test_a_missing_key_falls_back_to_the_model_default_not_a_literal():
+    """The whole point of the rewrite: defaults live on the model and nowhere
+    else. A snapshot taken before a field exists must still produce the model's
+    default for it, so the broadcast shape is stable across a partial state."""
+    dumped = StateUpdate.from_snapshot({"mood": 0.9}).model_dump()
+
+    assert dumped["mood"] == 0.9  # supplied value wins
+    # Every other field present, at the model's declared default.
+    assert dumped["energy"] == 0.5
+    assert dumped["emotion"] == "neutral"
+    assert dumped["interaction_count"] == 0
+    assert dumped["user_mental_model"] is None
+    assert set(dumped) == set(StateUpdate.model_fields)
+
+
+def test_snapshot_keys_outside_the_schema_are_dropped():
+    """`get_context_snapshot` also carries `valence`/`arousal`, which the
+    broadcast never included. Leaking them would change the wire payload and
+    hand consumers fields the contract does not promise."""
+    dumped = StateUpdate.from_snapshot(
+        {"mood": 0.1, "valence": 0.1, "arousal": 0.9, "junk": object()}
+    ).model_dump()
+    assert "valence" not in dumped
+    assert "arousal" not in dumped
+    assert "junk" not in dumped
+
+
+# ---------------------------------------------------------------- on the wire
+
+
+@pytest.fixture
+def mock_components():
+    state = MagicMock()
+    state.update_from_appraisal = AsyncMock()
+    state.update_theory_of_mind = AsyncMock()
+    state.get_context_snapshot = MagicMock()
+    state.get_behavioral_directive = MagicMock()
+
+    decision = MagicMock()
+    decision.decide = AsyncMock()
+    decision.is_speculative_stop_confirmed = MagicMock()
+
+    identity = MagicMock()
+    identity.validate_response = AsyncMock()
+
+    return {
+        "perception": AsyncMock(),
+        "appraisal": MagicMock(),
+        "state": state,
+        "decision": decision,
+        "action": MagicMock(),
+        "learning": AsyncMock(),
+        "identity": identity,
+    }
+
+
+@pytest.mark.asyncio
+async def test_the_pipeline_broadcasts_the_state_update_through_the_model(
+    mock_components,
+):
+    """End to end: the `state.update` the pipeline emits must be exactly what
+    `StateUpdate.from_snapshot` produces — the proof the model is load-bearing
+    rather than a shadow of a hand-written dict.
+
+    The snapshot here is deliberately partial (`mood` only), which is why this
+    catches a regression a fuller snapshot would not: it forces the model's
+    defaults to fill the other ten fields, so a broadcast built from a stray
+    literal with different defaults, or missing a field, would diverge here.
+    """
+    pipeline = CognitivePipeline(**mock_components)
+    mock_components["state"].last_speculative_intent = None
+    mock_components["perception"].perceive.return_value = MagicMock(
+        event_type="USER_MESSAGE",
+        raw_content="hello",
+        intent="CHAT",
+        event_id="evt-1",
+        metadata={},
+    )
+    mock_components["appraisal"].appraise.return_value = AppraisalVector(
+        relevance=1.0,
+        novelty=0.5,
+        goal_congruence=0.2,
+        agency=0.8,
+        norm_alignment=1.0,
+        relationship_impact=0.1,
+    )
+    snapshot = {"mood": 0.33, "cortisol": 0.7}
+    mock_components["state"].get_context_snapshot.return_value = snapshot
+    mock_components["state"].get_behavioral_directive.return_value = "be friendly"
+    mock_components["decision"].decide.return_value = ActionPlan(
+        action_type="RESPOND_CHAT", goal="GREET", payload={"message": "hi"}
+    )
+
+    async def mock_execute(plan):
+        yield {"type": "content", "data": "Hi there!"}
+        yield {"type": "done", "data": ""}
+
+    mock_components["action"].execute.side_effect = mock_execute
+    mock_components["identity"].validate_response.return_value = (True, "")
+    mock_components["identity"].get_persona_prompt.return_value = "System prompt"
+
+    broadcasts = [
+        chunk
+        async for chunk in pipeline.execute(
+            {"type": "USER_MESSAGE", "content": "hello"}
+        )
+        if chunk.get("subject") == "state.update"
+    ]
+
+    assert broadcasts, "pipeline emitted no state.update"
+    expected = StateUpdate.from_snapshot(snapshot).model_dump()
+    for chunk in broadcasts:
+        assert chunk["data"] == expected
+        # The supplied values survived; the rest are model defaults.
+        assert chunk["data"]["mood"] == 0.33
+        assert chunk["data"]["cortisol"] == 0.7
+        assert chunk["data"]["energy"] == 0.5
+        assert set(chunk["data"]) == set(StateUpdate.model_fields)


### PR DESCRIPTION
## The item, and why the obvious fix was wrong

`StateUpdate` was on the open list as a dead wire model — "no publisher in Python, Rust, or the frontend." The obvious move was to delete it. Reading the code first changed the fix.

`state.update` **is a live subject.** It carries two shapes:
- a lifecycle message from `BaseAgent.set_state` — `{agent, state, timestamp}`
- the full **affect broadcast** from `CognitivePipeline`, consumed by `SurfacingAgent._on_agent_state` to drive mood-congruent recall and APRA vocal modulation

The affect broadcast's fields are **exactly** `StateUpdate`'s — because the pipeline built them as an 11-field dict literal, **duplicated verbatim across its two publish sites**, while `StateUpdate` sat unused describing the same payload. Two definitions of one wire contract, and the model was the half nothing referenced.

So deleting the model removes a symbol and **leaves the duplication**. The real fix is the other direction.

## What changed

- Added `StateUpdate.from_snapshot(snapshot)` — pulls only modelled fields (so `valence`/`arousal`, which the snapshot also carries, stay dropped exactly as the literal dropped them) and lets the **model's own defaults** fill anything the snapshot omits.
- Both pipeline publish sites now emit `StateUpdate.from_snapshot(state_snapshot).model_dump()`.

The item is resolved by the model **gaining a publisher**, not by removal. Net **−22 lines** in `pipeline.py`.

## Safety

- **No non-Python consumer.** Grepped the Rust crates and the frontend for `state.update` and these affect fields — nothing. The sole consumer is `SurfacingAgent`, which duck-types with `.get(...)` defaults, so it tolerated the lifecycle shape before and is unaffected now.
- **Byte-identical output**, verified against the old literal for a populated snapshot (extras dropped), a partial snapshot, and an empty one. The model defaults were already equal to the literal's hardcoded defaults, field-for-field, so the wire bytes do not move.

## Tests

`tests/test_state_update_contract.py`: field mapping, default fallback from a partial snapshot, out-of-schema key dropping, and an **end-to-end pipeline test** asserting the emitted `state.update` equals `StateUpdate.from_snapshot(...)`. That test uses a deliberately partial snapshot (`mood`, `cortisol` only), forcing the model defaults to fill the other nine — which is what makes it catch a reverted or divergent literal.

700 tests pass (696 before), ruff clean. **4 mutations, 4 caught**: drop a field in `from_snapshot`; leak extras; a publish site reverting to a divergent literal; a changed model default.

## Not done

The lifecycle payload (`{agent, state, timestamp}`) is still unmodelled — a genuinely different message sharing the subject. Modelling it would mean a second contract or a union the duck-typing consumer doesn't need. The consumer reading affect fields with defaults is exactly what makes one subject carrying two shapes safe, and that's worth keeping simple.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of affect and state updates broadcast through `state.update` events.
  * Ensured partial state snapshots receive appropriate defaults.
  * Prevented unsupported or unexpected fields from appearing in state-update payloads.

* **Tests**
  * Added coverage verifying complete, partial, and empty state snapshots produce the expected broadcast data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->