### PR TITLE
Stop the agent inventing its own biography

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -5014,3 +5014,82 @@ files touched.
 **NOT done:** nothing else from the six was left partial. The other 19
 findings from the original audit remain fixed as of the previous
 re-verification; this entry only covers the six that weren't.
+
+## 2026-08-02 — The grounding gate only ever protected the user's facts
+
+`ActionService._check_response_grounding` has caught fabricated *shared*
+memories since it landed: `_MEMORY_CLAIM_RE` matches "you told me…", "you used
+to", "remember when we…", and rejects the response if the claim's substantive
+words appear in neither the surfaced memories nor the user's message.
+
+Reading it while wiring up biography seeding made the asymmetry obvious. Every
+pattern in that regex is second-person. Nothing looked at what the agent said
+about *itself*. Ask it about a sibling it was never told about and it invents
+one — fluently, in the persona's voice, indistinguishable from a passage the
+user actually wrote. For an agent whose entire premise is being a *particular*
+person, that is the worst-shaped failure available: a blank can be filled in,
+but a confident fabrication has to be noticed first, and nothing surfaces it.
+
+**The gate.** `_SELF_CLAIM_RE` is the mirror image — first-person assertions of
+concrete biographical fact (`my brother`, `i grew up`, `i studied`, `when i was
+a child`). Feelings, opinions and preferences are deliberately out of scope.
+
+The rule for what counts as fabricated is *not* the same as the user-facing
+one, and the difference is the whole design. That gate fires on two unsupported
+words, which is right for a long attributed claim and catastrophic here: "my
+family means everything to me" contains two unsupported words and invents
+nothing. This gate fires only on **ungrounded proper nouns and 3+ digit
+numbers** inside a self-claim — names, places, institutions, years, which is
+where self-invention actually lives. The known cost is a lowercased fabricated
+name ("my brother rahul") slipping through; precision was worth more, because a
+gate that misfires on ordinary speech forces a regeneration, costs latency and
+fires a cortisol burst every time.
+
+**Grounding against the biography, not the turn.** The obvious implementation —
+check self-claims against the surfaced memories, like the user gate does — is
+wrong. Retrieval returns what is relevant to the conversation, so a true
+sentence about her brother would be rejected on every turn where the family
+passage did not happen to surface. `SelfKnowledgeStore` caches the vocabulary of
+all `source='biography'` memories instead. Conversational memories are excluded
+on purpose: they are things the *user* said, and letting them ground
+autobiography would mean one hallucinated detail that reached the store becomes
+the evidence for the next — the gate ratifying its own escapes.
+
+The agent's own name is seeded explicitly, because a biography written in the
+third person ("she talks calmly…") never contains it.
+
+**Gaps are recorded, not discarded.** `self_knowledge_gaps` (both backends)
+keys on the term so repeated hits accumulate: a name that comes up constantly
+and is never grounded outranks a one-off. There is no `resolved` flag — a gap
+the biography now covers simply stops being hit. Nothing reads the table
+automatically yet; it exists so the agent can eventually raise these itself.
+
+**Composition over new call sites.** The original method body became
+`_check_user_memory_grounding` and `_check_response_grounding` now runs both
+gates in sequence, so the post-generation check and both retry checks in
+`_stream_self_correction` gained the new gate without the retry path growing a
+second branch.
+
+**Behaviour when it fires**: the self-correction prompt tells the agent to say
+plainly that it does not know and let the subject go — explicitly *not* to ask
+the user to fill the gap. Confirmed with the maintainer rather than assumed;
+the asking behaviour is a separate decision and the table is the substrate for
+it when it comes.
+
+**Verified**: 26 new tests, all six planned mutations caught. The first pass
+had one survivor — nothing covered the filter that stops a capitalised common
+noun ("My School was strict") reading as a name — so two tests were added and
+the mutation re-run to confirm they catch it. Full backend suite via junit-xml:
+730 passed, 0 failed/errored/skipped. `ruff check .` clean.
+
+**NOT done:** the gate is a backstop, not the mechanism — the prompt guideline
+does the real work, and a lowercase fabricated name still passes. Nothing reads
+`self_knowledge_gaps` yet. `find_biography_file()` still hardcodes a walk to
+`config/biography.md` with no env-var override, so a biography kept outside the
+repo cannot be pointed at without a code change; `PERSONA_PROFILE_PATH` already
+solved exactly this for the persona and the same fix applies. Separately,
+`parse_biography` mis-nests sibling headings when a file has no top-level `#`:
+`heading_trail = [h for h in heading_trail if h]` compacts the trail and
+destroys depth alignment, so section two is filed as "Section One / Section
+Two" and every memory carries the first section's name. Both are real bugs,
+both out of scope here.

--- a/backend/app/cognitive/action.py
+++ b/backend/app/cognitive/action.py
@@ -55,6 +55,57 @@ _GROUNDING_STOPWORDS = frozenset(
     }
 )
 
