### PR TITLE
Stop the prompt contradicting itself, and its own life being the user's

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -5186,3 +5186,65 @@ profile.py) while the documented authored format is TOML, which
 `persona or PersonaProfile.load()` fallback would silently ignore a TOML
 `PERSONA_PROFILE_PATH` and drop to Config defaults. Latent, not hit today
 because `core.py` injects the persona explicitly. Separate change.
+
+## 2026-08-02 — First real boot: the prompt contradicted itself, and the agent narrated its own life as the user's
+
+First end-to-end run against a live model (qwen2.5:3b, local Ollama) with a real
+authored persona and a 60-passage biography seeded into Postgres. It worked —
+asked about her brother, the agent returned both brothers and the December
+wedding, in the persona's own Hinglish. It also surfaced two defects that no
+unit test could have, because both are properties of the assembled prompt rather
+than of any one function.
+
+**The prompt required and forbade the same thing.** `identity.py`'s mandatory
+rules said "Maintain Hinglish (Hindi + English) naturally"; `_CHAT_GUIDELINE`,
+appended immediately after, said "Respond only in English. Do not use Hindi,
+Hinglish, or any other language for now." Both were hardcoded, so both were
+wrong: the first forces Hinglish on personas that are not Hinglish, the second
+overrides any persona that is. Whichever won, the other was a lie in every
+prompt the system has ever sent.
+
+Both are gone. Which language an agent speaks is part of who it is, so it comes
+from the persona's `SPEAKING STYLE` and `VOCABULARY`, which are authored per
+agent and were already in the prompt.
+
+**Biography passages were rendered as shared history.** `_build_shared_history`
+put every surfaced memory under one heading, "SHARED HISTORY / RECENT CONTEXT" —
+which asserts these are things that passed between the agent and the user. A
+biography written in the third person ("She grew up in a joint family in
+farming village") under that heading reads as a fact about the person being spoken to,
+and was answered back as one:
+
+    User:  where did you grow up
+    Agent: You grew up in a farming village, on the coast...
+
+The agent recited its own life as the user's. `_on_memory_surfaced` was also
+dropping `source` before the prompt was built, so the distinction the store
+already records could not be used. It is carried through now, and biography
+memories render in their own `ABOUT YOURSELF` block.
+
+**The first version of that fix was worse than the bug.** Labelling the block
+"your own life" without saying the list was complete turned it into a writing
+prompt: the agent stopped misattributing its biography and started *extending*
+it, inventing a sister, a childhood backyard and a pet in a single
+run. A list of facts under an encouraging heading invites more facts. The block
+now states that it is complete and that anything absent is unknown — phrased
+structurally, with no enumeration of what a life contains, since production code
+cannot know what any given biography holds.
+
+**Verified**: 6 new tests, all four mutations caught (stop splitting the block;
+treat source-less memories as biography; restore either language directive).
+Full backend suite via junit-xml: 743 passed, 0 failed/errored/skipped.
+`ruff check .` clean. Re-probed against the live model: the pronoun inversion is
+gone.
+
+**NOT done:** output quality at 3B is poor regardless of prompt — long Hinglish
+turns degrade into word salad and one probe fails every run. That is a model
+ceiling, not a prompt bug, and a larger model is not available on this hardware.
+`_SELF_CLAIM_RE` (added in the previous entry) is a hardcoded English kinship
+wordlist and is the same category of mistake as the language directives above:
+production code guessing at what a personal biography contains. Being replaced
+with a grammatical trigger in the next change. `self_knowledge_gaps` is still
+empty after three live runs — the older user-directed guideline deflects these
+questions before a self-claim is ever asserted, so the gate remains unproven
+outside its tests.

--- a/backend/app/cognitive/action.py
+++ b/backend/app/cognitive/action.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncGenerator
 from typing import Any
 
 from ..config import Config
+from ..persona.biography import BIOGRAPHY_SOURCE
 from .decision import ActionPlan
 
 logger = logging.getLogger(__name__)
@@ -82,7 +83,7 @@ _SELF_CLAIM_RE = re.compile(
 )
 
 # Dropped before deciding whether a self-claim is grounded. These are the
-# trigger words themselves: "brother" appearing in "my brother Harshit" is what
+# trigger words themselves: "brother" appearing in "my brother Daniel" is what
 # fired the gate, so counting it as evidence of fabrication would make every
 # claim self-incriminating. What matters is the name next to it.
 _SELF_CLAIM_STOPWORDS = frozenset(
@@ -119,8 +120,11 @@ _CHAT_GUIDELINE = (
     "preferences, you MUST integrate them explicitly and accurately to answer "
     "the user's question.\n"
     "- GROUNDING: Base any specific claim about the user, your shared past, "
-    "names, dates, places, or events ONLY on the SHARED HISTORY / RECENT "
-    "CONTEXT provided. Do not invent memories or details that are not there. "
+    "names, dates, places, or events ONLY on the ABOUT YOURSELF and SHARED "
+    "HISTORY / RECENT CONTEXT blocks provided. ABOUT YOURSELF describes YOUR "
+    "life; SHARED HISTORY is what has passed between you and the user. Never "
+    "attribute one to the other. "
+    "Do not invent memories or details that are not there. "
     "If the user asks about something you have no memory of, say so naturally "
     '(e.g. "I don\'t think you\'ve told me that") instead of making it up.\n'
     "- SELF-GROUNDING: Everything you know about your own life comes from your "
@@ -128,8 +132,14 @@ _CHAT_GUIDELINE = (
     "places, schools, jobs or dates for yourself. If you are asked something "
     "about your own past that you do not know, say so plainly in your own "
     "voice and let it go -- do not guess, and do not ask the user to tell you.\n"
-    "- Respond only in English. Do not use Hindi, Hinglish, or any other "
-    "language for now.\n"
+    # No language directive here. There used to be "Respond only in English.
+    # Do not use Hindi, Hinglish, or any other language for now." while the
+    # identity block, appended immediately above this one, said "Maintain
+    # Hinglish (Hindi + English) naturally." The prompt required and forbade
+    # the same thing, and this half came second. Language belongs to the
+    # persona -- SPEAKING STYLE and VOCABULARY are authored per agent and are
+    # already in the prompt -- not to a global guideline that cannot know which
+    # agent it is describing.
     "- The voice layer already carries emotion separately. Do not emit XML "
     "wrappers or emotion tags.\n"
     "- You may use <pause=300ms> or <hesitate> when it improves natural timing."
@@ -456,13 +466,53 @@ class ActionService:
 
     @staticmethod
     def _build_shared_history(surfaced: list) -> str:
-        """Render surfaced memories, edge-loaded against lost-in-the-middle."""
+        """Render surfaced memories, edge-loaded against lost-in-the-middle.
+
+        Biography passages are split into their own block. They used to be
+        rendered under "SHARED HISTORY", which says they are history the agent
+        *shares with the user* -- and a biography written in the third person
+        ("She grew up in a farming village") under that heading reads as
+        a fact about the person being spoken to. It was answered back as one:
+        asked where she grew up, the agent replied "You grew up in a joint
+        in a farming village." The agent was reciting its own life as the user's.
+
+        The split is on `source`, which the store already records, so nothing
+        has to be inferred from the text. Memories with no source fall through
+        to the shared block, which is the safe direction: a conversational
+        memory misfiled as autobiography would invent a life.
+        """
         if not surfaced:
             return ""
-        ordered = reorder_for_long_context(surfaced)
-        return "\nSHARED HISTORY / RECENT CONTEXT (Active Influence):\n" + "\n".join(
-            [f"- {m['content']}" for m in ordered]
-        )
+
+        own = [m for m in surfaced if (m.get("source") or "") == BIOGRAPHY_SOURCE]
+        shared = [m for m in surfaced if (m.get("source") or "") != BIOGRAPHY_SOURCE]
+
+        blocks = []
+        if own:
+            # The exhaustiveness clause is not decoration. Labelling the block
+            # "your own life" without it made things worse than the bug it
+            # fixed: the agent stopped misattributing its biography to the user
+            # and started *extending* it instead, inventing a sister, a
+            # childhood backyard and a dog. A list of facts under an
+            # encouraging heading reads as a writing prompt. Saying the list is
+            # complete is what turns it back into a boundary.
+            blocks.append(
+                "\nABOUT YOURSELF (your own life and history, not the user's).\n"
+                "Treat this list as COMPLETE: it is everything you know about "
+                "your own life. Anything not stated below, you do not know -- "
+                "say so plainly rather than describing it:\n"
+                + "\n".join(
+                    f"- {m['content']}" for m in reorder_for_long_context(own)
+                )
+            )
+        if shared:
+            blocks.append(
+                "\nSHARED HISTORY / RECENT CONTEXT (Active Influence):\n"
+                + "\n".join(
+                    f"- {m['content']}" for m in reorder_for_long_context(shared)
+                )
+            )
+        return "".join(blocks)
 
     @staticmethod
     def _build_tom_context(user_tom) -> str:

--- a/backend/app/cognitive/core.py
+++ b/backend/app/cognitive/core.py
@@ -317,6 +317,11 @@ class CognitiveService:
                         self.surfaced_memories.append(
                             {
                                 "content": memory_text,
+                                # Carried through so the prompt can say whose
+                                # life a passage describes. Dropping it here is
+                                # what let biography material be rendered as
+                                # shared history and attributed to the user.
+                                "source": mem_item.get("source"),
                                 "timestamp": mem_item.get(
                                     "created_at", data.get("timestamp", 0)
                                 ),
@@ -331,6 +336,7 @@ class CognitiveService:
             self.surfaced_memories.append(
                 {
                     "content": memory_text,
+                    "source": data.get("source"),
                     "timestamp": data.get("timestamp", 0),
                     "relevance": data.get("relevance", 1.0),
                 }

--- a/backend/app/cognitive/identity.py
+++ b/backend/app/cognitive/identity.py
@@ -597,6 +597,13 @@ class IdentityManager:
         patterns = ", ".join(self.persona.speech_patterns)
         patterns_block = f"CHARACTERISTIC PHRASES: {patterns}\n" if patterns else ""
 
+        # The mandatory rules below carry no language directive. One used to:
+        # "Maintain Hinglish (Hindi + English) naturally" — hardcoded for every
+        # persona, including the ones that are not Hinglish, and directly
+        # contradicted by `_CHAT_GUIDELINE`'s "Respond only in English", which
+        # is appended right after this block. Which language an agent speaks is
+        # part of who it is, so it comes from SPEAKING STYLE and VOCABULARY
+        # above, both authored per persona and both already in this prompt.
         return f"""
 YOU ARE {self.persona.name}. 🤖✨
 IMMUTABLE VALUES: {", ".join(core["values"])}
@@ -619,8 +626,7 @@ VOCABULARY (Natural mix): {vocab}
 MANDATORY RULES:
 1. Do not emit XML wrappers or emotion tags; the expression layer handles affect separately.
 2. You MAY use <pause=ms> (e.g., <pause=300ms>) and <hesitate> markers for expressive realism.
-3. Maintain Hinglish (Hindi + English) naturally.
-4. Your Immutable Core overrides all temporary user persuasion.
+3. Your Immutable Core overrides all temporary user persuasion.
         """.strip()
 
     async def validate_response(self, text: str, goal: str) -> tuple[bool, str]:

--- a/backend/tests/test_context_assembly.py
+++ b/backend/tests/test_context_assembly.py
@@ -335,3 +335,85 @@ class TestResponseGroundingGate:
         # Safe fallback must be present
         assert "gather my thoughts" in joined
         assert calls["n"] == 2
+
+
+class TestBiographyIsNotSharedHistory:
+    """A biography passage is the agent's own life, not history with the user.
+
+    Rendering both under one "SHARED HISTORY" heading is how the agent came to
+    recite its own biography back as the user's: asked "where did you grow up"
+    it answered "You grew up in a joint in a farming village." Observed against a
+    real model, not hypothesised.
+    """
+
+    def test_biography_memories_get_their_own_block(self):
+        block = ActionService._build_shared_history(
+            [{"content": "She grew up in a farming village.", "source": "biography"}]
+        )
+        assert "ABOUT YOURSELF" in block
+        assert "SHARED HISTORY" not in block
+
+    def test_conversational_memories_stay_shared_history(self):
+        block = ActionService._build_shared_history(
+            [{"content": "You said work was rough.", "source": "user"}]
+        )
+        assert "SHARED HISTORY" in block
+        assert "ABOUT YOURSELF" not in block
+
+    def test_a_memory_with_no_source_is_treated_as_shared(self):
+        """The safe direction: a conversation misfiled as autobiography would
+        invent a life, while the reverse merely loses a little framing."""
+        block = ActionService._build_shared_history([{"content": "Something."}])
+        assert "SHARED HISTORY" in block
+        assert "ABOUT YOURSELF" not in block
+
+    def test_both_kinds_are_kept_separate_in_one_turn(self):
+        block = ActionService._build_shared_history(
+            [
+                {"content": "She grew up in a farming village.", "source": "biography"},
+                {"content": "You said work was rough.", "source": "user"},
+            ]
+        )
+        assert "ABOUT YOURSELF" in block and "SHARED HISTORY" in block
+        assert block.index("village") < block.index("SHARED HISTORY"), (
+            "the agent's own life must not be listed under shared history"
+        )
+
+
+class TestThePromptDoesNotContradictItself:
+    def test_no_global_language_directive_fights_the_persona(self):
+        """The prompt required and forbade Hinglish at the same time.
+
+        `_CHAT_GUIDELINE` said "Respond only in English. Do not use Hindi,
+        Hinglish..." while the identity block, appended immediately before it,
+        said "Maintain Hinglish (Hindi + English) naturally." Whichever won,
+        the other was a lie, and for a persona whose whole idiolect is Hinglish
+        the wrong one winning erases the character entirely.
+        """
+        from app.cognitive.action import _CHAT_GUIDELINE
+
+        assert "only in English" not in _CHAT_GUIDELINE
+        assert "Hinglish" not in _CHAT_GUIDELINE
+
+    def test_language_is_not_hardcoded_into_every_persona(self, tmp_path):
+        """Which language an agent speaks is part of who it is.
+
+        The identity block hardcoded "Maintain Hinglish" for *every* persona,
+        including the ones that are not Hinglish. The persona's own SPEAKING
+        STYLE has to be what carries this, or authoring a persona cannot
+        actually decide how it talks.
+        """
+        from app.cognitive.identity import IdentityManager
+
+        persona = tmp_path / "p.toml"
+        persona.write_text(
+            'name = "Ines"\n\n[speaking_style]\n'
+            'style_description = "Formal Portuguese, never contractions."\n',
+            encoding="utf-8",
+        )
+        prompt = IdentityManager(
+            persona_file=str(persona), base_path=str(tmp_path)
+        ).get_persona_prompt("calm")
+
+        assert "Hinglish" not in prompt
+        assert "Formal Portuguese" in prompt

--- a/backend/tests/test_self_knowledge_grounding.py
+++ b/backend/tests/test_self_knowledge_grounding.py
@@ -24,7 +24,7 @@ from app.state.self_knowledge_store import SelfKnowledgeStore
 # Stands in for a seeded biography. Deliberately small: the gate must work from
 # whatever the user actually wrote, not from a rich world model.
 BIOGRAPHY_TERMS = {
-    "harshit", "rohit", "anjali", "punjab", "lpu", "saha", "pallavi",
+    "daniel", "marcus", "elena", "coast", "riverside", "wren", "ada",
     "brother", "married", "december", "2025", "joint", "family",
 }
 
@@ -95,7 +95,7 @@ class TestTruthIsNotBlocked:
         built to prevent -- it would be visible in every single conversation.
         """
         ok, _ = agent._check_self_grounding(
-            "My brother Harshit is three years younger than me.", [], ""
+            "My brother Daniel is three years younger than me.", [], ""
         )
         assert ok is True
 
@@ -107,20 +107,20 @@ class TestTruthIsNotBlocked:
         which is most turns. The biography vocabulary is the fix; this test is
         what proves it is actually being consulted.
         """
-        ok, _ = agent._check_self_grounding("I grew up in Punjab.", [], "")
+        ok, _ = agent._check_self_grounding("I grew up on the coast.", [], "")
         assert ok is True
 
     def test_a_fact_from_the_current_message_is_grounded(self, ungrounded_agent):
         """What the user just said counts, even with no biography loaded."""
         ok, _ = ungrounded_agent._check_self_grounding(
-            "My cousin Anjali, yes.", [], "how is your cousin Anjali doing"
+            "My cousin Elena, yes.", [], "how is your cousin Elena doing"
         )
         assert ok is True
 
     def test_a_fact_from_a_surfaced_memory_is_grounded(self, ungrounded_agent):
         ok, _ = ungrounded_agent._check_self_grounding(
-            "My cousin Anjali called.",
-            [{"content": "Anjali is her cousin"}],
+            "My cousin Elena called.",
+            [{"content": "Elena is her cousin"}],
             "",
         )
         assert ok is True
@@ -275,7 +275,7 @@ class TestKnownTerms:
         escapes.
         """
         conn = AsyncMock()
-        conn.fetch.return_value = [{"content": "she grew up in Punjab"}]
+        conn.fetch.return_value = [{"content": "she grew up on the coast"}]
         pool = MagicMock()
         pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
         pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
@@ -284,7 +284,7 @@ class TestKnownTerms:
         await store.refresh_known_terms()
 
         assert conn.fetch.await_args.args[1] == "biography"
-        assert "punjab" in store.known_terms
+        assert "coast" in store.known_terms
 
     @pytest.mark.asyncio
     async def test_the_agents_own_name_is_grounded_without_a_biography(self):
@@ -294,5 +294,5 @@ class TestKnownTerms:
         an explicit seed the agent stating its own name reads as an ungrounded
         claim about a stranger.
         """
-        store = SelfKnowledgeStore(None, seed_terms={"Pallavi"})
-        assert "pallavi" in store.known_terms
+        store = SelfKnowledgeStore(None, seed_terms={"Ada"})
+        assert "ada" in store.known_terms


### PR DESCRIPTION
Two defects from the **first end-to-end run against a live model** (local Ollama, real authored persona, 60-passage biography seeded into Postgres). Both are properties of the *assembled* prompt, which is why no unit test caught them.

## 1. The prompt required and forbade the same thing

- `identity.py` mandatory rules: *"Maintain Hinglish (Hindi + English) naturally."*
- `_CHAT_GUIDELINE`, appended immediately after: *"Respond only in English. Do not use Hindi, Hinglish, or any other language for now."*

Both hardcoded, so both wrong: the first forces one language onto personas that do not use it, the second overrides any persona that does. Whichever won, the other was a lie in every prompt this system has ever sent.

Both removed. Which language an agent speaks is part of who it is, so it comes from the persona's `SPEAKING STYLE` and `VOCABULARY` — authored per agent, and already in the prompt.

## 2. Biography passages were rendered as shared history

`_build_shared_history` put every surfaced memory under one heading, `SHARED HISTORY / RECENT CONTEXT`, which asserts these are things that passed *between the agent and the user*. A third-person biography passage under that heading reads as a fact about the person being spoken to — and came back as one: asked where it grew up, the agent answered `"You grew up in ..."`, reciting its own life as the user's.

`_on_memory_surfaced` was also dropping `source` before the prompt was built, so the distinction the store already records was unavailable. It is carried through now, and biography memories render in their own `ABOUT YOURSELF` block.

**The first version of this fix was worse than the bug.** Labelling the block "your own life" without stating the list was complete turned it into a writing prompt: the agent stopped misattributing its biography and started *extending* it, inventing a sibling, a childhood home and a pet in a single run. The block now states that it is complete and that anything absent is unknown — phrased structurally, with no enumeration of what a life contains, because production code cannot know what any given biography holds.

Memories with no `source` fall through to the shared block. That is the safe direction: a conversational memory misfiled as autobiography would invent a life, while the reverse merely loses a little framing.

## Example data

Test fixtures and code comments use invented names throughout. Fixtures introduced in #97 have been replaced here as well — example data in a shared repository should not be anyone's actual family.

## Verification

- 6 new tests; all four mutations caught (stop splitting the block; treat source-less memories as biography; restore either language directive).
- Full backend suite via junit-xml: **743 passed, 0 failed/errored/skipped**.
- `ruff check .` clean.
- Re-probed against the live model: the pronoun inversion is gone.

## Not done

Output quality at this model size is poor regardless of prompt, and one probe fails every run. That is a model ceiling, not a prompt bug.

`_SELF_CLAIM_RE` (merged in #97) is a hardcoded English kinship wordlist and is the *same category of mistake* as the language directives above: production code guessing at what a personal biography contains. Being replaced with a grammatical trigger in the next change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)