### PR TITLE
Stop sibling biography sections nesting under the first

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -5141,3 +5141,48 @@ the trail and destroys depth alignment, so section two is filed as "Section One
 / Section Two" and every memory carries the first section's name. Real bug,
 separate change. `.env.example` was not touched: it documents no persona paths
 either, so adding only this one would be inconsistent.
+
+## 2026-08-02 — Sibling biography sections were nesting under the first one
+
+`parse_biography` keeps a heading trail so "How she argues / With family" reads
+as one place. The trail is indexed by heading *depth*, and the last line of the
+heading branch compacted it:
+
+    heading_trail = [h for h in heading_trail if h]
+
+For a file with a top-level `#`, slot 0 is filled and nothing is lost — which is
+why the shipped `config/biography.md` and every test built on it were fine. For
+a file whose sections all start at `##`, slot 0 is legitimately empty. Dropping
+it left a length-1 trail, so the *next* `##` sliced `[:1]`, kept its
+predecessor, and appended itself underneath.
+
+Every section after the first was therefore filed as "First Section / Second
+Section". Since `memory_text` folds the heading into the stored content, the
+first section's name ended up inside **every memory in the file** — so a cue
+matching that name matched the entire biography and retrieval could no longer
+separate anything. Found while writing a real biography that opened at `##`;
+worked around at the time by using `#` per section.
+
+The fix keeps the trail depth-aligned, with empty slots intact, and filters
+empties only at the point of use in `flush()`. Verified against four shapes:
+siblings with no top-level heading, siblings under one, a skipped level
+(`#` then `###`, which still reads as "A / C"), and sections at `#`.
+
+**Migration note.** For a file without a top-level `#` this changes the heading,
+and the fingerprint covers heading and text — so on the next boot the affected
+passages are pruned and re-seeded under their corrected headings. That is the
+intended outcome (the old headings were wrong), and the existing prune-then-seed
+ordering already handles it in a single pass. Files with a top-level `#`,
+including the shipped example, are unaffected.
+
+**Verified**: 3 new tests; all three mutations caught, including reintroducing
+the original compaction. Full backend suite via junit-xml: 737 passed, 0
+failed/errored/skipped. `ruff check .` clean.
+
+**NOT done:** `PersonaProfile.load()` parses JSON only (`json.loads` at
+profile.py) while the documented authored format is TOML, which
+`authoring.read_persona_file` handles. The boot path goes through
+`IdentityManager` and is fine, but `agent_state.py`'s
+`persona or PersonaProfile.load()` fallback would silently ignore a TOML
+`PERSONA_PROFILE_PATH` and drop to Config defaults. Latent, not hit today
+because `core.py` injects the persona explicitly. Separate change.

--- a/backend/app/persona/biography.py
+++ b/backend/app/persona/biography.py
@@ -102,8 +102,12 @@ def parse_biography(markdown: str) -> list[BiographyEntry]:
         text = " ".join(" ".join(buffer).split()).strip()
         buffer.clear()
         if text:
+            # Empty slots are dropped only here, at the point of use. The trail
+            # itself stays depth-aligned -- see below for why that matters.
             entries.append(
-                BiographyEntry(heading=" / ".join(heading_trail), text=text)
+                BiographyEntry(
+                    heading=" / ".join(h for h in heading_trail if h), text=text
+                )
             )
 
     for line in (markdown or "").splitlines():
@@ -117,7 +121,15 @@ def parse_biography(markdown: str) -> list[BiographyEntry]:
             while len(heading_trail) < depth - 1:
                 heading_trail.append("")
             heading_trail.append(match.group(2))
-            heading_trail = [h for h in heading_trail if h]
+            # Deliberately NOT compacted here. The trail is indexed by heading
+            # depth, so dropping empty slots destroys that alignment: in a file
+            # whose sections all start at `##` with no `#` above them, slot 0 is
+            # legitimately empty, and compacting it made the next `##` believe
+            # it was nesting under the previous one. Every section after the
+            # first was then filed as "First Section / Second Section", and
+            # since the heading is folded into the stored text, every single
+            # memory carried the first section's name -- so a cue matching that
+            # name matched the entire biography.
             continue
 
         if not line.strip():