+# The mirror of _MEMORY_CLAIM_RE, pointed the other way. That gate protects the
+# *user's* facts; nothing protected the agent's own, so a model asked about a
+# sibling it was never told about would invent one -- fluently, in character,
+# and indistinguishable from a real memory. For an agent built to be a
+# particular person, a confident fabrication about itself is worse than a blank:
+# the blank can be filled in, the fabrication has to be noticed first.
+#
+# Restricted to assertions of concrete biographical *fact* -- family, origin,
+# schooling, where it lived. Feelings, opinions and preferences are deliberately
+# out of scope: they come up constantly in ordinary talk, and gating them buys a
+# little fidelity at the cost of making the agent evasive about everything.
+_SELF_CLAIM_RE = re.compile(
+    r"\b("
+    r"my (?:brother|sister|siblings?|mother|father|mom|mum|dad|papa|mama"
+    r"|parents?|family|cousin|uncle|aunt|grand(?:mother|father)"
+    r"|school|college|university|hometown|village|neighbou?rhood"
+    r"|roommate|classmate|childhood)"
+    r"|i (?:grew up|was born|studied|graduated)"
+    r"|i (?:live|lived|moved) (?:in|to|at)"
+    r"|i used to live"
+    r"|i come from"
+    r"|when i was (?:a |an |in |at )?(?:child|kid|little|young|\d+)"
+    r")\b",
+    re.IGNORECASE,
+)
+
+# Dropped before deciding whether a self-claim is grounded. These are the
+# trigger words themselves: "brother" appearing in "my brother Harshit" is what
+# fired the gate, so counting it as evidence of fabrication would make every
+# claim self-incriminating. What matters is the name next to it.
+_SELF_CLAIM_STOPWORDS = frozenset(
+    {
+        "brother", "sister", "siblings", "mother", "father", "mom", "mum",
+        "dad", "papa", "mama", "parent", "parents", "family", "cousin",
+        "uncle", "aunt", "grandmother", "grandfather", "school", "college",
+        "university", "hometown", "village", "neighborhood", "neighbourhood",
+        "roommate", "classmate", "childhood", "grew", "born", "studied",
+        "graduated", "live", "lived", "moved", "come", "child", "kid",
+        "little", "young", "name", "years", "year", "old",
+    }
+)
+
+# Capitalised words that carry no identifying weight, so they are not treated as
+# proper nouns when they open a clause or stand alone.
+_NON_NAME_CAPITALS = frozenset({"i", "i'm", "i've", "oh", "yeah", "haan", "arre"})
+
+# What counts as a "specific" in a self-claim: a capitalised word that is not
+# sentence-initial (a name, a place, an institution) or a number long enough to
+# be a year rather than an age or a count.
+_SELF_SPECIFIC_RE = re.compile(r"\b([A-Z][A-Za-z']{2,}|\d{3,})\b")
+
 
 # Static half of the chat system prompt, appended after the identity block.
 # Hoisted out of execute() so the prompt contract is visible at module scope
@@ -72,6 +123,11 @@ _CHAT_GUIDELINE = (
     "CONTEXT provided. Do not invent memories or details that are not there. "
     "If the user asks about something you have no memory of, say so naturally "
     '(e.g. "I don\'t think you\'ve told me that") instead of making it up.\n'
+    "- SELF-GROUNDING: Everything you know about your own life comes from your "
+    "biography and from this conversation. Never invent family members, "
+    "places, schools, jobs or dates for yourself. If you are asked something "
+    "about your own past that you do not know, say so plainly in your own "
+    "voice and let it go -- do not guess, and do not ask the user to tell you.\n"
     "- Respond only in English. Do not use Hindi, Hinglish, or any other "
     "language for now.\n"
     "- The voice layer already carries emotion separately. Do not emit XML "
@@ -208,12 +264,16 @@ class ActionService:
     Enforces the Identity Protocol in LLM generations.
     """
 
-    def __init__(self, llm_service=None, memory_store=None):
+    def __init__(self, llm_service=None, memory_store=None, self_knowledge=None):
         self.llm = llm_service
         self.memory = memory_store
+        # Optional, like publish_cb. Absent, the self-grounding gate still runs
+        # against surfaced memories and the user's message -- it simply has a
+        # smaller vocabulary to count as grounded, and records no gaps.
+        self.self_knowledge = self_knowledge
         self.publish_cb = None
 
-    def _check_response_grounding(
+    def _check_user_memory_grounding(
         self, response: str, surfaced, user_message: str
     ) -> tuple[bool, str]:
         """Deterministic anti-hallucination gate for fabricated shared memories.
@@ -255,6 +315,88 @@ class ActionService:
                     "reference facts present in SHARED HISTORY."),
                 )
         return True, ""
