### PR TITLE
Make the self-claim trigger grammatical instead of a noun list

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -5248,3 +5248,51 @@ with a grammatical trigger in the next change. `self_knowledge_gaps` is still
 empty after three live runs — the older user-directed guideline deflects these
 questions before a self-claim is ever asserted, so the gate remains unproven
 outside its tests.
+
+
+## 2026-08-02 -- The self-grounding trigger was a wordlist; now it is grammar
+
+`_SELF_CLAIM_RE` decided whether a sentence was a biographical claim about the
+agent by matching an enumerated list of possessed nouns -- brother, sister,
+mother, hometown, school, roommate, childhood. That list is production code
+guessing at the shape of a stranger's life. It protected the kinds of life its
+author happened to imagine and silently ignored the rest: "my brother Rahul"
+was caught, "my dog Jolly" was not, and the only fix available was to keep
+adding nouns, which is the same mistake repeated.
+
+The trigger is now grammatical: any first-person possessive (`my <word>`) plus
+the same handful of first-person life verbs. "my" is a claim about English;
+"brother" was a claim about someone's family. Precision does not suffer,
+because a trigger has never been what rejects a response -- rejection still
+requires an *ungrounded proper noun or year* inside the sentence, checked
+against the biography the user actually wrote. What is true of a given person
+comes entirely from their own file; production code only decides what shape a
+claim has.
+
+**`_SELF_CLAIM_STOPWORDS` is gone with it.** It existed because the trigger
+word itself ("brother" in "my brother Daniel") would otherwise be counted as
+the fabricated specific, making every claim indict itself -- so it was a second
+wordlist that had to be kept in sync with the first by hand. The replacement is
+structural: `_self_claim_gaps` records the character spans the trigger matched
+and skips any specific falling inside one. The exemption is now derived from
+the pattern rather than restated alongside it, so the two cannot drift.
+
+`_NON_NAME_CAPITALS` stays. It is about English capitalisation conventions --
+"I", "I've", and interjections that appear capitalised mid-sentence -- not
+about what a biography may contain.
+
+**Verified**: 3 new tests, both mutations caught (narrow the trigger back to a
+noun list; drop the trigger-span exemption -- the second kills three tests,
+including one written for the old stopword list, which is the evidence that the
+structural rule subsumes it). Full backend suite via junit-xml: 746 passed,
+0 failed/errored/skipped. `ruff check .` clean.
+
+**NOT done:** the widened trigger fires on possessives that are opinions rather
+than facts -- "my favourite film is <Title>" now enters the gate where it did
+not before, and will be rejected if the title is ungrounded. That is arguably
+correct for an agent modelled on a real person, since an invented favourite is
+an invented fact about her, but it is a behaviour change and it has not been
+observed against a live model. Not re-probed live: the older user-directed
+guideline still deflects these questions before a self-claim is asserted, so
+`self_knowledge_gaps` remains empty and the gate is still unproven outside its
+tests.