--- a/backend/tests/test_biography_seeding.py
+++ b/backend/tests/test_biography_seeding.py
@@ -85,6 +85,32 @@ def test_the_heading_is_folded_into_the_stored_text():
     assert entry.memory_text == "Her sister: They speak every Sunday."
 
 
+def test_sibling_sections_do_not_nest_under_the_first():
+    """A file whose sections all start at `##` must not chain them together.
+
+    The heading trail is indexed by depth, so slot 0 is legitimately empty when
+    nothing sits above `##`. Compacting the trail destroyed that alignment and
+    every section after the first was filed under its predecessor. Because the
+    heading is folded into the stored text, that put the *first* section's name
+    inside every memory in the file — so a cue matching that name matched the
+    entire biography, and retrieval could no longer separate anything.
+    """
+    entries = parse_biography("## How she talks\n\nA.\n\n## Her family\n\nB.\n")
+    assert [e.heading for e in entries] == ["How she talks", "Her family"]
+
+
+def test_a_top_level_heading_still_encloses_its_sections():
+    """Real nesting must survive the fix that stopped the false nesting."""
+    entries = parse_biography("# Bio\n\n## Talks\n\nA.\n\n## Family\n\nB.\n")
+    assert [e.heading for e in entries] == ["Bio / Talks", "Bio / Family"]
+
+
+def test_a_skipped_heading_level_keeps_the_enclosing_section():
+    """People skip levels. `#` then `###` still means "C inside A"."""
+    entries = parse_biography("# A\n\n### C\n\ntext\n")
+    assert entries[0].heading == "A / C"
+
+
 def test_prose_before_any_heading_is_still_kept():
     """The file is written by a person, not authored against a spec."""
     entries = parse_biography("She is stubborn about small things.\n")


### PR DESCRIPTION
## The bug

`parse_biography` keeps a heading trail so "How she argues / With family" reads as one place. The trail is indexed by heading **depth**, and the last line of the heading branch compacted it:

```python
heading_trail = [h for h in heading_trail if h]
```

With a top-level `#`, slot 0 is filled and nothing is lost — which is why the shipped `config/biography.md` and every test built on it were fine. In a file whose sections all start at `##`, slot 0 is legitimately empty. Dropping it left a length-1 trail, so the next `##` sliced `[:1]`, kept its predecessor and appended itself underneath.

```
## Alpha      ->  'Alpha'
## Beta       ->  'Alpha / Beta'      # wrong
```

Every section after the first was filed under its predecessor. `memory_text` folds the heading into the stored content, so **the first section's name ended up inside every memory in the file** — a cue matching that name matched the entire biography, and retrieval could no longer separate anything.

Found while writing a real biography that opened at `##`.

## The fix

The trail stays depth-aligned with empty slots intact; empties are filtered only at the point of use in `flush()`. Verified against four shapes:

| input | heading |
|---|---|
| siblings, no top-level `#` | `Alpha`, `Beta` |
| siblings under `# Bio` | `Bio / Alpha`, `Bio / Beta` |
| skipped level (`#` then `###`) | `A / C` |
| sections at `#` | `One`, `Two` |

## Migration

For a file without a top-level `#` the heading changes, and the fingerprint covers heading *and* text — so the affected passages are pruned and re-seeded under their corrected headings on the next boot. That is the intended outcome (the old headings were wrong), and the existing prune-then-seed ordering handles it in a single pass. Files with a top-level `#`, including the shipped example, are unaffected.

## Verification

- 3 new tests; all three mutations caught, including reintroducing the original compaction.
- Full backend suite via junit-xml: **737 passed, 0 failed/errored/skipped**.
- `ruff check .` clean.

## Not done

`PersonaProfile.load()` parses JSON only while the documented authored format is TOML (which `authoring.read_persona_file` handles). The boot path goes through `IdentityManager` and is fine, but `agent_state.py`'s `persona or PersonaProfile.load()` fallback would silently ignore a TOML `PERSONA_PROFILE_PATH` and drop to Config defaults. Latent — `core.py` injects the persona explicitly — and a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)