### PR TITLE
Let the biography live outside the repo

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -5014,3 +5014,52 @@ files touched.
 **NOT done:** nothing else from the six was left partial. The other 19
 findings from the original audit remain fixed as of the previous
 re-verification; this entry only covers the six that weren't.
+
+## 2026-08-02 — A biography that can live outside the repo
+
+`PERSONA_PROFILE_PATH` has let an authored persona live anywhere since
+`config/persona.toml` landed. The biography never got the counterpart:
+`find_biography_file()` took an `explicit` argument that no caller ever
+supplied, and `core.py` called it bare, so the only readable location was the
+tracked `config/biography.md`.
+
+That is a worse constraint than it was for the persona, and for a reason
+specific to what the two files are. A persona is a temperament — bounded
+numbers and a tone — and living in the repo is defensible. A biography is an
+actual person's life, written by someone who knows them. Requiring it to sit at
+a tracked path means the only way to use the feature is to commit that material.
+
+`BIOGRAPHY_PATH` (`Config`) is now consulted by `find_biography_file()` when no
+explicit argument is given, so nothing else had to change: `core.py`,
+`seed_biography_once` and the scripts all keep their existing signatures and
+pick the setting up for free.
+
+**A set-but-missing path resolves to "no biography" and is deliberately not
+retried through discovery.** The silent fallback is the dangerous branch here,
+more so than for the persona: seeding is fingerprinted and effectively one-way,
+so a typo'd path would plant the shipped *example* person's history in a real
+agent's memory, which then has to be pruned back out passage by passage. It
+warns instead, matching what `IdentityManager` already does for a missing
+persona file.
+
+An explicit argument still beats the setting, so callers that pass a path mean
+it and deployment config cannot override them.
+
+`test_the_shipped_biography_parses` gained a fixture neutralising an ambient
+`BIOGRAPHY_PATH`; it asserts that *discovery* finds the shipped file, and would
+otherwise fail on any machine with the setting exported. No conftest-wide
+isolation was added (unlike `PERSONA_PROFILE_PATH`), precisely because that test
+needs real discovery to work.
+
+**Verified**: 4 new tests; all three mutations caught (ignore the setting, fall
+back to discovery on a missing path, let the setting beat an explicit
+argument). Full backend suite via junit-xml: 708 passed, 0
+failed/errored/skipped. `ruff check .` clean. Also confirmed end to end that
+`BIOGRAPHY_PATH` pointing outside the repo resolves and parses.
+
+**NOT done:** `parse_biography` still mis-nests sibling headings when a file has
+no top-level `#` — `heading_trail = [h for h in heading_trail if h]` compacts
+the trail and destroys depth alignment, so section two is filed as "Section One
+/ Section Two" and every memory carries the first section's name. Real bug,
+separate change. `.env.example` was not touched: it documents no persona paths
+either, so adding only this one would be inconsistent.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -55,6 +55,11 @@ class AppSettings(BaseSettings):
     # A user-authored persona (see app/persona/profile.py). Unset means "use the
     # PSYCH_* / AI_NAME defaults below", which is exactly the previous behaviour.
     PERSONA_PROFILE_PATH: str | None = None
+    # The authored biography (see app/persona/biography.py). Unset means "walk
+    # up for config/biography.md", the historical behaviour. Set, it can point
+    # anywhere — which is the point: a biography is a real person's life, and
+    # keeping it out of the repo should not require a code change.
+    BIOGRAPHY_PATH: str | None = None
     # Where `personality.json`/`history.json` live. Unset means "beside the
     # code", which is the historical behaviour and fine for a normal deployment
     # — but it makes the package directory writable state, so anything that

--- a/backend/app/persona/biography.py
+++ b/backend/app/persona/biography.py
@@ -33,6 +33,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from ..config import Config
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_BIOGRAPHY_FILE = "config/biography.md"
@@ -151,15 +153,37 @@ def read_biography(path: Path | None) -> list[BiographyEntry]:
 
 
 def find_biography_file(explicit: str | None = None) -> Path | None:
-    """Locate `config/biography.md`, walking up from this module.
+    """Locate the biography: an explicit path, then `BIOGRAPHY_PATH`, then discovery.
 