+
+    def _self_claim_gaps(self, response: str, surfaced, user_message: str) -> list[str]:
+        """Specifics the response asserts about the agent's own life, ungrounded.
+
+        Fires only on *proper nouns and numbers* inside a biographical
+        self-claim -- invented siblings, hometowns, institutions, years. That is
+        narrower than the user-directed gate's "two unsupported words" rule, and
+        deliberately so: "my family means everything to me" contains two
+        unsupported words and is not a fabrication of anything. Names and dates
+        are where self-invention actually lives, and restricting the gate to
+        them is what keeps the agent warm rather than evasive.
+
+        The known cost is a lowercased fabricated name -- "my brother rahul" --
+        passing through. Precision is worth more here: a gate that misfires on
+        ordinary speech forces a regeneration, costs latency, and fires a
+        cortisol burst every time.
+
+        Grounding is checked against the biography's whole vocabulary, not just
+        the memories surfaced this turn. Retrieval returns what is relevant to
+        the conversation, so grounding against it alone would reject true
+        statements whenever the relevant passage happened not to surface.
+        """
+        if not response or not _SELF_CLAIM_RE.search(response):
+            return []
+
+        grounding_text = " ".join(
+            (m.get("content") or "") for m in (surfaced or [])
+        )
+        grounding_text = f"{grounding_text} {user_message or ''}".lower()
+        grounded = set(re.findall(r"\b[a-z0-9']{3,}\b", grounding_text))
+        grounded |= getattr(self.self_knowledge, "known_terms", None) or set()
+
+        gaps: list[str] = []
+        for raw_sentence in re.split(r"(?<=[.!?])\s+", response):
+            sentence = raw_sentence.strip()
+            if not _SELF_CLAIM_RE.search(sentence):
+                continue
+            for match in _SELF_SPECIFIC_RE.finditer(sentence):
+                # A capital in the first position is sentence case, not a name.
+                if match.start() == 0:
+                    continue
+                token = match.group(1).lower()
+                if token in _NON_NAME_CAPITALS or token in _SELF_CLAIM_STOPWORDS:
+                    continue
+                if token not in grounded:
+                    gaps.append(token)
+        return gaps
+
+    def _check_self_grounding(
+        self, response: str, surfaced, user_message: str
+    ) -> tuple[bool, str]:
+        """Reject a response that invents concrete facts about the agent itself."""
+        if not self._self_claim_gaps(response, surfaced, user_message):
+            return True, ""
+        return (
+            False,
+            (
+                "You stated a specific detail about your own life -- a name, "
+                "place, institution or date -- that appears nowhere in your "
+                "biography or in this conversation. Never invent family "
+                "members, places or events for yourself. If you do not know "
+                "something about your own past, say so plainly in your own "
+                "voice and let the subject go; do not ask the user to fill "
+                "it in."
+            ),
+        )
+
+    def _check_response_grounding(
+        self, response: str, surfaced, user_message: str
+    ) -> tuple[bool, str]:
+        """Both grounding gates: the user's past, then the agent's own.
+
+        Composed under the original name so every existing call site -- the
+        post-generation check and both retry checks -- gains the self gate
+        without the retry path having to grow a second branch.
+        """
+        is_grounded, reason = self._check_user_memory_grounding(
+            response, surfaced, user_message
+        )
+        if not is_grounded:
+            return is_grounded, reason
+        return self._check_self_grounding(response, surfaced, user_message)
 
     def _validate_partial_response(self, text: str, goal: str) -> tuple[bool, str]:
         stripped = text.strip()
@@ -616,9 +758,28 @@ class ActionService:
             state.accumulated_response, surfaced, msg
         )
         if not is_grounded:
+            await self._record_self_gaps(state.accumulated_response, surfaced, msg)
             raise MetacognitiveException(ground_reason)
 
         yield {"type": "done", "data": "finished"}
+
+    async def _record_self_gaps(self, response: str, surfaced, user_message: str):
+        """Note what the agent did not know about itself, and carry on.
+
+        Only reached when the composite gate has already failed, so re-deriving
+        the terms costs one regex pass on a response that is being thrown away
+        regardless. Recording is best-effort: the turn has already been stopped
+        from lying, and losing the note is far cheaper than raising here.
+        """
+        if self.self_knowledge is None:
+            return
+        gaps = self._self_claim_gaps(response, surfaced, user_message)
+        if not gaps:
+            return
+        try:
+            await self.self_knowledge.record_gap(gaps, user_message)
+        except Exception as e:
+            logger.debug(f"[Action] Could not record self-knowledge gap: {e}")
 
     async def _announce_self_correction(self, reason: str):
         """Interrupt playback so the retry is not spoken over the bad take."""

--- a/backend/app/cognitive/core.py
+++ b/backend/app/cognitive/core.py
@@ -22,6 +22,7 @@ from ..persona.biography import (
 )
 from ..persona.history_migration import migrate_history_memories
 from ..state import StateService
+from ..state.self_knowledge_store import SelfKnowledgeStore
 from .action import ActionService
 from .appraisal import AppraisalEngine, AppraisalVector
 from .decision import DecisionService
@@ -68,7 +69,19 @@ class CognitiveService:
         self.decision = DecisionService(
             llm_service=llm_service, memory_store=memory_store
         )
