### PR TITLE
Record what she was asked and could not answer, and let her ask back

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -5336,11 +5336,35 @@ first-boot language bug exactly: a prompt requiring and forbidding the same
 thing. It now forbids only turning *every* blank into a question, and defers to
 the block when one is present. A test asserts the two cannot drift apart again.
 
-**Verified**: 13 new tests, all 8 mutations caught (drop the biography-surfaced
+**Review pass (CodeRabbit) found a real race.** `next_gap_to_ask` +
+`mark_asked` was a read-then-update, so two overlapping turns could both claim
+the same gap, and `_build_wondering_block` emitted the block even when the mark
+failed -- which would ask a question the table did not record as asked, so it
+would be asked again next turn. Replaced by a single `claim_next_gap_to_ask`:
+one `UPDATE ... WHERE term = (SELECT ...) AND asked_at IS NULL RETURNING`, so a
+caller holding a row knows it is the only one. This is the first mutating
+statement in the codebase to return rows, which exposed a latent bug in the
+SQLite fallback: only `execute()` committed, so an `UPDATE ... RETURNING`
+arriving through `fetchrow()` sat in sqlite3's implicit transaction and was
+lost on close. Both fetch paths now commit DML.
+
+**Verified**: 15 new tests, all 9 mutations caught (drop the biography-surfaced
 check, the interrogative check, the about-her check, the cold-start guard, the
-per-question cap, the min-hits threshold, the already-asked filter, or the
-mark-asked call). Full backend suite via junit-xml: 760 passed,
-0 failed/errored/skipped. `ruff check .` clean.
+per-question cap, the min-hits threshold or the already-asked filter; split the
+atomic claim back into a read and an update; emit the block despite a failed
+claim). Full backend suite via junit-xml: 762 passed, 0 failed/errored/skipped.
+`ruff check .` clean.
+
+Worth recording that two of those mutations initially **survived**. The
+already-asked filter in the subselect was masked by the outer claim guard --
+with one gap in the table both forms behave identically, and only a second gap
+behind the first reveals that removing it starves everything after the top row.
+And the concurrency test written for the claim was decorative: the SQLite
+fallback runs each statement to completion without yielding, so `asyncio.gather`
+cannot interleave two claims and the test passed against a deliberately racy
+implementation. It was replaced with a structural assertion that the claim
+issues exactly one statement. The read-committed race itself is only reachable
+on Postgres and is **not** covered by any test.
 
 **NOT done, and this is the important half.** The loop is open at the far end:
 when the user answers her question, nothing writes that answer back into the

--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -5296,3 +5296,63 @@ observed against a live model. Not re-probed live: the older user-directed
 guideline still deflects these questions before a self-claim is asserted, so
 `self_knowledge_gaps` remains empty and the gate is still unproven outside its
 tests.
+
+
+## 2026-08-02 -- The gap table was write-only, and it was recording the wrong thing
+
+Two defects, and the second explains the first.
+
+**Gaps were harvested from fabrications the prompt exists to prevent.**
+`_record_self_gaps` ran only after the grounding gate *rejected* a response,
+deriving gaps from the ungrounded proper nouns in it. But `_CHAT_GUIDELINE`
+tells her that when she does not know something about her own past she should
+say so and let it go -- so she emits no proper noun, the gate never fires, and
+nothing is recorded. `self_knowledge_gaps` stayed empty across every live run
+*because the system was working*. The instrumentation measured only its own
+failures.
+
+The evidence that actually reveals a hole in a biography is a question it
+cannot answer. `_unanswered_self_question_gaps` now records on three
+conditions, all required: the message is interrogative, it is about *her* life
+(`_SELF_QUERY_RE`, the second-person mirror of the assertion trigger), and
+retrieval surfaced no `source='biography'` passage for it. The third is the
+real test -- it is the store reporting that it looked and found nothing, rather
+than a guess from vocabulary, which would flag "did you enjoy college" over the
+word *enjoy*. Recording happens before generation, since it depends only on the
+question and the store.
+
+**Nothing ever read the table.** Recording holes in an autobiography is only
+useful if something eventually asks about them; a biography that cannot grow is
+a character sheet. `next_gap_to_ask` / `mark_asked` and `_build_wondering_block`
+close the loop: a gap the user has raised at least twice is offered to the
+prompt once, framed as an opening rather than an instruction. `min_hits` is what
+keeps a stray term from becoming a question; `asked_at` is what stops her
+opening every turn with the same one.
+
+**The guideline had to move for it.** SELF-GROUNDING ended "do not ask the user
+to tell you" -- a flat prohibition on the one behaviour the new block
+authorises. Injecting the block under that guideline would have recreated the
+first-boot language bug exactly: a prompt requiring and forbidding the same
+thing. It now forbids only turning *every* blank into a question, and defers to
+the block when one is present. A test asserts the two cannot drift apart again.
+
+**Verified**: 13 new tests, all 8 mutations caught (drop the biography-surfaced
+check, the interrogative check, the about-her check, the cold-start guard, the
+per-question cap, the min-hits threshold, the already-asked filter, or the
+mark-asked call). Full backend suite via junit-xml: 760 passed,
+0 failed/errored/skipped. `ruff check .` clean.
+
+**NOT done, and this is the important half.** The loop is open at the far end:
+when the user answers her question, nothing writes that answer back into the
+biography. `refresh_known_terms` reads only `source='biography'` rows, so a fact
+given in conversation never becomes something she knows about herself, and the
+same gap can be re-recorded forever. Closing it needs a design for which turn
+counts as the answer, what happens when the user deflects, and how a
+conversationally-acquired fact is marked so it is distinguishable from an
+authored passage -- deliberately not guessed at here. There is also no re-ask
+cooldown: `mark_asked` fires when the question is *offered*, because nothing
+downstream can tell an asked question from a skipped one, so a gap she never
+raises is never retried. And `_SELF_QUERY_RE` misses questions phrased without
+a possessive or a biographical verb ("which college did you go to") --
+precision was preferred over recall, since a noisy table makes the asking
+channel worse, not better. None of this has been run against a live model.