--- a/backend/app/cognitive/action.py
+++ b/backend/app/cognitive/action.py
@@ -63,39 +63,25 @@ _GROUNDING_STOPWORDS = frozenset(
 # particular person, a confident fabrication about itself is worse than a blank:
 # the blank can be filled in, the fabrication has to be noticed first.
 #
-# Restricted to assertions of concrete biographical *fact* -- family, origin,
-# schooling, where it lived. Feelings, opinions and preferences are deliberately
-# out of scope: they come up constantly in ordinary talk, and gating them buys a
-# little fidelity at the cost of making the agent evasive about everything.
+# The trigger is *grammatical, not lexical*: any first-person possessive, plus
+# the handful of verb phrases that place the speaker's own life in the world.
+# An earlier version enumerated the possessed nouns -- brother, hometown, school
+# -- which meant the gate only protected the kinds of life its author happened
+# to think of. Every biography is different, so a noun list is a guess about
+# someone else's family; "my" is a guess about English. Nothing here decides
+# what is *true* of a given person: that comes entirely from their biography.
+#
+# Feelings and opinions are still out of scope in practice, because a trigger
+# alone never rejects anything -- see _self_claim_gaps, which needs an
+# ungrounded proper noun or year before it will fire.
 _SELF_CLAIM_RE = re.compile(
-    r"\b("
-    r"my (?:brother|sister|siblings?|mother|father|mom|mum|dad|papa|mama"
-    r"|parents?|family|cousin|uncle|aunt|grand(?:mother|father)"
-    r"|school|college|university|hometown|village|neighbou?rhood"
-    r"|roommate|classmate|childhood)"
-    r"|i (?:grew up|was born|studied|graduated)"
-    r"|i (?:live|lived|moved) (?:in|to|at)"
-    r"|i used to live"
-    r"|i come from"
-    r"|when i was (?:a |an |in |at )?(?:child|kid|little|young|\d+)"
-    r")\b",
+    r"\bmy\s+[a-z][a-z']*"
+    r"|\bi\s+(?:grew up|was born|studied|graduated)\b"
+    r"|\bi\s+(?:live|lived|moved)\s+(?:in|to|at)\b"
+    r"|\bi\s+used\s+to\s+live\b"
+    r"|\bi\s+come\s+from\b"
+    r"|\bwhen\s+i\s+was\s+(?:a |an |in |at )?(?:child|kid|little|young|\d+)\b",
     re.IGNORECASE,
-)
-
-# Dropped before deciding whether a self-claim is grounded. These are the
-# trigger words themselves: "brother" appearing in "my brother Daniel" is what
-# fired the gate, so counting it as evidence of fabrication would make every
-# claim self-incriminating. What matters is the name next to it.
-_SELF_CLAIM_STOPWORDS = frozenset(
-    {
-        "brother", "sister", "siblings", "mother", "father", "mom", "mum",
-        "dad", "papa", "mama", "parent", "parents", "family", "cousin",
-        "uncle", "aunt", "grandmother", "grandfather", "school", "college",
-        "university", "hometown", "village", "neighborhood", "neighbourhood",
-        "roommate", "classmate", "childhood", "grew", "born", "studied",
-        "graduated", "live", "lived", "moved", "come", "child", "kid",
-        "little", "young", "name", "years", "year", "old",
-    }
 )
 
 # Capitalised words that carry no identifying weight, so they are not treated as
@@ -360,14 +346,22 @@ class ActionService:
         gaps: list[str] = []
         for raw_sentence in re.split(r"(?<=[.!?])\s+", response):
             sentence = raw_sentence.strip()
-            if not _SELF_CLAIM_RE.search(sentence):
+            triggers = [m.span() for m in _SELF_CLAIM_RE.finditer(sentence)]
+            if not triggers:
                 continue
             for match in _SELF_SPECIFIC_RE.finditer(sentence):
                 # A capital in the first position is sentence case, not a name.
                 if match.start() == 0:
                     continue
+                # Words inside the trigger phrase itself are never the
+                # fabrication -- "My School" fired the gate, so counting
+                # "School" as the invented specific would make every claim
+                # indict itself. Excluding the matched span does this without
+                # a list of trigger words to keep in sync with the pattern.
+                if any(s <= match.start() < e for s, e in triggers):
+                    continue
                 token = match.group(1).lower()
-                if token in _NON_NAME_CAPITALS or token in _SELF_CLAIM_STOPWORDS:
+                if token in _NON_NAME_CAPITALS:
                     continue
                 if token not in grounded:
                     gaps.append(token)

--- a/backend/tests/test_self_knowledge_grounding.py
+++ b/backend/tests/test_self_knowledge_grounding.py
@@ -80,6 +80,20 @@ class TestFabricationIsCaught:
         )
         assert ok is False
 