-        self.action = ActionService(llm_service=llm_service, memory_store=memory_store)
+        # The agent's own name is seeded explicitly: a biography written in the
+        # third person ("she talks calmly…") never contains it, so without this
+        # the grounding gate would treat the agent stating its own name as an
+        # ungrounded claim.
+        self.self_knowledge = SelfKnowledgeStore(
+            pool=getattr(memory_store, "pool", None),
+            seed_terms={self.identity.persona.name},
+        )
+        self.action = ActionService(
+            llm_service=llm_service,
+            memory_store=memory_store,
+            self_knowledge=self.self_knowledge,
+        )
         self.learning = ReflectionService(
             llm_service=llm_service,
             graph_store=graph_db,
@@ -234,6 +247,11 @@ class CognitiveService:
         # After the biography, so a first boot writes the authored history
         # before anything reflection has since added on top of it.
         await self.migrate_history_once()
+
+        # After seeding, so the grounding vocabulary includes the passages that
+        # were just written. Loading it before would leave the agent unable to
+        # ground its own life on the very boot that gave it one.
+        await self.self_knowledge.refresh_known_terms()
 
         # Initialize appraisal engine with identity boundaries
         boundaries = self.identity.personality.get("boundaries", [])

--- a/backend/app/state/self_knowledge_store.py
+++ b/backend/app/state/self_knowledge_store.py
@@ -1,0 +1,194 @@
+"""SelfKnowledgeStore -- what the agent knows, and does not know, about itself.
+
+The existing grounding gate in ``ActionService`` protects the *user's* facts: it
+catches "you told me…" and "remember when we…" claims whose content appears
+nowhere in context. It has no counterpart for the agent's own life, so an LLM
+asked about a sibling it has never been told about will invent one, fluently and
+in character. For an agent whose whole point is to be a *particular* person that
+is the worst available failure: a confident fabrication is much harder to notice
+and undo than a blank.
+
+This store supplies the two things that gate needs.
+
+**Known terms.** The vocabulary of the agent's seeded biography, loaded once and
+cached. Grounding a self-claim only against the handful of memories surfaced
+*this turn* would reject true statements whenever the relevant passage happened
+not to surface -- retrieval returns what is relevant to the conversation, not
+everything the agent knows. Checking against the biography's whole vocabulary
+instead means the agent can talk freely about its real life and is stopped only
+on specifics that appear nowhere the user ever wrote.
+
+**Gaps.** When the gate does fire, the unsupported specifics are recorded rather
+than discarded. Those terms are the map of what the biography is still missing,
+ordered by how often they actually come up. Nothing reads them automatically
+yet; they are the substrate for the agent eventually raising them itself.
+
+Storage follows ``MentalLexicon``: dialect-neutral SQL with ``$n`` placeholders
+and ``ON CONFLICT`` upserts, which run natively on Postgres and are translated
+for SQLite by ``SQLiteConnection._translate_query``. Every operation is
+best-effort -- a store that is unreachable degrades the gate to surfaced-memory
+grounding, and must never break a turn.
+"""
+
+import asyncio
+import logging
+import re
+
+logger = logging.getLogger("self_knowledge_store")
+
+# Matches the tokenisation the grounding gate uses, so a term counted as
+# "unsupported" there is looked up in exactly the form stored here.
+_WORD_RE = re.compile(r"\b[a-z0-9']{3,}\b")
+
+# The biography is prose about a person, so its vocabulary is dominated by
+# ordinary English. That is harmless: extra grounding terms only ever make the
+# gate *more* permissive, and the gate's real precision comes from requiring
+# several unsupported specifics rather than from this set being tight.
+_MAX_KNOWN_TERMS = 20000
+
+# How many gap terms one failed response may record. A single fabricated
+# sentence should not be able to flood the table.
+_MAX_GAPS_PER_HIT = 8
+
+
+class SelfKnowledgeStore:
+    """Biography vocabulary cache plus a record of ungrounded self-claims."""
+
+    def __init__(self, pool, seed_terms: set[str] | None = None):
+        self.pool = pool
+        # Terms true of the agent regardless of what the biography says -- its
+        # own name, most obviously, which a biography written in the third
+        # person ("she talks calmly…") never actually contains.
+        self._seed_terms = {t.lower() for t in (seed_terms or set())}
+        self._known_terms: set[str] = set(self._seed_terms)
+        self._ready = False
+        self._init_lock = asyncio.Lock()
+
+    @property
+    def known_terms(self) -> set[str]:
+        """Biography vocabulary, for the grounding gate to read synchronously.
+
+        Returns the live set rather than a copy: this is read once per gated
+        response and copying twenty thousand strings on that path would cost
+        more than the check it feeds.
+        """
+        return self._known_terms
+
+    # ---- schema ------------------------------------------------------------
+
+    async def _ensure_ready(self):
+        """Idempotently create the table. Never raises."""
+        if self._ready:
+            return
+        async with self._init_lock:
+            if self._ready:
+                return
+            try:
+                async with self.pool.acquire() as conn:
+                    await conn.execute(
+                        "CREATE TABLE IF NOT EXISTS self_knowledge_gaps ("
+                        "term text PRIMARY KEY, "
+                        "times_hit integer NOT NULL DEFAULT 1, "
+                        "example_prompt text, "
+                        "first_seen timestamp DEFAULT current_timestamp, "
+                        "last_seen timestamp DEFAULT current_timestamp)"
+                    )
+                self._ready = True
+            except Exception as e:
+                logger.debug(f"SelfKnowledgeStore not ready ({e}); gaps not recorded")
+
+    # ---- known terms -------------------------------------------------------
+
+    async def refresh_known_terms(self) -> int:
+        """Reload the biography vocabulary into the cache. Returns term count.
+
+        Reads only ``source = 'biography'`` rows. Ordinary conversational
+        memories are deliberately excluded: they are things the *user* said,
+        and grounding the agent's autobiography in its own past chatter would
+        let one hallucinated detail become the evidence for the next.
+        """
+        if self.pool is None:
+            return len(self._known_terms)
+        try:
+            async with self.pool.acquire() as conn:
+                rows = await conn.fetch(
+                    "SELECT content FROM memories WHERE source = $1", "biography"
+                )
+        except Exception as e:
+            logger.debug(f"Could not refresh self-knowledge terms ({e})")
+            return len(self._known_terms)
+
+        terms = set(self._seed_terms)
+        for row in rows or ():
+            content = dict(row).get("content") or ""
+            terms.update(_WORD_RE.findall(content.lower()))
+            if len(terms) >= _MAX_KNOWN_TERMS:
+                break
+
+        self._known_terms = terms
+        logger.info(
+            "[SelfKnowledge] %d biography term(s) available for grounding.",
+            len(terms),
+        )
+        return len(terms)
+
+    # ---- gaps --------------------------------------------------------------
+
+    async def record_gap(self, terms, example_prompt: str = "") -> int:
+        """Record specifics the agent could not ground about itself.
+
+        Returns the number of terms written. Best-effort throughout: a gap that
+        fails to persist is a lost note, while an exception here would abort a
+        turn that has already been correctly stopped from lying.
+        """
+        await self._ensure_ready()
+        if not self._ready or not terms:
+            return 0
+
+        # Sorted so the cap is deterministic rather than set-iteration order --
+        # a test asserting which terms survived should not depend on hashing.
+        selected = sorted({str(t).lower() for t in terms if t})[:_MAX_GAPS_PER_HIT]
+        snippet = (example_prompt or "")[:500]
+
+        written = 0
+        try:
+            async with self.pool.acquire() as conn:
+                for term in selected:
+                    await conn.execute(
+                        "INSERT INTO self_knowledge_gaps "
+                        "(term, times_hit, example_prompt, first_seen, last_seen) "
+                        "VALUES ($1, 1, $2, current_timestamp, current_timestamp) "
+                        "ON CONFLICT (term) DO UPDATE SET "
+                        "times_hit = self_knowledge_gaps.times_hit + 1, "
+                        "last_seen = current_timestamp",
+                        term,
+                        snippet,
+                    )
+                    written += 1
+        except Exception as e:
+            logger.debug(f"Could not record self-knowledge gap ({e})")
+
+        if written:
+            logger.info(
+                "[SelfKnowledge] Recorded %d ungrounded self-claim term(s): %s",
+                written,
+                ", ".join(selected[:5]),
+            )
+        return written
+
+    async def top_gaps(self, limit: int = 20) -> list[dict]:
+        """The most frequently hit gaps, for inspection and for later asking."""
+        await self._ensure_ready()
+        if not self._ready:
+            return []
+        try:
+            async with self.pool.acquire() as conn:
+                rows = await conn.fetch(
+                    "SELECT term, times_hit, example_prompt, last_seen "
+                    "FROM self_knowledge_gaps ORDER BY times_hit DESC LIMIT $1",
+                    int(limit),
+                )
+            return [dict(r) for r in rows or ()]
+        except Exception as e:
+            logger.debug(f"Could not read self-knowledge gaps ({e})")
+            return []

--- a/backend/app/state/sqlite_fallback.py
+++ b/backend/app/state/sqlite_fallback.py
@@ -151,6 +151,22 @@ class SQLiteConnection:
             "CREATE INDEX IF NOT EXISTS lexical_assoc_b_idx ON lexical_associations(term_b)"
         )
 