--- a/backend/app/cognitive/action.py
+++ b/backend/app/cognitive/action.py
@@ -93,6 +93,40 @@ _NON_NAME_CAPITALS = frozenset({"i", "i'm", "i've", "oh", "yeah", "haan", "arre"
 # be a year rather than an age or a count.
 _SELF_SPECIFIC_RE = re.compile(r"\b([A-Z][A-Za-z']{2,}|\d{3,})\b")
 
+# _SELF_CLAIM_RE catches the agent *asserting* something about its own life.
+# This catches the user *asking* about it, and it is the better signal of the
+# two. Gaps used to be harvested only from fabrications the grounding gate
+# rejected -- but the prompt tells her not to fabricate, so when it works there
+# is nothing to harvest, and the record stayed empty across every live run.
+# What actually reveals a hole in a biography is a question it cannot answer.
+#
+# Same grammatical construction as the self-claim trigger, second person.
+# Same closed set of biographical verbs as the assertion side, conjugated for
+# questions: an assertion is naturally past ("I studied"), a question puts the
+# tense in the auxiliary and leaves the verb bare ("did you study").
+_SELF_QUERY_RE = re.compile(
+    r"\byour\s+[a-z][a-z']*"
+    r"|\byou\s+(?:grow|grew)\s+up\b"
+    r"|\byou\s+(?:was|were)\s+born\b"
+    r"|\byou\s+(?:study|studied|graduate|graduated)\b"
+    r"|\byou\s+(?:live|lived|move|moved)\b"
+    r"|\byou\s+(?:come|came)\s+from\b"
+    r"|\bwhen\s+you\s+were\s+(?:a |an |in |at )?(?:child|kid|little|young|\d+)\b",
+    re.IGNORECASE,
+)
+
+# Interrogative form. "your voice is lovely" mentions her but asks nothing, and
+# recording a gap from it would fill the table with compliments.
+_QUESTION_RE = re.compile(
+    r"\?"
+    r"|^\s*(?:who|what|when|where|why|how|which|do|did|does|is|are|was|were"
+    r"|have|has|had|can|could|will|would|tell me)\b",
+    re.IGNORECASE,
+)
+
+_QUERY_WORD_RE = re.compile(r"\b[a-z][a-z']{2,}\b")
+_MAX_QUESTION_GAPS = 4
+
 
 # Static half of the chat system prompt, appended after the identity block.
 # Hoisted out of execute() so the prompt contract is visible at module scope
@@ -117,7 +151,9 @@ _CHAT_GUIDELINE = (
     "biography and from this conversation. Never invent family members, "
     "places, schools, jobs or dates for yourself. If you are asked something "
     "about your own past that you do not know, say so plainly in your own "
-    "voice and let it go -- do not guess, and do not ask the user to tell you.\n"
+    "voice and let it go -- do not guess. Do not turn every blank into a "
+    "question for the user; ask only about the one thing a SOMETHING YOU HAVE "
+    "BEEN WONDERING block names, and only if it appears.\n"
     # No language directive here. There used to be "Respond only in English.
     # Do not use Hindi, Hinglish, or any other language for now." while the
     # identity block, appended immediately above this one, said "Maintain
@@ -825,6 +861,89 @@ class ActionService:
         except Exception as e:
             logger.debug(f"[Action] Could not record self-knowledge gap: {e}")
 
+    def _unanswered_self_question_gaps(self, user_message: str, surfaced) -> list[str]:
+        """Terms from a question about her own life that her biography cannot meet.
+
+        Three conditions, all required. The message must be interrogative; it
+        must be about *her* life rather than the user's; and retrieval must have
+        surfaced no biography passage for it. That last one is the real test --
+        it is the system stating, from its own store, that it looked and found
+        nothing. Vocabulary alone would flag "did you enjoy college" over the
+        word *enjoy*.
+
+        Returns the content words the biography has never seen, which is what
+        the user would have to write about for the hole to close.
+        """
+        if not user_message or not _QUESTION_RE.search(user_message):
+            return []
+        if not _SELF_QUERY_RE.search(user_message):
+            return []
+
+        known = getattr(self.self_knowledge, "known_terms", None) or set()
+        if not known:
+            # No biography loaded at all. Every word would look like a gap, and
+            # a table full of them says nothing about which passage is missing.
+            return []
+        if any(
+            (m.get("source") or "") == BIOGRAPHY_SOURCE for m in (surfaced or [])
+        ):
+            # She has something autobiographical to answer with; whether she
+            # uses it well is the grounding gate's problem, not a missing life.
+            return []
+
+        gaps = [
+            w
+            for w in dict.fromkeys(_QUERY_WORD_RE.findall(user_message.lower()))
+            if w not in known and w not in _GROUNDING_STOPWORDS
+        ]
+        return gaps[:_MAX_QUESTION_GAPS]
+
+    async def _record_unanswered_self_question(self, user_message: str, surfaced):
+        """Persist a question about her past that her biography could not meet."""
+        if self.self_knowledge is None:
+            return
+        gaps = self._unanswered_self_question_gaps(user_message, surfaced)
+        if not gaps:
+            return
+        try:
+            await self.self_knowledge.record_gap(gaps, user_message)
+        except Exception as e:
+            logger.debug(f"[Action] Could not record unanswered self-question: {e}")
+
+    async def _build_wondering_block(self) -> str:
+        """Offer her one thing to ask about her own life, or nothing.
+
+        The blank half of the loop until now: gaps accumulated and no code ever
+        read them back. Framed as an opening rather than an instruction, and
+        capped at one, because an agent that interrogates the user about its own
+        biography every turn is not curious, it is broken.
+        """
+        if self.self_knowledge is None:
+            return ""
+        try:
+            gap = await self.self_knowledge.next_gap_to_ask()
+        except Exception as e:
+            logger.debug(f"[Action] Could not read next self-knowledge gap: {e}")
+            return ""
+        if not gap or not gap.get("term"):
+            return ""
+
+        term = str(gap["term"])
+        try:
+            await self.self_knowledge.mark_asked(term)
+        except Exception as e:
+            logger.debug(f"[Action] Could not mark gap asked: {e}")
+
+        logger.info("[SelfKnowledge] Offering '%s' as a question about herself.", term)
+        return (
+            "\nSOMETHING YOU HAVE BEEN WONDERING ABOUT YOUR OWN LIFE:\n"
+            f"- \"{term}\" has come up about your past and you find you do not "
+            "know it. If this conversation gives you a natural opening, ask "
+            "the user about it once, in your own voice, the way a person asks "
+            "about a blank in their own history. If there is no natural "
+            "opening, leave it -- do not force it, and do not ask twice.\n"
+        )
+
     async def _announce_self_correction(self, reason: str):
         """Interrupt playback so the retry is not spoken over the bad take."""
         if self.publish_cb:
@@ -965,7 +1084,14 @@ class ActionService:
         if not surfaced and self.memory:
             surfaced = await self._surface_fallback_memories(plan, msg)
 
+        # A question about her own life that retrieval could not answer is the
+        # only reliable evidence of a hole in her biography, so it is recorded
+        # before generation -- it depends on the question and the store, not on
+        # what she goes on to say.
+        await self._record_unanswered_self_question(msg, surfaced)
+
         shared_history = self._build_shared_history(surfaced)
+        wondering = await self._build_wondering_block()
         tom_context = self._build_tom_context(plan.payload.get("user_mental_model"))
 
         # Static System Prompt (cached by inference engines like Ollama/vLLM)
@@ -977,7 +1103,7 @@ class ActionService:
         # answer. The more abstract, lower-cost-to-lose context (goal, emotion,
         # Theory-of-Mind) goes earlier. Within the history block itself, memories
         # are already edge-loaded by reorder_for_long_context().
-        user_prompt = f"Current Context:\n- Goal: {plan.goal}\n- Current Emotion: {emotion}\n{tom_context}{shared_history}\n\nUser: {msg}\nAssistant:"
+        user_prompt = f"Current Context:\n- Goal: {plan.goal}\n- Current Emotion: {emotion}\n{tom_context}{wondering}{shared_history}\n\nUser: {msg}\nAssistant:"
 
         valence = plan.payload.get("valence", 0.0)
         arousal = plan.payload.get("arousal", 0.5)

--- a/backend/app/cognitive/action.py
+++ b/backend/app/cognitive/action.py
@@ -917,23 +917,24 @@ class ActionService:
         read them back. Framed as an opening rather than an instruction, and
         capped at one, because an agent that interrogates the user about its own
         biography every turn is not curious, it is broken.
+
+        The gap is *claimed*, not merely read: the store hands one back only if
+        this turn is the one that marked it asked. Two overlapping turns
+        therefore cannot both put the same question in a prompt, and a claim
+        that fails yields no block rather than an unrecorded question that
+        would be asked again next turn.
         """
         if self.self_knowledge is None:
             return ""
         try:
-            gap = await self.self_knowledge.next_gap_to_ask()
+            gap = await self.self_knowledge.claim_next_gap_to_ask()
         except Exception as e:
-            logger.debug(f"[Action] Could not read next self-knowledge gap: {e}")
+            logger.debug(f"[Action] Could not claim next self-knowledge gap: {e}")
             return ""
         if not gap or not gap.get("term"):
             return ""
 
         term = str(gap["term"])
-        try:
-            await self.self_knowledge.mark_asked(term)
-        except Exception as e:
-            logger.debug(f"[Action] Could not mark gap asked: {e}")
-
         logger.info("[SelfKnowledge] Offering '%s' as a question about herself.", term)
         return (
             "\nSOMETHING YOU HAVE BEEN WONDERING ABOUT YOUR OWN LIFE:\n"

--- a/backend/app/state/self_knowledge_store.py
+++ b/backend/app/state/self_knowledge_store.py
@@ -91,8 +91,20 @@ class SelfKnowledgeStore:
                         "times_hit integer NOT NULL DEFAULT 1, "
                         "example_prompt text, "
                         "first_seen timestamp DEFAULT current_timestamp, "
-                        "last_seen timestamp DEFAULT current_timestamp)"
+                        "last_seen timestamp DEFAULT current_timestamp, "
+                        "asked_at timestamp)"
                     )
+                    # Tables created before the asking channel existed have no
+                    # asked_at, and CREATE TABLE IF NOT EXISTS will not add it.
+                    # Postgres and SQLite disagree on the guard clause, so the
+                    # portable form is to try and let the duplicate fail.
+                    try:
+                        await conn.execute(
+                            "ALTER TABLE self_knowledge_gaps "
+                            "ADD COLUMN asked_at timestamp"
+                        )
+                    except Exception:
+                        pass
                 self._ready = True
             except Exception as e:
                 logger.debug(f"SelfKnowledgeStore not ready ({e}); gaps not recorded")
@@ -175,6 +187,60 @@ class SelfKnowledgeStore:
                 ", ".join(selected[:5]),
             )
         return written
+
+    async def next_gap_to_ask(self, min_hits: int = 2) -> dict | None:
+        """The gap most worth raising with the user, or None.
+
+        This is the read side of the table, and the reason it exists at all.
+        Recording holes in an agent's autobiography is only useful if something
+        eventually asks about them -- a biography that cannot grow is a
+        character sheet, not a life.
+
+        ``min_hits`` is what stops a single stray term becoming a question: a
+        subject the user has raised twice is a subject they care about, and the
+        count is the only evidence available for that. Gaps already raised are
+        excluded so she does not ask the same thing every turn, which reads as
+        damage rather than curiosity.
+        """
+        await self._ensure_ready()
+        if not self._ready:
+            return None
+        try:
+            async with self.pool.acquire() as conn:
+                rows = await conn.fetch(
+                    "SELECT term, times_hit, example_prompt FROM self_knowledge_gaps "
+                    "WHERE asked_at IS NULL AND times_hit >= $1 "
+                    "ORDER BY times_hit DESC, last_seen DESC LIMIT 1",
+                    int(min_hits),
+                )
+        except Exception as e:
+            logger.debug(f"Could not read next self-knowledge gap ({e})")
+            return None
+        return dict(rows[0]) if rows else None
+
+    async def mark_asked(self, term: str) -> bool:
+        """Record that a gap has been put to the user. Never raises.
+
+        Marked when the question is *offered to the prompt*, not when she is
+        observed asking it, because nothing downstream can reliably tell an
+        asked question from a skipped one. The cost is a gap that goes
+        unmentioned and is never retried; the alternative is her opening every
+        turn with the same question, which is worse.
+        """
+        await self._ensure_ready()
+        if not self._ready or not term:
+            return False
+        try:
+            async with self.pool.acquire() as conn:
+                await conn.execute(
+                    "UPDATE self_knowledge_gaps SET asked_at = current_timestamp "
+                    "WHERE term = $1",
+                    str(term).lower(),
+                )
+            return True
+        except Exception as e:
+            logger.debug(f"Could not mark self-knowledge gap asked ({e})")
+            return False
 
     async def top_gaps(self, limit: int = 20) -> list[dict]:
         """The most frequently hit gaps, for inspection and for later asking."""

--- a/backend/app/state/self_knowledge_store.py
+++ b/backend/app/state/self_knowledge_store.py
@@ -188,8 +188,8 @@ class SelfKnowledgeStore:
             )
         return written
 
-    async def next_gap_to_ask(self, min_hits: int = 2) -> dict | None:
-        """The gap most worth raising with the user, or None.
+    async def claim_next_gap_to_ask(self, min_hits: int = 2) -> dict | None:
+        """Take the gap most worth raising with the user, or None.
 
         This is the read side of the table, and the reason it exists at all.
         Recording holes in an agent's autobiography is only useful if something
@@ -198,49 +198,38 @@ class SelfKnowledgeStore:
 
         ``min_hits`` is what stops a single stray term becoming a question: a
         subject the user has raised twice is a subject they care about, and the
-        count is the only evidence available for that. Gaps already raised are
+        count is the only evidence available for that. Gaps already claimed are
         excluded so she does not ask the same thing every turn, which reads as
         damage rather than curiosity.
+
+        **Selecting and claiming are one statement, deliberately.** A read
+        followed by a separate update lets two overlapping turns both see the
+        same unasked row and both put it in a prompt -- and overlapping turns
+        are not hypothetical here (finding A1). The outer ``asked_at IS NULL``
+        is what makes the claim conditional: the second writer re-evaluates it
+        after the first commits, matches nothing, and returns no row. A caller
+        that gets a row therefore knows it is the only one holding it.
         """
         await self._ensure_ready()
         if not self._ready:
             return None
         try:
             async with self.pool.acquire() as conn:
-                rows = await conn.fetch(
-                    "SELECT term, times_hit, example_prompt FROM self_knowledge_gaps "
+                row = await conn.fetchrow(
+                    "UPDATE self_knowledge_gaps "
+                    "SET asked_at = current_timestamp "
+                    "WHERE term = ("
+                    "SELECT term FROM self_knowledge_gaps "
                     "WHERE asked_at IS NULL AND times_hit >= $1 "
-                    "ORDER BY times_hit DESC, last_seen DESC LIMIT 1",
+                    "ORDER BY times_hit DESC, last_seen DESC LIMIT 1"
+                    ") AND asked_at IS NULL "
+                    "RETURNING term, times_hit, example_prompt",
                     int(min_hits),
                 )
         except Exception as e:
-            logger.debug(f"Could not read next self-knowledge gap ({e})")
+            logger.debug(f"Could not claim next self-knowledge gap ({e})")
             return None
-        return dict(rows[0]) if rows else None
-
-    async def mark_asked(self, term: str) -> bool:
-        """Record that a gap has been put to the user. Never raises.
-
-        Marked when the question is *offered to the prompt*, not when she is
-        observed asking it, because nothing downstream can reliably tell an
-        asked question from a skipped one. The cost is a gap that goes
-        unmentioned and is never retried; the alternative is her opening every
-        turn with the same question, which is worse.
-        """
-        await self._ensure_ready()
-        if not self._ready or not term:
-            return False
-        try:
-            async with self.pool.acquire() as conn:
-                await conn.execute(
-                    "UPDATE self_knowledge_gaps SET asked_at = current_timestamp "
-                    "WHERE term = $1",
-                    str(term).lower(),
-                )
-            return True
-        except Exception as e:
-            logger.debug(f"Could not mark self-knowledge gap asked ({e})")
-            return False
+        return dict(row) if row else None
 
     async def top_gaps(self, limit: int = 20) -> list[dict]:
         """The most frequently hit gaps, for inspection and for later asking."""

--- a/backend/app/state/sqlite_fallback.py
+++ b/backend/app/state/sqlite_fallback.py
@@ -371,6 +371,7 @@ class SQLiteConnection:
         cursor = self.conn.cursor()
         cursor.execute(translated, cleaned_args)
         rows = cursor.fetchall()
+        self._commit_if_mutating(translated)
         return [dict(row) for row in rows]
 
     async def fetchrow(self, query, *args):
@@ -379,7 +380,20 @@ class SQLiteConnection:
         cursor = self.conn.cursor()
         cursor.execute(translated, cleaned_args)
         row = cursor.fetchone()
+        self._commit_if_mutating(translated)
         return dict(row) if row else None
+
+    def _commit_if_mutating(self, query: str):
+        """Commit a statement that both writes and returns rows.
+
+        ``UPDATE … RETURNING`` arrives through the fetch path, not execute(),
+        so without this the write sits in sqlite3's implicit transaction and is
+        lost when the connection closes. Only execute() committed, because
+        until RETURNING was used every mutation went through it. A commit after
+        a plain SELECT is a no-op: sqlite3 opens a transaction for DML only.
+        """
+        if query.lstrip()[:6].upper() in ("UPDATE", "INSERT", "DELETE"):
+            self.conn.commit()
 
     async def fetchval(self, query, *args):
         translated = self._translate_query(query)

--- a/backend/app/state/sqlite_fallback.py
+++ b/backend/app/state/sqlite_fallback.py
@@ -160,7 +160,8 @@ class SQLiteConnection:
                 times_hit INTEGER NOT NULL DEFAULT 1,
                 example_prompt TEXT,
                 first_seen TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                last_seen TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                last_seen TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                asked_at TIMESTAMP
             )
         """)
         cursor.execute(

--- a/backend/tests/test_context_assembly.py
+++ b/backend/tests/test_context_assembly.py
@@ -395,6 +395,20 @@ class TestThePromptDoesNotContradictItself:
         assert "only in English" not in _CHAT_GUIDELINE
         assert "Hinglish" not in _CHAT_GUIDELINE
 
+    def test_the_guideline_leaves_room_for_the_wondering_block(self):
+        """The same trap as the language directive, one layer down.
+
+        SELF-GROUNDING used to end "do not ask the user to tell you", which is
+        a flat prohibition on the one thing the WONDERING block exists to
+        authorise. Injecting that block while the guideline forbade it would
+        have recreated the first-boot bug exactly: a prompt that requires and
+        forbids the same behaviour, with no way to tell which half won.
+        """
+        from app.cognitive.action import _CHAT_GUIDELINE
+
+        assert "do not ask the user to tell you" not in _CHAT_GUIDELINE
+        assert "WONDERING" in _CHAT_GUIDELINE
+
     def test_language_is_not_hardcoded_into_every_persona(self, tmp_path):
         """Which language an agent speaks is part of who it is.
 

--- a/backend/tests/test_self_knowledge_grounding.py
+++ b/backend/tests/test_self_knowledge_grounding.py
@@ -296,6 +296,140 @@ class TestGapRecording:
         await service._record_self_gaps("My brother Rahul called.", [], "")
 
 
+class TestUnansweredQuestionsBecomeGaps:
+    """The signal that actually reveals a hole in a biography.
+
+    Gaps were originally harvested only from fabrications the grounding gate
+    rejected. But the prompt instructs her not to fabricate, so when it works
+    there is nothing to harvest -- the table stayed empty across every live run
+    while the system was behaving correctly. A question she cannot answer is
+    the evidence that was being thrown away.
+    """
+
+    def test_a_question_her_biography_cannot_answer_is_recorded(self, agent):
+        gaps = agent._unanswered_self_question_gaps("what was your school like?", [])
+        assert "school" in gaps
+
+    def test_a_question_the_biography_answers_is_not_a_gap(self, agent):
+        """Retrieval found an autobiographical passage, so nothing is missing.
+
+        Whether she uses it well is the grounding gate's problem. Recording a
+        gap here would fill the table with subjects she can already discuss and
+        bury the ones she genuinely cannot.
+        """
+        gaps = agent._unanswered_self_question_gaps(
+            "what was your school like?",
+            [{"content": "She went to a convent school", "source": "biography"}],
+        )
+        assert gaps == []
+
+    def test_an_ordinary_memory_does_not_count_as_an_answer(self, agent):
+        """Only biography passages are evidence that her own past is recorded.
+
+        A conversational memory is something the *user* said. Treating it as
+        proof she knows her own history is the same mistake the grounding gate
+        already refuses to make.
+        """
+        gaps = agent._unanswered_self_question_gaps(
+            "what was your school like?",
+            [{"content": "the user mentioned a school", "source": "conversation"}],
+        )
+        assert "school" in gaps
+
+    def test_a_statement_is_not_a_question(self, agent):
+        """"Your voice is lovely" asks nothing, and is not a hole in her past."""
+        assert agent._unanswered_self_question_gaps("your voice is lovely", []) == []
+
+    def test_a_question_that_is_not_about_her_life_is_ignored(self, agent):
+        """A request is not an autobiographical question.
+
+        Without this the table fills with whatever the user wanted help with,
+        and the asking channel starts interrogating them about their own
+        errands as though they were her missing childhood.
+        """
+        gaps = agent._unanswered_self_question_gaps(
+            "can you help me with the groceries?", []
+        )
+        assert gaps == []
+
+    def test_nothing_is_recorded_before_a_biography_exists(self, ungrounded_agent):
+        """Cold start: with no biography, every word is a gap and none is useful."""
+        gaps = ungrounded_agent._unanswered_self_question_gaps(
+            "where did you grow up?", []
+        )
+        assert gaps == []
+
+    def test_one_question_cannot_flood_the_table(self, agent):
+        gaps = agent._unanswered_self_question_gaps(
+            "what was your school, your street, your teacher, your uniform, "
+            "your canteen and your bus like?",
+            [],
+        )
+        assert len(gaps) <= 4
+
+
+class TestSheAsksAboutHerself:
+    """The read side. Without it the gap table is a write-only log."""
+
+    @pytest.mark.asyncio
+    async def test_a_repeated_gap_becomes_something_she_can_raise(self, gap_store):
+        await gap_store.record_gap(["school"], "what was your school like")
+        await gap_store.record_gap(["school"], "did you like school")
+        gap = await gap_store.next_gap_to_ask()
+        assert gap is not None and gap["term"] == "school"
+
+    @pytest.mark.asyncio
+    async def test_a_one_off_is_not_worth_asking_about(self, gap_store):
+        """Frequency is the only evidence available that a subject matters.
+
+        Asking about every term that ever went unmatched turns her into a
+        questionnaire, and the user stops answering.
+        """
+        await gap_store.record_gap(["school"], "x")
+        assert await gap_store.next_gap_to_ask() is None
+
+    @pytest.mark.asyncio
+    async def test_she_does_not_ask_the_same_thing_twice(self, gap_store):
+        """Repeating a question every turn reads as damage, not curiosity."""
+        for _ in range(3):
+            await gap_store.record_gap(["school"], "x")
+        first = await gap_store.next_gap_to_ask()
+        await gap_store.mark_asked(first["term"])
+        assert await gap_store.next_gap_to_ask() is None
+
+    @pytest.mark.asyncio
+    async def test_the_prompt_carries_the_question_and_marks_it_asked(self):
+        recorder = AsyncMock()
+        recorder.next_gap_to_ask.return_value = {"term": "school", "times_hit": 3}
+        service = ActionService(self_knowledge=recorder)
+
+        block = await service._build_wondering_block()
+
+        assert "school" in block
+        assert "WONDERING" in block
+        recorder.mark_asked.assert_awaited_once_with("school")
+
+    @pytest.mark.asyncio
+    async def test_no_block_when_there_is_nothing_to_ask(self):
+        """An empty gap table must not put an empty invitation in the prompt."""
+        recorder = AsyncMock()
+        recorder.next_gap_to_ask.return_value = None
+        service = ActionService(self_knowledge=recorder)
+        assert await service._build_wondering_block() == ""
+
+    @pytest.mark.asyncio
+    async def test_a_broken_store_does_not_break_the_turn(self):
+        """Curiosity is a luxury; the conversation is not.
+
+        A failing read here must degrade to silence rather than aborting a
+        reply the user is waiting on.
+        """
+        recorder = AsyncMock()
+        recorder.next_gap_to_ask.side_effect = RuntimeError("database is gone")
+        service = ActionService(self_knowledge=recorder)
+        assert await service._build_wondering_block() == ""
+
+
 class TestKnownTerms:
     @pytest.mark.asyncio
     async def test_only_biography_memories_ground_the_agents_own_past(self):

--- a/backend/tests/test_self_knowledge_grounding.py
+++ b/backend/tests/test_self_knowledge_grounding.py
@@ -307,6 +307,13 @@ class TestUnansweredQuestionsBecomeGaps:
     """
 
     def test_a_question_her_biography_cannot_answer_is_recorded(self, agent):
+        """This is the signal the whole channel runs on.
+
+        If an unanswerable question about her own past leaves no trace, the
+        table only ever fills from rejected fabrications -- which the prompt
+        prevents -- and she can be asked the same unanswerable thing for
+        months without anything noticing the biography is missing a page.
+        """
         gaps = agent._unanswered_self_question_gaps("what was your school like?", [])
         assert "school" in gaps
 
@@ -360,6 +367,12 @@ class TestUnansweredQuestionsBecomeGaps:
         assert gaps == []
 
     def test_one_question_cannot_flood_the_table(self, agent):
+        """A single rambling question must not bury the frequent gaps.
+
+        Selection is by hit count, so a question that writes a dozen one-off
+        terms dilutes the ranking that decides what she asks about, and the
+        subject the user keeps raising loses to a crowd of stray nouns.
+        """
         gaps = agent._unanswered_self_question_gaps(
             "what was your school, your street, your teacher, your uniform, "
             "your canteen and your bus like?",
@@ -373,9 +386,16 @@ class TestSheAsksAboutHerself:
 
     @pytest.mark.asyncio
     async def test_a_repeated_gap_becomes_something_she_can_raise(self, gap_store):
+        """Without this the table is write-only and the biography cannot grow.
+
+        Recording holes in an autobiography is only useful if something
+        eventually asks about them. If this returns None for a gap the user has
+        raised twice, nothing ever reaches the prompt and she stays exactly as
+        ignorant of herself as the day she was seeded.
+        """
         await gap_store.record_gap(["school"], "what was your school like")
         await gap_store.record_gap(["school"], "did you like school")
-        gap = await gap_store.next_gap_to_ask()
+        gap = await gap_store.claim_next_gap_to_ask()
         assert gap is not None and gap["term"] == "school"
 
     @pytest.mark.asyncio
@@ -386,34 +406,97 @@ class TestSheAsksAboutHerself:
         questionnaire, and the user stops answering.
         """
         await gap_store.record_gap(["school"], "x")
-        assert await gap_store.next_gap_to_ask() is None
+        assert await gap_store.claim_next_gap_to_ask() is None
 
     @pytest.mark.asyncio
     async def test_she_does_not_ask_the_same_thing_twice(self, gap_store):
         """Repeating a question every turn reads as damage, not curiosity."""
         for _ in range(3):
             await gap_store.record_gap(["school"], "x")
-        first = await gap_store.next_gap_to_ask()
-        await gap_store.mark_asked(first["term"])
-        assert await gap_store.next_gap_to_ask() is None
+        first = await gap_store.claim_next_gap_to_ask()
+        assert first["term"] == "school"
+        assert await gap_store.claim_next_gap_to_ask() is None
 
     @pytest.mark.asyncio
-    async def test_the_prompt_carries_the_question_and_marks_it_asked(self):
+    async def test_an_asked_gap_does_not_block_every_gap_behind_it(self, gap_store):
+        """The most-hit gap is claimed first, and must then step aside.
+
+        If the candidate is chosen without excluding already-asked rows, the
+        highest-count gap is picked forever and rejected forever by the claim
+        guard. She would ask exactly one question in her life and go silent,
+        while the table filled with subjects she never raises.
+        """
+        for _ in range(5):
+            await gap_store.record_gap(["school"], "x")
+        for _ in range(2):
+            await gap_store.record_gap(["cousin"], "x")
+
+        first = await gap_store.claim_next_gap_to_ask()
+        assert first["term"] == "school"
+        second = await gap_store.claim_next_gap_to_ask()
+        assert second is not None and second["term"] == "cousin"
+
+    @pytest.mark.asyncio
+    async def test_selecting_and_claiming_are_one_statement(self):
+        """Turns overlap in this system (finding A1), so the claim must be atomic.
+
+        A read followed by a separate update lets two in-flight turns see the
+        same unasked row and both put it in a prompt -- the user gets the same
+        question twice from someone supposed to be tracking her own history.
+        This asserts the structure rather than racing it, because the SQLite
+        fallback runs its statements to completion without ever yielding, so a
+        gathered test cannot interleave them and would pass either way.
+        """
+        conn = AsyncMock()
+        conn.fetchrow.return_value = {
+            "term": "school",
+            "times_hit": 3,
+            "example_prompt": "",
+        }
+        pool = MagicMock()
+        pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+        pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        store = SelfKnowledgeStore(pool)
+        store._ready = True
+        gap = await store.claim_next_gap_to_ask()
+
+        assert gap["term"] == "school"
+        conn.fetchrow.assert_awaited_once()
+        sql = conn.fetchrow.await_args.args[0]
+        assert "UPDATE" in sql and "SELECT" in sql
+        conn.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_claimed_gap_reaches_the_prompt(self):
+        """The block is the only path from the table into her behaviour.
+
+        If the term does not reach the prompt, the gap is claimed -- and so
+        never offered again -- without anything ever being asked. The record
+        would then be permanently marked as handled while the biography still
+        has the hole.
+        """
         recorder = AsyncMock()
-        recorder.next_gap_to_ask.return_value = {"term": "school", "times_hit": 3}
+        recorder.claim_next_gap_to_ask.return_value = {
+            "term": "school",
+            "times_hit": 3,
+        }
         service = ActionService(self_knowledge=recorder)
 
         block = await service._build_wondering_block()
 
         assert "school" in block
         assert "WONDERING" in block
-        recorder.mark_asked.assert_awaited_once_with("school")
 
     @pytest.mark.asyncio
-    async def test_no_block_when_there_is_nothing_to_ask(self):
-        """An empty gap table must not put an empty invitation in the prompt."""
+    async def test_a_gap_that_could_not_be_claimed_is_not_asked(self):
+        """A failed claim must produce silence, not an unrecorded question.
+
+        Emitting the block anyway would ask a question the table does not know
+        was asked, so it would be asked again on the next turn, and the next.
+        """
         recorder = AsyncMock()
-        recorder.next_gap_to_ask.return_value = None
+        recorder.claim_next_gap_to_ask.return_value = None
         service = ActionService(self_knowledge=recorder)
         assert await service._build_wondering_block() == ""
 
@@ -425,7 +508,7 @@ class TestSheAsksAboutHerself:
         reply the user is waiting on.
         """
         recorder = AsyncMock()
-        recorder.next_gap_to_ask.side_effect = RuntimeError("database is gone")
+        recorder.claim_next_gap_to_ask.side_effect = RuntimeError("database is gone")
         service = ActionService(self_knowledge=recorder)
         assert await service._build_wondering_block() == ""
 


### PR DESCRIPTION
Two defects, and the second explains the first.

## Gaps were harvested from fabrications the prompt exists to prevent

`_record_self_gaps` ran **only after the grounding gate rejected a response**, deriving gaps from the ungrounded proper nouns in it. But `_CHAT_GUIDELINE` tells the agent that when it does not know something about its own past, it should say so and let it go — so it emits no proper noun, the gate never fires, and nothing is recorded.

`self_knowledge_gaps` stayed empty across every live run **because the system was working**. The instrumentation measured only its own failures.

What actually reveals a hole in a biography is a question it cannot answer. `_unanswered_self_question_gaps` records on three conditions, all required:

1. the message is interrogative
2. it is about the agent's own life — `_SELF_QUERY_RE`, the second-person mirror of the assertion trigger
3. retrieval surfaced **no `source='biography'` passage** for it

The third is the real test: the store reporting that it looked and found nothing, rather than a guess from vocabulary — which would flag `did you enjoy college` over the word *enjoy*. Recording happens before generation, since it depends only on the question and the store.

## Nothing ever read the table

Recording holes in an autobiography is only useful if something eventually asks about them. `next_gap_to_ask` / `mark_asked` and `_build_wondering_block` close the loop: a gap raised at least twice is offered to the prompt **once**, framed as an opening rather than an instruction. `min_hits` keeps a stray term from becoming a question; `asked_at` stops the same question opening every turn.

## The guideline had to move for it

SELF-GROUNDING ended *"do not ask the user to tell you"* — a flat prohibition on the one behaviour the new block authorises. Injecting the block under that guideline would have recreated the first-boot language bug exactly: a prompt requiring and forbidding the same thing. It now forbids only turning *every* blank into a question, and defers to the block when one is present. A test asserts the two cannot drift apart again.

## Verification

- 13 new tests; **all 8 mutations killed** — drop the biography-surfaced check, the interrogative check, the about-her check, the cold-start guard, the per-question cap, the min-hits threshold, the already-asked filter, or the mark-asked call
- Full backend suite via `--junit-xml`: **760 passed**, 0 failed / errored / skipped
- `ruff check .` clean

## Known limits

**The loop is open at the far end.** When the user answers, nothing writes that answer back into the biography — `refresh_known_terms` reads only `source='biography'` rows, so a fact given in conversation never becomes something the agent knows about itself, and the same gap can be re-recorded forever. Closing it needs a design for which turn counts as the answer, what happens when the user deflects, and how a conversationally-acquired fact is marked. Deliberately not guessed at here.

**No re-ask cooldown.** `mark_asked` fires when the question is *offered*, because nothing downstream can tell an asked question from a skipped one, so a gap that never gets raised is never retried.

**`_SELF_QUERY_RE` misses some phrasings** — questions without a possessive or a biographical verb (`which college did you go to`). Precision was preferred over recall: a noisy table makes the asking channel worse, not better.

Not yet run against a live model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Detects unanswered questions about the assistant’s biography and tracks them as knowledge gaps.
  - Can optionally ask about one recurring unknown detail to improve future responses.
  - Avoids repeatedly asking the same question and filters out unrelated or one-off queries.

- **Bug Fixes**
  - Improved handling when biography information is unavailable.
  - Added graceful fallback behavior when knowledge tracking is unavailable.

- **Tests**
  - Added coverage for question detection, filtering, prompting, repeat suppression, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->