+    def test_a_possession_nobody_thought_to_list_is_still_gated(self, agent):
+        """The trigger is grammatical, so it cannot miss a kind of life.
+
+        An earlier version enumerated the possessed nouns -- brother, hometown,
+        school -- so "my dog Jolly" sailed through while "my brother Rahul" was
+        caught. The gate then protected only the lives its author happened to
+        imagine, and every biography is a different life. "my" generalises;
+        a noun list is a guess about someone else's family.
+        """
+        ok, _ = agent._check_self_grounding(
+            "My dog Jolly waits by the door.", [], ""
+        )
+        assert ok is False
+
     def test_the_ungrounded_terms_are_returned_for_recording(self, agent):
         """The gap list is what makes the biography's holes visible later."""
         gaps = agent._self_claim_gaps("My brother Rahul lives in Mumbai.", [], "")
@@ -163,6 +177,24 @@ class TestOrdinarySpeechIsNotGated:
         specific would make the gate indict every claim it examines.
         """
         ok, _ = agent._check_self_grounding("My School was strict about it.", [], "")
+        assert ok is True
+
+    def test_the_possessed_noun_is_never_the_fabrication(self, agent):
+        """Whatever follows "my" fired the gate; it cannot also be the evidence.
+
+        This has to hold for any noun, not the ones a stopword list happened to
+        name -- otherwise the pattern and its exemption drift apart, and the
+        first noun added to one and forgotten in the other makes the gate
+        reject a sentence for containing its own trigger.
+        """
+        ok, _ = agent._check_self_grounding(
+            "My Landlord raised the rent again.", [], ""
+        )
+        assert ok is True
+
+    def test_a_first_person_verb_is_never_the_fabrication(self, agent):
+        """The same exemption, on the other half of the pattern."""
+        ok, _ = agent._check_self_grounding("I Studied hard for it.", [], "")
         assert ok is True
 
     def test_a_contraction_of_i_is_not_a_name(self, agent):


### PR DESCRIPTION
## Why

`_SELF_CLAIM_RE` decided whether a sentence asserted a biographical fact about the agent by matching an **enumerated list of possessed nouns** — brother, sister, mother, hometown, school, roommate, childhood.

That list is production code guessing at the shape of a stranger's life. It protected the kinds of life its author happened to imagine and silently ignored the rest: `my brother X` was caught, `my dog X` was not — and the only available fix was to keep adding nouns, which is the same mistake repeated.

## What changed

**The trigger is grammatical.** Any first-person possessive (`my <word>`) plus the same handful of first-person life verbs. `my` is a claim about English; `brother` was a claim about someone's family.

Precision does not suffer, because a trigger has never been what rejects a response — rejection still requires an **ungrounded proper noun or year** inside the sentence, checked against the biography the user actually wrote. Production code decides what *shape* a claim has; what is *true* of a given person comes entirely from their own file.

**`_SELF_CLAIM_STOPWORDS` is gone.** It existed only so the trigger word itself (`brother` in `my brother X`) would not be counted as the fabricated specific, making every claim indict itself — so it was a second wordlist that had to be kept in sync with the first by hand. `_self_claim_gaps` now records the character spans the trigger matched and skips any specific falling inside one. The exemption is derived from the pattern rather than restated alongside it, so the two cannot drift.

`_NON_NAME_CAPITALS` stays — it is about English capitalisation conventions, not about what a biography may contain.

## Verification

- 3 new tests; **both mutations caught**:
  - narrow the trigger back to a noun list → kills `test_a_possession_nobody_thought_to_list_is_still_gated`
  - drop the trigger-span exemption → kills 3 tests, including one written for the old stopword list, which is the evidence that the structural rule subsumes it
- Full backend suite via `--junit-xml`: **746 passed**, 0 failed / errored / skipped
- `ruff check .` clean

## Known behaviour change

The widened trigger now admits possessives that are opinions rather than facts — `my favourite film is <Title>` enters the gate where it did not before, and is rejected if the title is ungrounded. Arguably correct for an agent modelled on a real person (an invented favourite is an invented fact about her), but it is a behaviour change and has not been observed against a live model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)