+        # Specifics the agent tried to assert about its own life but could not
+        # ground in the biography, the surfaced memories or the user's message.
+        # Keyed on the term so repeated hits accumulate.
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS self_knowledge_gaps (
+                term TEXT PRIMARY KEY,
+                times_hit INTEGER NOT NULL DEFAULT 1,
+                example_prompt TEXT,
+                first_seen TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                last_seen TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        cursor.execute(
+            "CREATE INDEX IF NOT EXISTS self_gap_hits_idx ON self_knowledge_gaps(times_hit DESC)"
+        )
+
         # Migration for existing memories table to add developmental stage columns
         cursor.execute("PRAGMA table_info(memories)")
         existing_mem_cols = {row[1] for row in cursor.fetchall()}

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -237,3 +237,22 @@ create table if not exists lexical_associations (
 
 create index if not exists lexical_assoc_a_idx on lexical_associations(term_a);
 create index if not exists lexical_assoc_b_idx on lexical_associations(term_b);
+
+-- Self-knowledge gaps: specifics the agent tried to assert about its own life
+-- and could not ground in anything the user has written or said. Recorded
+-- rather than silently swallowed, because the gaps are the map of what the
+-- biography is still missing -- and, later, of what the agent could ask about.
+--
+-- Keyed on the term so repeated hits accumulate: a name the user mentions
+-- constantly but never explained climbs times_hit, while a one-off stays low.
+-- There is deliberately no `resolved` flag; a gap the biography now covers
+-- simply stops being hit, and last_seen already carries that.
+create table if not exists self_knowledge_gaps (
+  term text primary key,
+  times_hit integer not null default 1,
+  example_prompt text,
+  first_seen timestamptz default now(),
+  last_seen timestamptz default now()
+);
+
+create index if not exists self_gap_hits_idx on self_knowledge_gaps(times_hit desc);

--- a/backend/tests/test_self_knowledge_grounding.py
+++ b/backend/tests/test_self_knowledge_grounding.py
@@ -1,0 +1,298 @@
+"""Tests for the self-directed grounding gate and the gap record behind it.
+
+The pre-existing gate protects the *user's* facts ("you told me…"). This one is
+its mirror: it stops the agent inventing concrete details about its own life --
+siblings, hometowns, institutions, years -- that appear nowhere in its biography
+or in the conversation.
+
+Two failure directions matter, and they pull against each other. Letting a
+fabrication through gives the user a confident false memory of a real person,
+which is far harder to notice and undo than a blank. Firing on ordinary speech
+makes the agent evasive about its own life, forces a regeneration, and costs a
+cortisol burst every time. Most of these tests guard the second direction,
+because that is the one a naive implementation gets wrong.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.cognitive.action import ActionService
+from app.state.conversation_store import ConversationHistoryStore
+from app.state.self_knowledge_store import SelfKnowledgeStore
+
+# Stands in for a seeded biography. Deliberately small: the gate must work from
+# whatever the user actually wrote, not from a rich world model.
+BIOGRAPHY_TERMS = {
+    "harshit", "rohit", "anjali", "punjab", "lpu", "saha", "pallavi",
+    "brother", "married", "december", "2025", "joint", "family",
+}
+
+
+@pytest.fixture
+def agent():
+    store = MagicMock()
+    store.known_terms = BIOGRAPHY_TERMS
+    return ActionService(self_knowledge=store)
+
+
+@pytest.fixture
+def ungrounded_agent():
+    """An agent with no biography at all -- the cold-start case."""
+    return ActionService()
+
+
+@pytest.fixture
+async def gap_store():
+    store = ConversationHistoryStore()
+    store.dsn = "sqlite:///:memory:"  # isolated per test; no shared app.db state
+    await store.initialize()
+    yield SelfKnowledgeStore(store.pool)
+    await store.close()
+
+
+class TestFabricationIsCaught:
+    def test_invented_sibling_name_is_rejected(self, agent):
+        """A brother the user never mentioned must not become part of her past.
+
+        This is the whole point of the gate. An LLM asked about family will
+        supply one, in character and without hedging, and the user has no way
+        to tell it apart from a passage they wrote themselves.
+        """
+        ok, reason = agent._check_self_grounding(
+            "My brother Rahul says the same thing.", [], ""
+        )
+        assert ok is False
+        assert "own life" in reason
+
+    def test_invented_hometown_is_rejected(self, agent):
+        ok, _ = agent._check_self_grounding("I grew up in Delhi.", [], "")
+        assert ok is False
+
+    def test_invented_year_is_rejected(self, agent):
+        """Dates are as inventable as names, and read as far more authoritative."""
+        ok, _ = agent._check_self_grounding("I was born in 1998.", [], "")
+        assert ok is False
+
+    def test_invented_institution_is_rejected(self, agent):
+        ok, _ = agent._check_self_grounding(
+            "I studied at IIT Bombay before this.", [], ""
+        )
+        assert ok is False
+
+    def test_the_ungrounded_terms_are_returned_for_recording(self, agent):
+        """The gap list is what makes the biography's holes visible later."""
+        gaps = agent._self_claim_gaps("My brother Rahul lives in Mumbai.", [], "")
+        assert set(gaps) == {"rahul", "mumbai"}
+
+
+class TestTruthIsNotBlocked:
+    def test_biography_sibling_is_allowed(self, agent):
+        """The agent must be able to talk about the family it actually has.
+
+        If this fails, the gate has made her unable to say true things about
+        her own life, which is a worse outcome than the fabrication it was
+        built to prevent -- it would be visible in every single conversation.
+        """
+        ok, _ = agent._check_self_grounding(
+            "My brother Harshit is three years younger than me.", [], ""
+        )
+        assert ok is True
+
+    def test_grounding_does_not_depend_on_what_surfaced_this_turn(self, agent):
+        """Retrieval returns what is relevant, not everything the agent knows.
+
+        Grounding self-claims against the surfaced memories alone would reject
+        true statements whenever the relevant passage happened not to surface,
+        which is most turns. The biography vocabulary is the fix; this test is
+        what proves it is actually being consulted.
+        """
+        ok, _ = agent._check_self_grounding("I grew up in Punjab.", [], "")
+        assert ok is True
+
+    def test_a_fact_from_the_current_message_is_grounded(self, ungrounded_agent):
+        """What the user just said counts, even with no biography loaded."""
+        ok, _ = ungrounded_agent._check_self_grounding(
+            "My cousin Anjali, yes.", [], "how is your cousin Anjali doing"
+        )
+        assert ok is True
+
+    def test_a_fact_from_a_surfaced_memory_is_grounded(self, ungrounded_agent):
+        ok, _ = ungrounded_agent._check_self_grounding(
+            "My cousin Anjali called.",
+            [{"content": "Anjali is her cousin"}],
+            "",
+        )
+        assert ok is True
+
+
+class TestOrdinarySpeechIsNotGated:
+    def test_feelings_about_family_are_not_a_factual_claim(self, agent):
+        """"My family means everything to me" invents nothing.
+
+        The user-directed gate fires on two unsupported words, which this
+        sentence has. Reusing that rule here would make the agent unable to
+        express affection for her own family without a regeneration.
+        """
+        ok, _ = agent._check_self_grounding(
+            "My family means everything to me, always.", [], ""
+        )
+        assert ok is True
+
+    def test_preferences_are_not_gated(self, agent):
+        """Tastes are half of a personality; gating them makes the agent flat."""
+        ok, _ = agent._check_self_grounding("I love rasgulla, obviously.", [], "")
+        assert ok is True
+
+    def test_a_sentence_opening_with_a_capital_is_not_a_name(self, agent):
+        """Sentence case is not evidence of a proper noun.
+
+        Without the first-position exemption every self-claim sentence would
+        indict itself on its own opening word.
+        """
+        ok, _ = agent._check_self_grounding(
+            "Delhi is far from my hometown anyway.", [], ""
+        )
+        assert ok is True
+
+    def test_a_capitalised_common_noun_is_not_a_name(self, agent):
+        """Capitalisation alone is not identity.
+
+        Models capitalise for emphasis and in title case. "My School" names no
+        institution, and treating the trigger word itself as the fabricated
+        specific would make the gate indict every claim it examines.
+        """
+        ok, _ = agent._check_self_grounding("My School was strict about it.", [], "")
+        assert ok is True
+
+    def test_a_contraction_of_i_is_not_a_name(self, agent):
+        """"I've" is capitalised, three letters long, and refers to nobody."""
+        ok, _ = agent._check_self_grounding(
+            "My family, I've said, is everything.", [], ""
+        )
+        assert ok is True
+
+    def test_a_response_with_no_self_claim_is_never_examined(self, agent):
+        """The trigger phrase is required, exactly as in the user-facing gate."""
+        ok, _ = agent._check_self_grounding(
+            "That sounds really hard. Rahul from work would say the same.", [], ""
+        )
+        assert ok is True
+
+
+class TestCompositeGate:
+    def test_the_user_directed_gate_still_fires(self, agent):
+        """Composition must not have disabled the gate that already existed."""
+        ok, reason = agent._check_response_grounding(
+            "You told me your dog Rex loved the beach at Brighton.", [], ""
+        )
+        assert ok is False
+        assert "SHARED HISTORY" in reason
+
+    def test_the_self_gate_fires_through_the_composite(self, agent):
+        """Every existing call site gains the new check by composition alone."""
+        ok, _ = agent._check_response_grounding("My sister Neha agrees.", [], "")
+        assert ok is False
+
+    def test_a_clean_response_passes_both(self, agent):
+        ok, reason = agent._check_response_grounding(
+            "That sounds lovely, honestly.", [], ""
+        )
+        assert ok is True
+        assert reason == ""
+
+
+class TestGapRecording:
+    @pytest.mark.asyncio
+    async def test_repeated_gaps_accumulate_hits(self, gap_store):
+        """Frequency is the signal for what the biography most needs.
+
+        A name that comes up constantly and is never grounded matters more than
+        a one-off, and only a running count can tell them apart.
+        """
+        await gap_store.record_gap(["rahul"], "who is rahul")
+        await gap_store.record_gap(["rahul"], "rahul again")
+        gaps = await gap_store.top_gaps()
+        assert len(gaps) == 1
+        assert gaps[0]["term"] == "rahul"
+        assert gaps[0]["times_hit"] == 2
+
+    @pytest.mark.asyncio
+    async def test_gaps_are_ranked_by_how_often_they_come_up(self, gap_store):
+        await gap_store.record_gap(["mumbai"], "x")
+        for _ in range(3):
+            await gap_store.record_gap(["rahul"], "x")
+        gaps = await gap_store.top_gaps()
+        assert [g["term"] for g in gaps] == ["rahul", "mumbai"]
+
+    @pytest.mark.asyncio
+    async def test_one_response_cannot_flood_the_table(self, gap_store):
+        """A single bad generation must not bury the genuinely frequent gaps."""
+        written = await gap_store.record_gap([f"term{i}" for i in range(50)], "x")
+        assert written == 8
+
+    @pytest.mark.asyncio
+    async def test_recording_survives_a_broken_pool(self):
+        """The turn has already been stopped from lying; losing the note is cheap.
+
+        Raising here would turn a correctly-caught fabrication into a failed
+        conversation, which is strictly worse than an unrecorded gap.
+        """
+        pool = MagicMock()
+        pool.acquire.side_effect = RuntimeError("database is gone")
+        store = SelfKnowledgeStore(pool)
+        assert await store.record_gap(["rahul"], "x") == 0
+
+    @pytest.mark.asyncio
+    async def test_the_action_service_records_what_it_rejected(self):
+        """The gate and the record must see the same terms.
+
+        If these drift apart the biography's holes stop being visible, and the
+        only signal left is the user noticing the agent going quiet.
+        """
+        recorder = AsyncMock()
+        recorder.known_terms = set()
+        service = ActionService(self_knowledge=recorder)
+        await service._record_self_gaps("My brother Rahul called.", [], "hi")
+        recorder.record_gap.assert_awaited_once()
+        assert set(recorder.record_gap.await_args.args[0]) == {"rahul"}
+
+    @pytest.mark.asyncio
+    async def test_nothing_is_recorded_without_a_store(self):
+        """The gate stays functional when the store was never wired in."""
+        service = ActionService()
+        await service._record_self_gaps("My brother Rahul called.", [], "")
+
+
+class TestKnownTerms:
+    @pytest.mark.asyncio
+    async def test_only_biography_memories_ground_the_agents_own_past(self):
+        """Conversational memories must not become evidence for autobiography.
+
+        Ordinary memories are things the *user* said. If they counted as
+        grounding, one hallucinated detail that reached the memory store would
+        become the justification for the next -- the gate would ratify its own
+        escapes.
+        """
+        conn = AsyncMock()
+        conn.fetch.return_value = [{"content": "she grew up in Punjab"}]
+        pool = MagicMock()
+        pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+        pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        store = SelfKnowledgeStore(pool)
+        await store.refresh_known_terms()
+
+        assert conn.fetch.await_args.args[1] == "biography"
+        assert "punjab" in store.known_terms
+
+    @pytest.mark.asyncio
+    async def test_the_agents_own_name_is_grounded_without_a_biography(self):
+        """A third-person biography never contains the name of its subject.
+
+        "She talks calmly…" describes her without ever naming her, so without
+        an explicit seed the agent stating its own name reads as an ungrounded
+        claim about a stranger.
+        """
+        store = SelfKnowledgeStore(None, seed_terms={"Pallavi"})
+        assert "pallavi" in store.known_terms


### PR DESCRIPTION
## Why

The grounding gate only ever pointed one way. `_MEMORY_CLAIM_RE` matches "you told me…", "you used to", "remember when we…" — every pattern is second-person, protecting the *user's* facts. Nothing looked at what the agent said about **itself**, so asked about a sibling it was never told about it would invent one: fluently, in the persona's voice, indistinguishable from a passage the user actually wrote.

For an agent built to be a particular person that is the worst-shaped failure available. A blank can be filled in; a fabrication has to be noticed first, and nothing surfaced it.

## What changed

`_SELF_CLAIM_RE` is the mirror image, restricted to concrete biographical fact (`my brother`, `i grew up`, `i studied`, `when i was a child`). Feelings, opinions and preferences are deliberately out of scope — they come up constantly, and gating them buys a little fidelity at the cost of making the agent evasive about everything.

**The rule for what counts as fabricated is deliberately different from the user-facing one.** That gate fires on two unsupported words, which is right for a long attributed claim and wrong here: "my family means everything to me" contains two unsupported words and invents nothing. This gate fires only on **ungrounded proper nouns and 3+ digit numbers** — names, places, institutions, years — which is where self-invention actually lives. The known cost is a lowercased fabricated name slipping through; precision is worth more, because a gate that misfires on ordinary speech forces a regeneration and fires a cortisol burst every time.

**Grounding is against the biography, not the turn.** The obvious implementation — check self-claims against the surfaced memories, like the user gate does — is wrong. Retrieval returns what is relevant to the conversation, so a true sentence about the agent's brother would be rejected on every turn where the family passage did not happen to surface. `SelfKnowledgeStore` caches the vocabulary of all `source='biography'` memories instead.

Conversational memories are excluded on purpose: they are things the *user* said, and letting them ground autobiography would mean one hallucinated detail that reached the store becomes the evidence for the next — the gate ratifying its own escapes. The agent's own name is seeded explicitly, because a third-person biography ("she talks calmly…") never contains it.

**Gaps are recorded, not discarded.** `self_knowledge_gaps` (both backends) keys on term so repeated hits accumulate. No `resolved` flag — a gap the biography now covers simply stops being hit. Nothing reads the table yet; it is the substrate for the agent eventually raising these itself.

**Composition over new call sites.** The original method body became `_check_user_memory_grounding`; `_check_response_grounding` now runs both gates in sequence, so the post-generation check and both retry checks in `_stream_self_correction` gained the new gate without the retry path growing a second branch.

## Verification

- 26 new tests; all six planned mutations caught. The first pass had **one survivor** — nothing covered the filter stopping a capitalised common noun ("My School was strict") reading as a name — so two tests were added and the mutation re-run to confirm they catch it.
- Full backend suite via junit-xml: **730 passed, 0 failed/errored/skipped**.
- `ruff check .` clean.

## Not done

The gate is a backstop; the prompt guideline does the real work. A lowercased fabricated name still passes. Nothing reads `self_knowledge_gaps` yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)