-    Same reasoning as the persona file: the agents are launched from the repo
-    root, from `backend/`, and from a container WORKDIR, so a path relative to
-    the process working directory resolves differently in each.
+    Discovery walks up from this module rather than trusting the process working
+    directory, because the agents are launched from several places (the repo
+    root, `backend/`, and a container WORKDIR) and a relative path would resolve
+    differently in each.
+
+    `BIOGRAPHY_PATH` is the counterpart to `PERSONA_PROFILE_PATH`, and exists
+    for the same reason plus a sharper one. The persona is a temperament and
+    could reasonably live in the repo; a biography is an actual person's life,
+    written by someone who knows them, and a system that can only read it from
+    a tracked path forces that material into git to be used at all.
+
+    A path that is set but missing resolves to "no biography" and is *not*
+    retried through discovery. Falling back would quietly seed the repo's own
+    example file — and seeding is fingerprinted and effectively one-way, so a
+    typo would plant a stranger's history that then has to be pruned back out.
     """
+    if explicit is None:
+        explicit = getattr(Config, "BIOGRAPHY_PATH", None) or None
+
     if explicit:
         path = Path(explicit)
-        return path if path.exists() else None
+        if path.exists():
+            return path
+        logger.warning(
+            "[Biography] No biography file at %s; continuing without one. "
+            "Discovery is deliberately not attempted for an explicit path.",
+            explicit,
+        )
+        return None
 
     for parent in Path(__file__).resolve().parents:
         candidate = parent / DEFAULT_BIOGRAPHY_FILE

--- a/backend/tests/test_biography_seeding.py
+++ b/backend/tests/test_biography_seeding.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from app import config as config_module
 from app.persona.biography import (
     BIOGRAPHY_SOURCE,
     BiographyEntry,
@@ -229,8 +230,66 @@ async def test_no_memory_store_is_not_an_error():
 # --------------------------------------------------------------------------
 
 
-def test_the_shipped_biography_parses():
+def test_the_shipped_biography_parses(no_biography_setting):
     """The example a user starts from must survive its own parser."""
     found = find_biography_file()
     assert found is not None and found.name == "biography.md"
     assert read_biography(found), "the shipped biography produced no passages"
+
+
+# --------------------------------------------------------------------------
+# locating the file
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def no_biography_setting(monkeypatch):
+    """Neutralise an ambient BIOGRAPHY_PATH so discovery is what is tested."""
+    monkeypatch.setattr(config_module.config_instance, "BIOGRAPHY_PATH", None)
+
+
+def test_biography_path_setting_overrides_discovery(monkeypatch, tmp_path):
+    """A biography is a real person's life; it must be storable outside the repo.
+
+    Without this the only readable location is the tracked `config/biography.md`,
+    which forces that material into git in order to be used at all.
+    """
+    external = tmp_path / "elsewhere.md"
+    external.write_text("# Her\n\nShe is real.\n", encoding="utf-8")
+    monkeypatch.setattr(
+        config_module.config_instance, "BIOGRAPHY_PATH", str(external)
+    )
+    assert find_biography_file() == external
+
+
+def test_a_missing_biography_path_does_not_fall_back_to_the_shipped_file(
+    monkeypatch, tmp_path
+):
+    """A typo'd path must mean "no biography", never "the repo's example".
+
+    Seeding is fingerprinted and effectively one-way, so a silent fallback
+    would plant the shipped example person's history in a real agent's memory,
+    which then has to be pruned back out passage by passage.
+    """
+    monkeypatch.setattr(
+        config_module.config_instance,
+        "BIOGRAPHY_PATH",
+        str(tmp_path / "typo.md"),
+    )
+    assert find_biography_file() is None
+
+
+def test_an_explicit_argument_beats_the_setting(monkeypatch, tmp_path):
+    """Callers that pass a path mean it -- deployment config must not win."""
+    wanted = tmp_path / "wanted.md"
+    wanted.write_text("# Her\n\nThis one.\n", encoding="utf-8")
+    other = tmp_path / "other.md"
+    other.write_text("# Her\n\nNot this one.\n", encoding="utf-8")
+    monkeypatch.setattr(config_module.config_instance, "BIOGRAPHY_PATH", str(other))
+    assert find_biography_file(str(wanted)) == wanted
+
+
+def test_discovery_still_works_when_the_setting_is_unset(no_biography_setting):
+    """The historical behaviour is the default; the setting is opt-in."""
+    found = find_biography_file()
+    assert found is not None and found.name == "biography.md"


### PR DESCRIPTION
## Why

`PERSONA_PROFILE_PATH` has let an authored persona live anywhere since `config/persona.toml` landed. The biography never got the counterpart: `find_biography_file()` took an `explicit` argument that no caller ever supplied, and `core.py` called it bare — so the only readable location was the tracked `config/biography.md`.

That constraint is worse here than it was for the persona. A persona is a temperament, bounded numbers and a tone, and living in the repo is defensible. A biography is an actual person's life, written by someone who knows them. Requiring a tracked path means the only way to use the feature at all is to commit that material.

## What changed

`BIOGRAPHY_PATH` (`Config`) is consulted by `find_biography_file()` when no explicit argument is given. Nothing else needed touching — `core.py`, `seed_biography_once` and the scripts keep their signatures and pick it up for free.

**A set-but-missing path resolves to "no biography" and is deliberately not retried through discovery.** That fallback is the dangerous branch: seeding is fingerprinted and effectively one-way, so a typo'd path would plant the shipped *example* person's history into a real agent's memory, to be pruned back out passage by passage afterwards. It warns instead, matching what `IdentityManager` already does for a missing persona file.

An explicit argument still beats the setting, so callers that pass a path mean it and deployment config cannot override them.

`test_the_shipped_biography_parses` gained a fixture neutralising an ambient `BIOGRAPHY_PATH` — it asserts that *discovery* finds the shipped file, and would otherwise fail on any machine with the setting exported. No conftest-wide isolation was added (unlike `PERSONA_PROFILE_PATH`) precisely because that test needs real discovery.

## Verification

- 4 new tests; all three mutations caught (ignore the setting; fall back to discovery on a missing path; let the setting beat an explicit argument).
- Full backend suite via junit-xml: **708 passed, 0 failed/errored/skipped**.
- `ruff check .` clean.
- Confirmed end to end that a path outside the repo resolves and parses.

## Not done

`parse_biography` still mis-nests sibling headings when a file has no top-level `#`: `heading_trail = [h for h in heading_trail if h]` compacts the trail and destroys depth alignment, so section two files as "Section One / Section Two" and every memory carries the first section's name. Real bug, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring an external biography file location.
  * Explicitly provided biography paths take precedence over configured settings.
  * When no location is configured, the application continues using the default biography file.

* **Bug Fixes**
  * Missing configured or explicitly provided biography files now produce a warning and do not unexpectedly fall back to the packaged example.

* **Tests**
  * Added coverage for external biography files, path precedence, missing files, and default discovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->