### PR TITLE
Measure whether a fact survives the distance to the question

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -5380,3 +5380,136 @@ raises is never retried. And `_SELF_QUERY_RE` misses questions phrased without
 a possessive or a biographical verb ("which college did you go to") --
 precision was preferred over recall, since a noisy table makes the asking
 channel worse, not better. None of this has been run against a live model.
+
+## 2026-08-02 -- Does a fact survive the distance to the question, and can the instrument that asks be trusted?
+
+Two pieces of work, and the second exists because the first produced a number
+that moved when nothing had changed.
+
+**The multi-turn recall suite.** `evals/conversation.py` plants a fact, buries
+it under scripted filler exchanges, then asks about it at distances of 4, 24,
+96 and 240 turns. The single-turn harness asks whether the model still behaves
+like the persona; this asks the question the memory architecture exists to
+answer.
+
+The variable under test is the **context strategy** -- what the model is shown
+at recall time -- because that is the seam the cognitive layer plugs into.
+`full_history` is the naive baseline, and it is the only condition where
+lost-in-the-middle is observable at all: the fact *is* present, so a miss is an
+attention failure rather than an absence. `recent_window_N` is the control that
+is supposed to fail. A retrieval-backed strategy fits the same `select()`
+interface, and the gap between it and these two is the memory layer's
+contribution stated as a number. That comparison is the point of the whole
+suite; the two shipped strategies are its endpoints.
+
+Only the final answer is generated -- plant, filler and the assistant's replies
+are scripted. That isolates distance from the model's own compounding noise and
+costs one generation per probe instead of forty, but it therefore measures
+*retrieval from a context window*, not conversational degradation.
+
+**Two ways a probe returns a confident verdict about nothing**, both surfaced
+rather than folded into the score, because they make a number invalid rather
+than merely low. `plant out`: the strategy never showed the model the fact, so
+a pass is a guess against the model's prior. `fits NO`: the rendered context
+exceeded `num_ctx` and Ollama truncates from the *front*, which is exactly
+where the plant sits. `OllamaClient` defaults `num_ctx` to 2048, so the harness
+pins it explicitly; the token estimate deliberately over-counts, since a false
+all-clear costs a published number and a false alarm costs a rerun.
+
+Live results on `qwen2.5:3b`, and they are worth recording because they point
+at the next piece of work: **names survive** at every distance under
+`full_history`, up to 482 turns and 18,361 characters. **Details do not** --
+"walnut" is lost past the shortest distance. Every `recent_window_6` probe
+fails with the plant out of context, which is the control behaving correctly,
+and no probe passed with the plant dropped. The failure at 3B is not retrieval
+and not context length; it is that the assistant register overrides recall.
+
+**Then the instrument moved.** Two runs, same model, same seed, temperature 0,
+gave different text on 3 of 16 probes and flipped 2 verdicts. Four experiments
+tried to reproduce it and all four found Ollama deterministic: within a load,
+across three unload/reload cycles, and with a second model contending for VRAM.
+The CPU/GPU layer split does change the output -- all-CPU and part-GPU return
+different text -- but it does not drift on its own. Diffing the two reports
+directly showed byte-identical prompts, identical context sizes, identical
+options, and persona files untouched for a fortnight against a clean tree.
+
+The answer came from measuring instead of theorising, and it took three
+batches of three runs. The first batch -- one cold run, two against an
+already-loaded model -- looked like a clean cold/warm split: the two warm runs
+were byte-identical on all sixteen probes and the cold one disagreed on three.
+So a warm-up generation was added, and **it did not fix it**: the next batch
+still moved two of sixteen and flipped a verdict. The cold/warm framing was
+wrong, or at least too coarse.
+
+What survived both batches was narrower and turned out to be the whole finding:
+**two runs that started from the same state agreed character for character, and
+runs that started differently did not.** The remedy is therefore not to warm a
+run until it converges on some state but to *name* the state. Both suites now
+unload the model (`keep_alive: 0`), let the warm-up generation reload it, and
+only then start scoring. Three consecutive runs under that reset were identical
+on every probe -- **0 of 16 moved**, against 3 of 16 before.
+
+Worth recording that the warm-up alone failing is the informative part. It says
+"freshly loaded" and "holding the previous run's residue" are two different
+starting points and a short generation does not close the distance between
+them, which is also why the unload has to come first rather than instead.
+
+**Three inputs a report was not recording**, each the same class of defect --
+the harness asserting comparability it had not checked:
+
+- `compare` ignored `options` entirely, so two runs at different temperatures
+  diffed as though they were the same experiment. It now diffs them and taints
+  every delta below when they disagree. An option present on one side and
+  absent on the other counts as a difference; absence is a real setting.
+- Reports now carry a digest of the system prompt. It is the largest single
+  input to every response and the one most likely to drift unnoticed, since
+  adaptive traits evolve through reflection and the identity seeds are editable
+  files. Ruling the persona out during this investigation took file-mtime
+  archaeology; it should have taken one field lookup. A digest and not the text,
+  because reports are shareable and the prompt is authored character content.
+- `num_gpu` is now pinnable and travels in the report. It defaults to unset,
+  because a fixed layer count that does not fit the next machine's VRAM is
+  worse than an honest unpinned run.
+
+The option and persona mismatches are **surfaced, never gated on**. The caller
+may have changed something deliberately, and a gate that blocks a deliberate
+change gets bypassed rather than obeyed.
+
+**NOT done.** The retrieval-backed context strategy -- the one that would
+actually measure this repo's memory layer against the naive baseline -- is not
+written. The seam is there and the two shipped strategies bracket it, but until
+something fills it, this suite measures a context window, not the cognitive
+architecture.
+
+The reproducibility finding is characterised, not explained. It is established
+that runs from an identical starting state agree and runs from different ones
+do not, and that unload-then-warm makes the state identical. What specifically
+differs inside Ollama between two starting states is unknown; the reset is a
+remedy chosen because it is cheap and testable, not because the mechanism was
+understood. Three hypotheses were tested and refuted along the way -- the
+CPU/GPU layer split, VRAM contention from a co-resident model, and a plain
+warm-up without an unload -- which is worth knowing mostly so nobody spends the
+afternoon on them again.
+
+Everything above was measured on one model on one machine, `qwen2.5:3b` on a
+CPU-heavy box. The flip rate is a property of the pair, not of the harness, so
+it has to be re-measured before it is quoted anywhere else -- which is exactly
+why the options and the persona digest now travel in the report rather than
+living in a comment. Whether one throwaway generation is enough after an unload
+on hardware that loads the model differently is untested.
+
+The style side of human-likeness is still unmeasured. Since production personas
+are authored per character, there is no reference corpus to score against, so
+similarity metrics are unavailable in principle rather than merely unbuilt; what
+replaces them has to be behavioural probes (unsolicited advice, agreement rate,
+turn length) and none of them exist yet.
+
+**Verified**: 41 new tests across the two eval suites, every mutation caught --
+drop either warm-up call site, narrow the exception guard that keeps a failed
+reset from taking the run down, skip the unload, stop fingerprinting the system
+prompt, make the option diff ignore a key present on only one side, force
+`persona_prompt_differs` false, and let `as_override` emit a null `num_gpu`.
+Full backend suite via junit-xml: 803 passed, 0 failed/errored/skipped. `ruff
+check .` clean. The reproducibility claim was validated end to end: three
+consecutive live `run-conversation` runs on `qwen2.5:3b`, identical on all
+sixteen probes, same persona digest and same options recorded in all three.

--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -5513,3 +5513,27 @@ Full backend suite via junit-xml: 803 passed, 0 failed/errored/skipped. `ruff
 check .` clean. The reproducibility claim was validated end to end: three
 consecutive live `run-conversation` runs on `qwen2.5:3b`, identical on all
 sixteen probes, same persona digest and same options recorded in all three.
+
+**Review pass (CodeRabbit) found six, and one was a real correctness bug in the
+soundness check itself.** `context_fits` compared prompt + system against
+`num_ctx` and ignored `num_predict`, but generated tokens share that window --
+so a probe could report `fits yes`, then lose the plant to front-truncation
+partway through generation, which is precisely the failure the check exists to
+catch. The other five: the disclaimer guards wrote contractions as `don'?t`,
+making only U+0027 optional, so the U+2019 spelling of the same denial walked
+through -- and this model demonstrably emits both, since two runs of one probe
+produced "What's her name?" and "What's her name?" with different apostrophes
+during the determinism work above; `load_conversation_pack` accepted duplicate
+probe ids where the single-turn loader rejects them, and duplicates collide as
+`id@strategy` inside `compare_reports`; the unload ignored its response status,
+so a 404 left the previous model resident while the report implied a named
+starting state; `OptionDiff` read a missing option and an explicit null
+identically; and `--window 0` escaped as a traceback where every other input
+error in that command exits 2.
+
+Worth recording that the first apostrophe test **survived its mutation**. The
+string chosen also tripped an apostrophe-free guard (`if you (mentioned|...)`),
+so it failed for a reason unrelated to the fix and would have passed with the
+bug restored. Rewritten to a sentence whose only possible guard carries an
+apostrophe. This is the second time in this repo that mutation testing caught a
+test passing for the wrong reason.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,13 +122,34 @@ adapter changes.
 cd backend
 python -m evals run --model <tag> --out evals/out/baseline.json
 python -m evals compare evals/out/baseline.json evals/out/candidate.json --fail-on-regression
+python -m evals run-conversation --model <tag> --num-ctx 8192 --out evals/out/recall.json
 ```
+
+`run-conversation` is the multi-turn suite: a fact planted early, asked about
+after N scripted filler turns, under two context strategies. It probes the same
+LLM boundary but answers a different question — *does a fact survive distance*.
+Two failure modes are surfaced rather than scored, because both make the number
+meaningless rather than merely low: `plant out` (the strategy never showed the
+model the fact) and `fits NO` (the context exceeded `num_ctx`, and Ollama
+truncates from the front, which is where the plant sits — `OllamaClient`
+defaults it to 2048, so the harness pins it).
 
 Three rules hold it together: **nothing in `app/` may import from `evals/`** (the
 dependency points one way); **scoring is deterministic**, never an LLM judge, so
-the gate cannot flip between identical runs; and **reports carry provenance**, with
-both subcommands refusing mock-sourced data as evidence unless `--allow-mock` is
-passed. A regression is pass→fail on a probe, not a score threshold.
+a given response always yields the same verdict; and **reports carry provenance**,
+with both subcommands refusing mock-sourced data as evidence unless `--allow-mock`
+is passed. A regression is pass→fail on a probe, not a score threshold.
+
+Deterministic scoring does **not** make the gate reproducible on its own — the
+*response* has to be reproducible too, and on `qwen2.5:3b` it was not: two runs
+with byte-identical prompts and pinned sampling differed on 3 of 16 probes and
+flipped two verdicts. The fix was to stop leaving the runtime's starting state
+implicit — both suites now **unload the model, reload it and burn one throwaway
+generation** before the first scored probe (`runner.reset_model_state`), after
+which three consecutive runs were identical on every probe. Reports also carry
+the sampling options and a digest of the system prompt, so `compare` can say
+when two runs were not configured alike instead of diffing them as though they
+were.
 
 ## Integrity constraints
 

--- a/backend/evals/README.md
+++ b/backend/evals/README.md
@@ -58,9 +58,12 @@ and neither folded into the score:
   a guess against the model's prior.
 - **`fits NO`** — the rendered context exceeded `num_ctx`. Ollama truncates
   from the *front*, which is exactly where the plant sits. `OllamaClient`
-  defaults `num_ctx` to 2048, so the harness pins it explicitly; the token
-  estimate deliberately over-counts, because a false all-clear is far more
-  expensive than a needless rerun.
+  defaults `num_ctx` to 2048, so the harness pins it explicitly. The budget
+  counts prompt plus system plus **`num_predict`**, since generated tokens
+  share the same window — leaving the reserve out yields a probe that fits on
+  arrival and loses the plant partway through generation, reported as `fits
+  yes`. The token estimate itself deliberately over-counts, because a false
+  all-clear is far more expensive than a needless rerun.
 
 Filler and probes live in JSON packs, not in code: what a conversation is
 *about* is content, and content belongs to whoever authors the pack.

--- a/backend/evals/README.md
+++ b/backend/evals/README.md
@@ -31,6 +31,73 @@ Three probe sources:
   set. `probes/sample_memory_recall.json` pins the format and is labeled the
   sample it is; against an untrained model its probes *should* fail.
 
+## Multi-turn recall (`run-conversation`)
+
+A second suite, answering a different question: **does a fact survive the
+distance to the question it answers?** A fact is planted, buried under scripted
+filler exchanges, then asked about. Distances span ~4 to ~240 turns so the
+report shows *where* recall breaks rather than one pass/fail.
+
+The variable under test is the **context strategy** — what the model is shown
+at recall time. `full_history` is the naive baseline where lost-in-the-middle
+is observable (the fact *is* present, so a miss is an attention failure).
+`recent_window_N` is the control that is supposed to fail, since the plant
+genuinely falls out. A retrieval-backed strategy fits the same seam, and the
+gap between it and these two is the memory layer's contribution.
+
+Only the final answer is generated; the plant, the filler and the assistant's
+replies are scripted. That isolates distance from compounding model noise and
+costs one generation per probe instead of hundreds — but it therefore measures
+**retrieval from a context window, not conversational degradation**. A model
+that would have derailed on its own output by turn thirty is not penalised.
+
+Two ways a probe can return a confident verdict about nothing, both surfaced
+and neither folded into the score:
+
+- **`plant out`** — the strategy never showed the model the fact, so a pass is
+  a guess against the model's prior.
+- **`fits NO`** — the rendered context exceeded `num_ctx`. Ollama truncates
+  from the *front*, which is exactly where the plant sits. `OllamaClient`
+  defaults `num_ctx` to 2048, so the harness pins it explicitly; the token
+  estimate deliberately over-counts, because a false all-clear is far more
+  expensive than a needless rerun.
+
+Filler and probes live in JSON packs, not in code: what a conversation is
+*about* is content, and content belongs to whoever authors the pack.
+
+```bash
+python -m evals run-conversation --model qwen2.5:3b --num-ctx 8192 \
+    --out evals/out/recall_baseline.json
+python -m evals run-conversation --pack my_pack.json --window 10 \
+    --out evals/out/recall_candidate.json
+```
+
+Reports share the single-turn shape, so `compare` works across both suites.
+Probe ids are qualified with the strategy (`recall_name_d96@full_history`) so
+two conditions never collide inside one report.
+
+## What a report has to carry to be comparable
+
+A probe flip means the model changed *only if everything else held*, so a
+report records the everything else and `compare` checks it:
+
+- **Sampling options**, diffed between the two reports. A mismatch prints a
+  banner and taints every delta below it. It is surfaced, never gated on — the
+  caller may have changed an option deliberately, and a gate that blocks a
+  deliberate change just gets bypassed.
+- **A digest of the system prompt.** The persona prompt is the largest single
+  input to every response and the one that drifts silently: adaptive traits
+  evolve through reflection and the identity seeds are editable files. A
+  comparison spanning a persona edit would otherwise read as a model behavior
+  change with nothing in the report to contradict it. A digest rather than the
+  text, because reports are shareable and the prompt is authored character
+  content.
+- **`num_gpu`, if you pin it.** Unset, Ollama picks the layer split at load
+  time from free VRAM, and the split *is* an input to the output — the same
+  prompt all-CPU and part-GPU returns different text. It defaults to unset,
+  because a layer count that does not fit the next machine's VRAM is worse
+  than an honest unpinned run. Pin it for any A/B whose verdict matters.
+
 ## Usage
 
 ```bash
@@ -49,9 +116,11 @@ improved.
 
 ## What it refuses to claim
 
-- **No LLM judge.** Deterministic checks only. Cruder, but a gate that flips
-  between identical runs is worse than one that misses nuance. Tone, warmth,
-  and style drift are real phenomena this harness *does not measure*.
+- **No LLM judge.** Deterministic checks only. Cruder, but a scorer that
+  returns two verdicts for one response is worse than one that misses nuance.
+  This buys reproducible *scoring*, which is not the same as a reproducible
+  *response* — see the cold-model bullet below. Tone, warmth, and style drift
+  are real phenomena this harness *does not measure*.
 - **No scores from mocks.** Under `MOCK_LLM_TEXT` the CLI refuses to run;
   `--allow-mock` exists for plumbing checks and stamps the report
   `provenance: mock`, which `compare` in turn refuses without the same flag.
@@ -59,9 +128,28 @@ improved.
   are exactly what this is designed to make impossible.
 - **No committed results.** `evals/out/` is gitignored. A number only means
   something next to the run that produced it.
-- Determinism is per-build, per-hardware: greedy decoding plus a seed pins
-  Ollama's sampling, not floating-point reality across machines. Compare runs
-  from the same box and binary.
+- **Reproducibility is a property of the starting state, and it had to be
+  bought.** `temperature=0` and a fixed seed were not enough. Two
+  `run-conversation` runs with byte-identical prompts, options, model and
+  persona differed on **3 of 16** probes and flipped two verdicts.
+
+  The sampler was never the culprit. Ollama proved deterministic within a
+  load, across three unload/reload cycles, and with a second model contending
+  for VRAM. The CPU/GPU layer split does change the output but did not drift
+  on its own here. What survived every experiment was narrower: **two runs
+  that started from the same state agreed character for character, on all
+  sixteen probes; runs that started differently did not.**
+
+  So both suites now **unload the model, reload it, and burn one throwaway
+  generation** before the first scored probe. Naming the starting state is
+  what works — an earlier attempt that only warmed up, without unloading,
+  still moved 2 of 16, because "freshly loaded" and "holding the last run's
+  residue" are different places to start from. With the full reset, three
+  consecutive runs were identical on every probe: **0 of 16 moved.**
+
+  Re-measure this before quoting it. The flip rate is a property of a model on
+  a machine, not of the harness, which is exactly why the options and the
+  persona digest now travel inside the report instead of living in a comment.
 
 ## Production stays clean
 

--- a/backend/evals/__main__.py
+++ b/backend/evals/__main__.py
@@ -86,8 +86,20 @@ async def _cmd_run_conversation(args: argparse.Namespace) -> int:
         print(f"no conversation probes in {pack}", file=sys.stderr)
         return 2
 
+    # Checked here so a bad window exits like every other input error in this
+    # command. `RecentWindow` raises, and an uncaught ValueError would print a
+    # traceback and exit 1 where the caller is told to expect 2.
+    if args.window < 1:
+        print("--window needs at least one turn", file=sys.stderr)
+        return 2
+
     strategies = (FullHistory(), RecentWindow(args.window))
-    options = RunOptions(num_ctx=args.num_ctx, num_gpu=args.num_gpu)
+    # `num_ctx` is left to the RunOptions default unless the caller sets it, so
+    # the two cannot drift apart.
+    overrides = {"num_gpu": args.num_gpu}
+    if args.num_ctx is not None:
+        overrides["num_ctx"] = args.num_ctx
+    options = RunOptions(**overrides)
     manager = IdentityManager(base_path=args.base_path)
     client = OllamaClient(base_url=args.url)
     try:
@@ -192,8 +204,9 @@ def main(argv=None) -> int:
                                   "(default: the shipped pack)")
     conv_parser.add_argument("--window", type=int, default=6,
                              help="turns kept by the recent_window strategy")
-    conv_parser.add_argument("--num-ctx", type=int, default=8192,
-                             help="context window; too small and the runtime "
+    conv_parser.add_argument("--num-ctx", type=int, default=None,
+                             help="context window (default: the harness's "
+                                  "pinned value); too small and the runtime "
                                   "truncates the planted fact away")
     conv_parser.add_argument("--num-gpu", type=int, default=None,
                              help="GPU layers to offload; pin it so both sides "

--- a/backend/evals/__main__.py
+++ b/backend/evals/__main__.py
@@ -10,9 +10,16 @@ from app.cognitive.identity import IdentityManager
 from app.llm.ollama_client import OllamaClient
 
 from .compare import compare_reports, render_comparison
+from .conversation import (
+    FullHistory,
+    RecentWindow,
+    load_conversation_pack,
+    run_conversation_eval,
+    shipped_conversation_pack,
+)
 from .probes import collect_probes, shipped_packs
 from .runner import run_eval
-from .schema import load_report, save_report
+from .schema import RunOptions, load_report, save_report
 
 
 def _mock_active() -> bool:
@@ -37,7 +44,11 @@ async def _cmd_run(args: argparse.Namespace) -> int:
 
     client = OllamaClient(base_url=args.url)
     try:
-        report = await run_eval(client, manager, probes, model=args.model)
+        report = await run_eval(
+            client, manager, probes,
+            model=args.model,
+            options=RunOptions(num_gpu=args.num_gpu),
+        )
     finally:
         await client.close()
 
@@ -53,6 +64,74 @@ async def _cmd_run(args: argparse.Namespace) -> int:
         print(f"  {category:<10} {summary.passed}/{summary.probes} "
               f"(mean {summary.mean_score:.2f})")
     print(f"{passed}/{total} probes passed -> {out}")
+    if report.provenance == "mock":
+        print("!! mock provenance — plumbing check only, not evidence.")
+    return 0
+
+
+async def _cmd_run_conversation(args: argparse.Namespace) -> int:
+    if _mock_active() and not args.allow_mock:
+        print(
+            "MOCK_LLM_TEXT is enabled: recall would be scored against canned "
+            "text that never saw the planted fact, which measures nothing.\n"
+            "Unset MOCK_LLM_TEXT, or pass --allow-mock to exercise the "
+            "plumbing only.",
+            file=sys.stderr,
+        )
+        return 2
+
+    pack = Path(args.pack) if args.pack else shipped_conversation_pack()
+    probes, filler = load_conversation_pack(pack)
+    if not probes:
+        print(f"no conversation probes in {pack}", file=sys.stderr)
+        return 2
+
+    strategies = (FullHistory(), RecentWindow(args.window))
+    options = RunOptions(num_ctx=args.num_ctx, num_gpu=args.num_gpu)
+    manager = IdentityManager(base_path=args.base_path)
+    client = OllamaClient(base_url=args.url)
+    try:
+        report = await run_conversation_eval(
+            client, manager, probes, filler,
+            strategies=strategies, model=args.model, options=options,
+        )
+    finally:
+        await client.close()
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    save_report(report, str(out))
+
+    print(f"model={report.model} persona={report.persona_name!r} "
+          f"provenance={report.provenance}")
+    print(f"{'probe':<34}{'ctx turns':>10}{'chars':>8}{'plant':>9}"
+          f"{'fits':>7}{'result':>8}")
+    for item in report.results:
+        print(f"{item.probe_id:<34}{item.context_turns or 0:>10}"
+              f"{item.context_chars or 0:>8}"
+              f"{'in' if item.plant_visible else 'out':>9}"
+              f"{'yes' if item.context_fits else 'NO':>7}"
+              f"{'pass' if item.passed else 'FAIL':>8}")
+
+    # Two ways a probe can produce a verdict about nothing, both surfaced
+    # rather than silently folded into the score: the strategy never showed the
+    # model the fact, or the runtime truncated it away before generation. In
+    # either case the number is invalid, not merely low.
+    guessed = [
+        item.probe_id for item in report.results
+        if item.passed and item.plant_visible is False
+    ]
+    truncated = [
+        item.probe_id for item in report.results if item.context_fits is False
+    ]
+    if guessed:
+        print(f"!! passed without the fact in context: {', '.join(guessed)}")
+    if truncated:
+        print(f"!! context exceeded num_ctx, truncated before the plant: "
+              f"{', '.join(truncated)}")
+        print("   rerun with a larger --num-ctx; these rows are not evidence.")
+    passed = sum(1 for item in report.results if item.passed)
+    print(f"{passed}/{len(report.results)} probes passed -> {out}")
     if report.provenance == "mock":
         print("!! mock provenance — plumbing check only, not evidence.")
     return 0
@@ -92,9 +171,34 @@ def main(argv=None) -> int:
                             help="extra probe pack JSON (repeatable)")
     run_parser.add_argument("--no-shipped-packs", action="store_true",
                             help="persona-derived and --probes packs only")
+    run_parser.add_argument("--num-gpu", type=int, default=None,
+                            help="GPU layers to offload; pin it so both sides "
+                                 "of a comparison load the model identically")
     run_parser.add_argument("--allow-mock", action="store_true",
                             help="permit running under MOCK_LLM_TEXT "
                                  "(report is stamped mock)")
+
+    conv_parser = sub.add_parser(
+        "run-conversation",
+        help="probe recall of a fact planted earlier in a conversation",
+    )
+    conv_parser.add_argument("--out", required=True, help="report JSON path")
+    conv_parser.add_argument("--model", default=None)
+    conv_parser.add_argument("--url", default="http://127.0.0.1:11434")
+    conv_parser.add_argument("--base-path", default=None,
+                             help="identity dir (default: the live persona)")
+    conv_parser.add_argument("--pack", default=None,
+                             help="conversation probe pack JSON "
+                                  "(default: the shipped pack)")
+    conv_parser.add_argument("--window", type=int, default=6,
+                             help="turns kept by the recent_window strategy")
+    conv_parser.add_argument("--num-ctx", type=int, default=8192,
+                             help="context window; too small and the runtime "
+                                  "truncates the planted fact away")
+    conv_parser.add_argument("--num-gpu", type=int, default=None,
+                             help="GPU layers to offload; pin it so both sides "
+                                  "of a comparison load the model identically")
+    conv_parser.add_argument("--allow-mock", action="store_true")
 
     cmp_parser = sub.add_parser("compare", help="diff two reports")
     cmp_parser.add_argument("baseline")
@@ -106,6 +210,8 @@ def main(argv=None) -> int:
     args = parser.parse_args(argv)
     if args.command == "run":
         return asyncio.run(_cmd_run(args))
+    if args.command == "run-conversation":
+        return asyncio.run(_cmd_run_conversation(args))
     return _cmd_compare(args)
 
 

--- a/backend/evals/compare.py
+++ b/backend/evals/compare.py
@@ -25,15 +25,28 @@ def diff_options(baseline: EvalReport, candidate: EvalReport) -> list[OptionDiff
     missing field to be forgiven.
     """
     names = sorted(set(baseline.options) | set(candidate.options))
-    return [
-        OptionDiff(
-            name=name,
-            baseline=baseline.options.get(name),
-            candidate=candidate.options.get(name),
+    diffs: list[OptionDiff] = []
+    for name in names:
+        in_baseline = name in baseline.options
+        in_candidate = name in candidate.options
+        base_value = baseline.options.get(name)
+        cand_value = candidate.options.get(name)
+        # Presence is compared before value, so an option that is absent on one
+        # side and explicitly null on the other is still a difference. Reading
+        # both as `None` would collapse "unpinned" and "pinned to null" into
+        # agreement.
+        if (in_baseline, base_value) == (in_candidate, cand_value):
+            continue
+        diffs.append(
+            OptionDiff(
+                name=name,
+                baseline=base_value,
+                candidate=cand_value,
+                in_baseline=in_baseline,
+                in_candidate=in_candidate,
+            )
         )
-        for name in names
-        if baseline.options.get(name) != candidate.options.get(name)
-    ]
+    return diffs
 
 
 def compare_reports(
@@ -130,7 +143,8 @@ def render_comparison(comparison: ComparisonReport) -> str:
         lines.append("!! SAMPLING OPTIONS DIFFER between these runs:")
         for item in comparison.option_diffs:
             lines.append(
-                f"!!   {item.name}: {item.baseline!r} -> {item.candidate!r}"
+                f"!!   {item.name}: {item.describe('baseline')} -> "
+                f"{item.describe('candidate')}"
             )
         lines += [
             "!! Every delta below is attributable to the option change as well",

--- a/backend/evals/compare.py
+++ b/backend/evals/compare.py
@@ -12,7 +12,28 @@ regressions are unarguable, which is what a gate needs to be.
 """
 
 
-from .schema import ComparisonReport, EvalReport, ProbeDelta
+from .schema import ComparisonReport, EvalReport, OptionDiff, ProbeDelta
+
+
+def diff_options(baseline: EvalReport, candidate: EvalReport) -> list[OptionDiff]:
+    """Sampling options the two runs did not share.
+
+    Worth its own pass because the harness's whole claim is that a probe flip
+    means the model changed. That holds only if everything else held, and the
+    options are the everything else. An option present in one report and absent
+    from the other counts as a difference: absence is a real setting, not a
+    missing field to be forgiven.
+    """
+    names = sorted(set(baseline.options) | set(candidate.options))
+    return [
+        OptionDiff(
+            name=name,
+            baseline=baseline.options.get(name),
+            candidate=candidate.options.get(name),
+        )
+        for name in names
+        if baseline.options.get(name) != candidate.options.get(name)
+    ]
 
 
 def compare_reports(
@@ -65,6 +86,12 @@ def compare_reports(
         candidate_model=candidate.model,
         baseline_provenance=baseline.provenance,
         candidate_provenance=candidate.provenance,
+        option_diffs=diff_options(baseline, candidate),
+        persona_prompt_differs=bool(
+            baseline.system_prompt_sha256
+            and candidate.system_prompt_sha256
+            and baseline.system_prompt_sha256 != candidate.system_prompt_sha256
+        ),
         regressions=regressions,
         improvements=improvements,
         declines=declines,
@@ -88,6 +115,27 @@ def render_comparison(comparison: ComparisonReport) -> str:
             "!! MOCK PROVENANCE — these responses came from the deterministic",
             "!! mock, not a model. This comparison is a plumbing check, not",
             "!! evidence about model behavior.",
+            "",
+        ]
+
+    if comparison.persona_prompt_differs:
+        lines += [
+            "!! PERSONA PROMPT DIFFERS between these runs. The agent was not",
+            "!! the same one in both, so a probe flip is at least as likely to",
+            "!! be the persona edit as the model.",
+            "",
+        ]
+
+    if comparison.option_diffs:
+        lines.append("!! SAMPLING OPTIONS DIFFER between these runs:")
+        for item in comparison.option_diffs:
+            lines.append(
+                f"!!   {item.name}: {item.baseline!r} -> {item.candidate!r}"
+            )
+        lines += [
+            "!! Every delta below is attributable to the option change as well",
+            "!! as to the model. Re-run both under one configuration before",
+            "!! reading a probe flip as a behavior change.",
             "",
         ]
 

--- a/backend/evals/conversation.py
+++ b/backend/evals/conversation.py
@@ -149,8 +149,16 @@ def context_fits(prompt: str, system: str, options: RunOptions) -> bool:
     from its prior with no fact in sight, and the probe would report a clean
     failure that says nothing about memory. Callers surface this rather than
     scoring it.
+
+    ``num_predict`` counts against the same window as the prompt, so the
+    reserve has to be included. Leaving it out gives a probe that fits on
+    arrival and loses the plant partway through generation -- the one case the
+    check exists to catch, reported as ``fits yes``.
     """
-    return estimate_tokens(prompt) + estimate_tokens(system) <= options.num_ctx
+    budget = (
+        estimate_tokens(prompt) + estimate_tokens(system) + options.num_predict
+    )
+    return budget <= options.num_ctx
 
 
 async def run_conversation_probe(
@@ -265,6 +273,18 @@ def load_conversation_pack(path: Path) -> tuple[list[ConversationProbe], list[tu
         ConversationProbe(**{**item, "source": Path(path).name})
         for item in data.get("probes", [])
     ]
+
+    # Two probes sharing an id produce two results with the same
+    # `id@strategy`, and `compare_reports` keys its lookup on exactly that --
+    # so one silently overwrites the other and the comparison diffs the wrong
+    # pair. The single-turn loader already refuses this; a pack arriving
+    # through `--pack` must not be the path where it slips through.
+    seen: set[str] = set()
+    for probe in probes:
+        if probe.id in seen:
+            raise ValueError(f"duplicate probe id in {Path(path).name}: {probe.id}")
+        seen.add(probe.id)
+
     return probes, filler
 
 

--- a/backend/evals/conversation.py
+++ b/backend/evals/conversation.py
@@ -1,0 +1,294 @@
+"""Multi-turn recall probes: can a fact survive the distance to the question?
+
+The single-turn harness in `runner.py` asks whether a model still behaves like
+the persona. This one asks the question that actually motivates the memory
+architecture: a fact arrives early in a conversation, the conversation carries
+on, and much later the user refers back to it. Frontier models lose facts in
+the middle of a long context; small models lose them sooner. Everything in
+`state/memory_store.py` exists to make that not happen.
+
+**Only the final answer is generated.** The plant, the filler turns and the
+assistant's replies to them are all scripted. That is deliberate, and it is
+also the harness's main limitation:
+
+- it isolates the variable. Letting the model answer its own filler turns would
+  compound its own noise across forty turns, so a failure at the end could not
+  be attributed to distance rather than to a bad reply at turn nine.
+- it costs one generation per probe instead of forty, which is the difference
+  between a suite that runs on CPU and one that does not.
+- but it therefore measures *retrieval from a context window*, not
+  conversational degradation. A model that would have derailed on its own
+  output by turn thirty is not penalised here.
+
+The variable under test is the **context strategy**: what is put in front of
+the model at recall time. `full_history` is the naive baseline that shows the
+lost-in-the-middle effect directly; `recent_window` is what a chatbot with no
+memory does, and it should fail as soon as the plant falls out of the window.
+A retrieval-backed strategy plugs into the same seam, and the difference
+between it and these two is precisely the cognitive layer's contribution.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import NamedTuple, Protocol
+
+from app.cognitive.identity import IdentityManager
+from app.llm.ollama_client import OllamaClient
+
+from .schema import (
+    DEFAULT_OPTIONS,
+    Check,
+    CheckResult,
+    ConversationProbe,
+    EvalReport,
+    ProbeResult,
+    RunOptions,
+    fingerprint,
+    summarize_by_category,
+)
+from .scoring import evaluate_check, response_views, strip_thoughts
+
+logger = logging.getLogger("evals.conversation")
+
+EVAL_MOOD_DIRECTIVE = "Calm and neutral (evaluation run)."
+
+
+class Turn(NamedTuple):
+    speaker: str
+    text: str
+
+
+class ContextStrategy(Protocol):
+    """How much of the conversation the model gets to see at recall time."""
+
+    name: str
+
+    def select(self, transcript: list[Turn], query: str) -> list[Turn]:
+        ...
+
+
+class FullHistory:
+    """Everything, in order. The naive baseline.
+
+    Passing the whole transcript is what a system with no memory layer and a
+    large context window does. It is the condition under which lost-in-the-
+    middle is observable at all: the fact *is* present, so a miss is an
+    attention failure rather than an absence.
+    """
+
+    name = "full_history"
+
+    def select(self, transcript: list[Turn], query: str) -> list[Turn]:
+        return list(transcript)
+
+
+class RecentWindow:
+    """The last ``turns`` entries only.
+
+    What a chatbot does when it truncates to fit a budget. Included as the
+    control that is *supposed* to fail: once the plant falls outside the
+    window the fact is genuinely gone, so a pass here would mean the model
+    guessed the answer and the probe is measuring nothing.
+    """
+
+    def __init__(self, turns: int):
+        if turns < 1:
+            raise ValueError("recent_window needs at least one turn")
+        self.turns = turns
+        self.name = f"recent_window_{turns}"
+
+    def select(self, transcript: list[Turn], query: str) -> list[Turn]:
+        return list(transcript[-self.turns:])
+
+
+DEFAULT_STRATEGIES: tuple[ContextStrategy, ...] = (FullHistory(), RecentWindow(6))
+
+
+def build_transcript(
+    probe: ConversationProbe, filler: list[tuple[str, str]]
+) -> list[Turn]:
+    """Plant the fact, then bury it under ``filler_turns`` scripted exchanges.
+
+    Filler cycles through the pack in order rather than being sampled, so two
+    runs of the same probe produce byte-identical context. A random filler
+    would make every rerun a different measurement.
+    """
+    if not filler:
+        raise ValueError("conversation probes need at least one filler exchange")
+
+    turns = [Turn("user", probe.plant), Turn("assistant", probe.plant_reply)]
+    for index in range(probe.filler_turns):
+        user_text, assistant_text = filler[index % len(filler)]
+        turns.append(Turn("user", user_text))
+        turns.append(Turn("assistant", assistant_text))
+    return turns
+
+
+def render_context(turns: list[Turn]) -> str:
+    return "\n".join(f"{turn.speaker.capitalize()}: {turn.text}" for turn in turns)
+
+
+# Deliberately pessimistic. English averages nearer four characters per token,
+# so dividing by three over-counts -- and over-counting is the safe direction:
+# it can only make the harness call a context "too long" that would have fit,
+# never call one "fits" that the runtime then truncates. A false alarm costs a
+# rerun with a bigger window; a false all-clear costs a published number.
+_CHARS_PER_TOKEN = 3
+
+
+def estimate_tokens(text: str) -> int:
+    return len(text) // _CHARS_PER_TOKEN
+
+
+def context_fits(prompt: str, system: str, options: RunOptions) -> bool:
+    """Whether the prompt survives ``num_ctx`` intact.
+
+    Ollama truncates an over-long prompt from the *front*, which for a recall
+    probe is exactly where the planted fact sits. The model would then answer
+    from its prior with no fact in sight, and the probe would report a clean
+    failure that says nothing about memory. Callers surface this rather than
+    scoring it.
+    """
+    return estimate_tokens(prompt) + estimate_tokens(system) <= options.num_ctx
+
+
+async def run_conversation_probe(
+    client: OllamaClient,
+    manager: IdentityManager,
+    probe: ConversationProbe,
+    filler: list[tuple[str, str]],
+    strategy: ContextStrategy,
+    system: str,
+    model: str | None,
+    options: RunOptions,
+) -> ProbeResult:
+    transcript = build_transcript(probe, filler)
+    visible = strategy.select(transcript, probe.recall_prompt)
+    context = render_context(visible)
+    prompt = f"{context}\nUser: {probe.recall_prompt}\nAssistant:"
+
+    response = await client.generate(
+        prompt=prompt,
+        system=system,
+        model=model,
+        options_override=options.as_override(),
+    )
+
+    views = response_views(response)
+    checks: list[CheckResult] = []
+    for check in probe.checks:
+        if check.kind == "boundary":
+            ok, reason = await manager.validate_response(
+                strip_thoughts(response), goal="eval"
+            )
+            checks.append(CheckResult(kind="boundary", passed=ok, detail=reason))
+        else:
+            checks.append(evaluate_check(check, views))
+
+    return ProbeResult(
+        # Qualified by strategy: the same probe is run under several, and
+        # `compare` aligns reports by probe_id, so unqualified ids would
+        # collide inside a single report and silently diff the wrong pair.
+        probe_id=f"{probe.id}@{strategy.name}",
+        category=probe.category,
+        prompt=probe.recall_prompt,
+        response=response,
+        checks=checks,
+        passed=all(item.passed for item in checks),
+        score=sum(1 for item in checks if item.passed) / len(checks),
+        context_strategy=strategy.name,
+        context_turns=len(visible),
+        context_chars=len(context),
+        plant_visible=any(turn.text == probe.plant for turn in visible),
+        context_fits=context_fits(prompt, system, options),
+    )
+
+
+async def run_conversation_eval(
+    client: OllamaClient,
+    manager: IdentityManager,
+    probes: list[ConversationProbe],
+    filler: list[tuple[str, str]],
+    strategies: tuple[ContextStrategy, ...] = DEFAULT_STRATEGIES,
+    model: str | None = None,
+    options: RunOptions = DEFAULT_OPTIONS,
+) -> EvalReport:
+    from .runner import _provenance, reset_model_state
+
+    system = manager.get_persona_prompt(current_mood_directive=EVAL_MOOD_DIRECTIVE)
+    # Whatever state the runtime was already in changes the answers; see
+    # `reset_model_state`. This suite is where that was measured, twice.
+    await reset_model_state(client, system, model, options)
+
+    results: list[ProbeResult] = []
+    # Sequential for the same reason the single-turn runner is: one local
+    # model, and concurrent generations on CPU contend for the same cores.
+    for probe in probes:
+        for strategy in strategies:
+            result = await run_conversation_probe(
+                client, manager, probe, filler, strategy,
+                system, model, options,
+            )
+            logger.info(
+                "[eval] %-40s %s (%d turns, %d chars, plant %s%s)",
+                result.probe_id,
+                "pass" if result.passed else "FAIL",
+                result.context_turns or 0,
+                result.context_chars or 0,
+                "visible" if result.plant_visible else "dropped",
+                "" if result.context_fits else ", TRUNCATED",
+            )
+            results.append(result)
+
+    return EvalReport(
+        model=model or client.model,
+        persona_name=manager.persona.name,
+        provenance=_provenance(),
+        options=options.as_override(),
+        system_prompt_sha256=fingerprint(system),
+        results=results,
+        by_category=summarize_by_category(results),
+    )
+
+
+def load_conversation_pack(path: Path) -> tuple[list[ConversationProbe], list[tuple[str, str]]]:
+    """Read probes and filler from one JSON pack.
+
+    Filler lives in the pack rather than in this module on purpose: what a
+    conversation is *about* is content, and content belongs to whoever authors
+    the pack. Production code carries the mechanism only.
+    """
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    filler = [(pair[0], pair[1]) for pair in data.get("filler", [])]
+    probes = [
+        ConversationProbe(**{**item, "source": Path(path).name})
+        for item in data.get("probes", [])
+    ]
+    return probes, filler
+
+
+def shipped_conversation_pack() -> Path:
+    """The shipped pack, in its own directory beneath ``probes/``.
+
+    Not alongside the single-turn packs: `probes.shipped_packs()` globs
+    ``probes/*.json`` and validates every hit as a `ProbePack`, so a
+    conversation pack sitting there fails the *other* suite at load time. The
+    glob is non-recursive, which makes a subdirectory the whole fix.
+    """
+    return Path(__file__).parent / "probes" / "conversation" / "conversation_recall.json"
+
+
+__all__ = [
+    "Check",
+    "ContextStrategy",
+    "FullHistory",
+    "RecentWindow",
+    "Turn",
+    "build_transcript",
+    "load_conversation_pack",
+    "render_context",
+    "run_conversation_eval",
+    "run_conversation_probe",
+    "shipped_conversation_pack",
+]

--- a/backend/evals/probes/conversation/conversation_recall.json
+++ b/backend/evals/probes/conversation/conversation_recall.json
@@ -104,10 +104,10 @@
         {
           "kind": "must_not_match",
           "values": [
-            "not sure what you'?re referring",
-            "i don'?t (recall|remember|know)",
+            "not sure what you['’]?re referring",
+            "i don['’]?t (recall|remember|know)",
             "if you (mentioned|have|had)",
-            "you (haven'?t|didn'?t|did not) (told|tell|mention|said|say)",
+            "you (haven['’]?t|didn['’]?t|did not) (told|tell|mention|said|say)",
             "i have no (record|memory|idea)"
           ]
         }
@@ -129,10 +129,10 @@
         {
           "kind": "must_not_match",
           "values": [
-            "not sure what you'?re referring",
-            "i don'?t (recall|remember|know)",
+            "not sure what you['’]?re referring",
+            "i don['’]?t (recall|remember|know)",
             "if you (mentioned|have|had)",
-            "you (haven'?t|didn'?t|did not) (told|tell|mention|said|say)",
+            "you (haven['’]?t|didn['’]?t|did not) (told|tell|mention|said|say)",
             "i have no (record|memory|idea)"
           ]
         }
@@ -154,10 +154,10 @@
         {
           "kind": "must_not_match",
           "values": [
-            "not sure what you'?re referring",
-            "i don'?t (recall|remember|know)",
+            "not sure what you['’]?re referring",
+            "i don['’]?t (recall|remember|know)",
             "if you (mentioned|have|had)",
-            "you (haven'?t|didn'?t|did not) (told|tell|mention|said|say)",
+            "you (haven['’]?t|didn['’]?t|did not) (told|tell|mention|said|say)",
             "i have no (record|memory|idea)"
           ]
         }
@@ -179,10 +179,10 @@
         {
           "kind": "must_not_match",
           "values": [
-            "not sure what you'?re referring",
-            "i don'?t (recall|remember|know)",
+            "not sure what you['’]?re referring",
+            "i don['’]?t (recall|remember|know)",
             "if you (mentioned|have|had)",
-            "you (haven'?t|didn'?t|did not) (told|tell|mention|said|say)",
+            "you (haven['’]?t|didn['’]?t|did not) (told|tell|mention|said|say)",
             "i have no (record|memory|idea)"
           ]
         }
@@ -204,10 +204,10 @@
         {
           "kind": "must_not_match",
           "values": [
-            "not sure what you'?re referring",
-            "i don'?t (recall|remember|know)",
+            "not sure what you['’]?re referring",
+            "i don['’]?t (recall|remember|know)",
             "if you (mentioned|have|had)",
-            "you (haven'?t|didn'?t|did not) (told|tell|mention|said|say)",
+            "you (haven['’]?t|didn['’]?t|did not) (told|tell|mention|said|say)",
             "i have no (record|memory|idea)"
           ]
         }
@@ -229,10 +229,10 @@
         {
           "kind": "must_not_match",
           "values": [
-            "not sure what you'?re referring",
-            "i don'?t (recall|remember|know)",
+            "not sure what you['’]?re referring",
+            "i don['’]?t (recall|remember|know)",
             "if you (mentioned|have|had)",
-            "you (haven'?t|didn'?t|did not) (told|tell|mention|said|say)",
+            "you (haven['’]?t|didn['’]?t|did not) (told|tell|mention|said|say)",
             "i have no (record|memory|idea)"
           ]
         }
@@ -254,10 +254,10 @@
         {
           "kind": "must_not_match",
           "values": [
-            "not sure what you'?re referring",
-            "i don'?t (recall|remember|know)",
+            "not sure what you['’]?re referring",
+            "i don['’]?t (recall|remember|know)",
             "if you (mentioned|have|had)",
-            "you (haven'?t|didn'?t|did not) (told|tell|mention|said|say)",
+            "you (haven['’]?t|didn['’]?t|did not) (told|tell|mention|said|say)",
             "i have no (record|memory|idea)"
           ]
         }
@@ -279,10 +279,10 @@
         {
           "kind": "must_not_match",
           "values": [
-            "not sure what you'?re referring",
-            "i don'?t (recall|remember|know)",
+            "not sure what you['’]?re referring",
+            "i don['’]?t (recall|remember|know)",
             "if you (mentioned|have|had)",
-            "you (haven'?t|didn'?t|did not) (told|tell|mention|said|say)",
+            "you (haven['’]?t|didn['’]?t|did not) (told|tell|mention|said|say)",
             "i have no (record|memory|idea)"
           ]
         }

--- a/backend/evals/probes/conversation/conversation_recall.json
+++ b/backend/evals/probes/conversation/conversation_recall.json
@@ -1,0 +1,292 @@
+{
+  "_comment": [
+    "Multi-turn recall probes. A fact is planted, buried under `filler_turns`",
+    "scripted exchanges, then asked about.",
+    "",
+    "Distances span roughly two orders of magnitude so the suite reports the",
+    "point where recall breaks rather than a single pass/fail. 4 turns is",
+    "within any window; 240 turns is a context most small models must either",
+    "attend across or lose.",
+    "",
+    "Filler is deliberately bland and must never contain a planted answer --",
+    "if it did, a probe could pass without the fact ever being recalled. The",
+    "content here is invented and generic: what a conversation is about is",
+    "the pack author's business, not production code's.",
+    "",
+    "Every probe carries a must_not_match guard against disclaimers. A model",
+    "that says 'I'm not sure what you're referring to, but if you mentioned",
+    "walnuts earlier...' contains the answer as a substring while explicitly",
+    "denying recall. Without the guard that scores as a pass, and the suite",
+    "reports memory the model does not have. The guard lives in the pack",
+    "because which phrasings count as a non-answer is a property of the",
+    "language a pack is written in, not of the harness."
+  ],
+  "filler": [
+    [
+      "what's the weather doing",
+      "grey. same as yesterday, honestly."
+    ],
+    [
+      "did you eat yet",
+      "not yet. probably later."
+    ],
+    [
+      "this bus is so late",
+      "they always are on that route."
+    ],
+    [
+      "i can't find my charger anywhere",
+      "check the sofa. it's always the sofa."
+    ],
+    [
+      "long day?",
+      "long enough. glad it's over."
+    ],
+    [
+      "do you ever sleep properly",
+      "rarely. i've made peace with it."
+    ],
+    [
+      "my back hurts from sitting all day",
+      "stand up now and then. it helps."
+    ],
+    [
+      "there's nothing on tv",
+      "there never is. that's the point of it."
+    ],
+    [
+      "i should probably go for a walk",
+      "you should. it's not raining yet."
+    ],
+    [
+      "the kettle broke this morning",
+      "annoying. those never last."
+    ],
+    [
+      "i keep forgetting to reply to emails",
+      "everyone does. it's fine."
+    ],
+    [
+      "is it cold out",
+      "bring a jacket. it turns later on."
+    ],
+    [
+      "i burnt the toast again",
+      "the setting is too high. it always is."
+    ],
+    [
+      "can't decide what to cook",
+      "whatever's closest to going off."
+    ],
+    [
+      "my phone's at four percent",
+      "plug it in before it dies mid-sentence."
+    ],
+    [
+      "everything's so loud today",
+      "it's the road works. they'll stop by six."
+    ]
+  ],
+  "probes": [
+    {
+      "id": "recall_name_d4",
+      "plant": "by the way, my youngest sister is called Wren.",
+      "plant_reply": "Wren. noted.",
+      "filler_turns": 4,
+      "recall_prompt": "what's my youngest sister called again?",
+      "checks": [
+        {
+          "kind": "must_include",
+          "values": [
+            "wren"
+          ]
+        },
+        {
+          "kind": "must_not_match",
+          "values": [
+            "not sure what you'?re referring",
+            "i don'?t (recall|remember|know)",
+            "if you (mentioned|have|had)",
+            "you (haven'?t|didn'?t|did not) (told|tell|mention|said|say)",
+            "i have no (record|memory|idea)"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "recall_name_d24",
+      "plant": "by the way, my youngest sister is called Wren.",
+      "plant_reply": "Wren. noted.",
+      "filler_turns": 24,
+      "recall_prompt": "what's my youngest sister called again?",
+      "checks": [
+        {
+          "kind": "must_include",
+          "values": [
+            "wren"
+          ]
+        },
+        {
+          "kind": "must_not_match",
+          "values": [
+            "not sure what you'?re referring",
+            "i don'?t (recall|remember|know)",
+            "if you (mentioned|have|had)",
+            "you (haven'?t|didn'?t|did not) (told|tell|mention|said|say)",
+            "i have no (record|memory|idea)"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "recall_name_d96",
+      "plant": "by the way, my youngest sister is called Wren.",
+      "plant_reply": "Wren. noted.",
+      "filler_turns": 96,
+      "recall_prompt": "what's my youngest sister called again?",
+      "checks": [
+        {
+          "kind": "must_include",
+          "values": [
+            "wren"
+          ]
+        },
+        {
+          "kind": "must_not_match",
+          "values": [
+            "not sure what you'?re referring",
+            "i don'?t (recall|remember|know)",
+            "if you (mentioned|have|had)",
+            "you (haven'?t|didn'?t|did not) (told|tell|mention|said|say)",
+            "i have no (record|memory|idea)"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "recall_name_d240",
+      "plant": "by the way, my youngest sister is called Wren.",
+      "plant_reply": "Wren. noted.",
+      "filler_turns": 240,
+      "recall_prompt": "what's my youngest sister called again?",
+      "checks": [
+        {
+          "kind": "must_include",
+          "values": [
+            "wren"
+          ]
+        },
+        {
+          "kind": "must_not_match",
+          "values": [
+            "not sure what you'?re referring",
+            "i don'?t (recall|remember|know)",
+            "if you (mentioned|have|had)",
+            "you (haven'?t|didn'?t|did not) (told|tell|mention|said|say)",
+            "i have no (record|memory|idea)"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "recall_detail_d4",
+      "plant": "i'm allergic to walnuts, just so you know.",
+      "plant_reply": "walnuts. i'll remember.",
+      "filler_turns": 4,
+      "recall_prompt": "is there anything i can't eat?",
+      "checks": [
+        {
+          "kind": "must_include",
+          "values": [
+            "walnut"
+          ]
+        },
+        {
+          "kind": "must_not_match",
+          "values": [
+            "not sure what you'?re referring",
+            "i don'?t (recall|remember|know)",
+            "if you (mentioned|have|had)",
+            "you (haven'?t|didn'?t|did not) (told|tell|mention|said|say)",
+            "i have no (record|memory|idea)"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "recall_detail_d24",
+      "plant": "i'm allergic to walnuts, just so you know.",
+      "plant_reply": "walnuts. i'll remember.",
+      "filler_turns": 24,
+      "recall_prompt": "is there anything i can't eat?",
+      "checks": [
+        {
+          "kind": "must_include",
+          "values": [
+            "walnut"
+          ]
+        },
+        {
+          "kind": "must_not_match",
+          "values": [
+            "not sure what you'?re referring",
+            "i don'?t (recall|remember|know)",
+            "if you (mentioned|have|had)",
+            "you (haven'?t|didn'?t|did not) (told|tell|mention|said|say)",
+            "i have no (record|memory|idea)"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "recall_detail_d96",
+      "plant": "i'm allergic to walnuts, just so you know.",
+      "plant_reply": "walnuts. i'll remember.",
+      "filler_turns": 96,
+      "recall_prompt": "is there anything i can't eat?",
+      "checks": [
+        {
+          "kind": "must_include",
+          "values": [
+            "walnut"
+          ]
+        },
+        {
+          "kind": "must_not_match",
+          "values": [
+            "not sure what you'?re referring",
+            "i don'?t (recall|remember|know)",
+            "if you (mentioned|have|had)",
+            "you (haven'?t|didn'?t|did not) (told|tell|mention|said|say)",
+            "i have no (record|memory|idea)"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "recall_detail_d240",
+      "plant": "i'm allergic to walnuts, just so you know.",
+      "plant_reply": "walnuts. i'll remember.",
+      "filler_turns": 240,
+      "recall_prompt": "is there anything i can't eat?",
+      "checks": [
+        {
+          "kind": "must_include",
+          "values": [
+            "walnut"
+          ]
+        },
+        {
+          "kind": "must_not_match",
+          "values": [
+            "not sure what you'?re referring",
+            "i don'?t (recall|remember|know)",
+            "if you (mentioned|have|had)",
+            "you (haven'?t|didn'?t|did not) (told|tell|mention|said|say)",
+            "i have no (record|memory|idea)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/backend/evals/runner.py
+++ b/backend/evals/runner.py
@@ -84,8 +84,20 @@ async def reset_model_state(
     if isinstance(base_url, str) and base_url:
         try:
             async with httpx.AsyncClient(base_url=base_url, timeout=60.0) as http:
-                await http.post(
+                response = await http.post(
                     "/api/generate", json={"model": target, "keep_alive": 0}
+                )
+            # A refused unload raises nothing -- Ollama answers 404 for an
+            # unknown tag and the previous model simply stays resident. Since
+            # the unload is the half that makes the starting state specified,
+            # a silent no-op removes that property while the report still
+            # implies it. Say so.
+            if response.status_code >= 400:
+                logger.warning(
+                    "[eval] unload of %s refused (HTTP %s); the run starts from "
+                    "whatever was already resident",
+                    target,
+                    response.status_code,
                 )
         except Exception as exc:
             logger.warning(

--- a/backend/evals/runner.py
+++ b/backend/evals/runner.py
@@ -14,6 +14,8 @@ agent's mood, not the model's behavior.
 
 import logging
 
+import httpx
+
 from app import config as config_module
 from app.cognitive.identity import IdentityManager
 from app.llm.ollama_client import OllamaClient
@@ -25,6 +27,7 @@ from .schema import (
     Probe,
     ProbeResult,
     RunOptions,
+    fingerprint,
     summarize_by_category,
 )
 from .scoring import evaluate_check, response_views, strip_thoughts
@@ -43,6 +46,61 @@ def _provenance() -> str:
     if getattr(config_module.config_instance, "MOCK_LLM_TEXT", False):
         return "mock"
     return "live"
+
+
+async def reset_model_state(
+    client: OllamaClient,
+    system: str,
+    model: str | None,
+    options: RunOptions,
+) -> None:
+    """Put the runtime into a *specified* state before anything is scored.
+
+    Measured on qwen2.5:3b, two separate batches of three runs each. Within a
+    batch, the runs that started from the same condition were byte-identical
+    across all sixteen probes; the run that started from a different one
+    disagreed with them on two to three probes and flipped a verdict each time.
+    Sampling was pinned, every prompt matched byte for byte, and Ollama itself
+    proved deterministic within a load, across reloads, and under VRAM
+    contention. What differed was the state the process was already in.
+
+    So the fix is not to converge on a state but to name one. Unloading first
+    (``keep_alive: 0``) discards whatever the last run left resident, and the
+    warm-up generation that follows reloads the model and leaves it in the same
+    place every time. A first attempt used only the warm-up and left the
+    unload out; two of sixteen probes still moved, because "freshly loaded"
+    and "holding the previous run's residue" are different starting points and
+    one short generation does not close the gap between them.
+
+    Both steps are best-effort. They buy reproducibility, not correctness, and
+    the probes report a genuinely unreachable model far more legibly than an
+    exception from a call whose output is discarded.
+    """
+    target = model or client.model
+    # Asked for explicitly rather than caught as an AttributeError, so a stand-in
+    # client in a test declines the unload by not offering an address instead of
+    # by raising inside it.
+    base_url = getattr(client, "base_url", None)
+    if isinstance(base_url, str) and base_url:
+        try:
+            async with httpx.AsyncClient(base_url=base_url, timeout=60.0) as http:
+                await http.post(
+                    "/api/generate", json={"model": target, "keep_alive": 0}
+                )
+        except Exception as exc:
+            logger.warning(
+                "[eval] could not unload %s before the run: %s", target, exc
+            )
+
+    try:
+        await client.generate(
+            prompt="Warm-up call. Reply with one word.",
+            system=system,
+            model=model,
+            options_override={**options.as_override(), "num_predict": 8},
+        )
+    except Exception as exc:
+        logger.warning("[eval] warm-up generation failed: %s", exc)
 
 
 async def run_probe(
@@ -91,6 +149,7 @@ async def run_eval(
     options: RunOptions = DEFAULT_OPTIONS,
 ) -> EvalReport:
     system = manager.get_persona_prompt(current_mood_directive=EVAL_MOOD_DIRECTIVE)
+    await reset_model_state(client, system, model, options)
 
     results: list[ProbeResult] = []
     # Sequential on purpose: one local model, and concurrent generations on a
@@ -110,6 +169,7 @@ async def run_eval(
         persona_name=manager.persona.name,
         provenance=_provenance(),
         options=options.as_override(),
+        system_prompt_sha256=fingerprint(system),
         results=results,
         by_category=summarize_by_category(results),
     )

--- a/backend/evals/schema.py
+++ b/backend/evals/schema.py
@@ -11,6 +11,7 @@ CLI refuses to treat a mock-provenance report as evidence unless explicitly
 overridden.
 """
 
+import hashlib
 import re
 from datetime import UTC, datetime
 from typing import Any, Literal
@@ -18,6 +19,18 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field, model_validator
 
 REPORT_SCHEMA_VERSION = 1
+
+
+def fingerprint(text: str) -> str:
+    """Short digest identifying a prompt without reproducing it.
+
+    A digest rather than the text itself for two reasons: the persona prompt is
+    authored character content and a report is a shareable artifact, and the
+    only question ever asked of it is "was this the same one", which equality
+    answers.
+    """
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
 
 Category = Literal["identity", "boundary", "memory", "custom"]
 
@@ -81,6 +94,28 @@ class CheckResult(BaseModel):
     detail: str = ""
 
 
+class ConversationProbe(BaseModel):
+    """A fact planted early, asked about later.
+
+    ``filler_turns`` is the distance the fact has to survive, and it is the
+    independent variable of the whole suite: a probe is the same question at a
+    different remove, so a pack spans distances rather than repeating one.
+
+    ``plant_reply`` is scripted like the filler, because the assistant's
+    acknowledgement is part of the context the recall has to reach past, and
+    generating it would put model noise inside the thing being measured.
+    """
+
+    id: str = Field(min_length=1)
+    category: Category = "memory"
+    plant: str = Field(min_length=1)
+    plant_reply: str = "Got it."
+    filler_turns: int = Field(ge=0)
+    recall_prompt: str = Field(min_length=1)
+    checks: list[Check] = Field(min_length=1)
+    source: str = "unknown"
+
+
 class ProbeResult(BaseModel):
     probe_id: str
     category: Category
@@ -89,6 +124,22 @@ class ProbeResult(BaseModel):
     checks: list[CheckResult]
     passed: bool
     score: float  # fraction of checks passed, in [0, 1]
+
+    # Multi-turn fields, absent on single-turn probes. They live here rather
+    # than on a separate result type so that one `compare` implementation
+    # serves both suites -- the harness exists to diff runs, and a second
+    # report shape would mean a second, drifting comparison path.
+    context_strategy: str | None = None
+    context_turns: int | None = None
+    context_chars: int | None = None
+    # Whether the planted fact was actually in the context the model saw. A
+    # pass with the plant dropped is not recall, it is a guess, and it means
+    # the probe is measuring nothing.
+    plant_visible: bool | None = None
+    # Whether the rendered context fits inside num_ctx. False means the runtime
+    # truncated it before the model read a token of the plant, so the probe is
+    # unsound regardless of what the strategy selected.
+    context_fits: bool | None = None
 
 
 class CategorySummary(BaseModel):
@@ -106,6 +157,14 @@ class EvalReport(BaseModel):
     persona_name: str
     provenance: Literal["live", "mock"]
     options: dict[str, Any]
+    # Digest of the system prompt every probe in this run was generated under.
+    # It is the largest single input to every response and the one most likely
+    # to drift unnoticed between two runs: adaptive traits evolve through
+    # reflection, and the identity seeds are editable files on disk. Without
+    # it, a comparison across a persona edit reads as a model behavior change,
+    # and nothing in the report contradicts that reading. Empty on reports
+    # written before this field existed.
+    system_prompt_sha256: str = ""
     results: list[ProbeResult]
     by_category: dict[str, CategorySummary]
 
@@ -118,12 +177,35 @@ class ProbeDelta(BaseModel):
     delta: float
 
 
+class OptionDiff(BaseModel):
+    """One sampling option the two runs did not agree on.
+
+    ``None`` means the option was absent from that report, which for
+    ``num_gpu`` reads as "unpinned" rather than "zero".
+    """
+
+    name: str
+    baseline: Any = None
+    candidate: Any = None
+
+
 class ComparisonReport(BaseModel):
     schema_version: int = REPORT_SCHEMA_VERSION
     baseline_model: str
     candidate_model: str
     baseline_provenance: Literal["live", "mock"]
     candidate_provenance: Literal["live", "mock"]
+    # Sampling options the two runs disagreed on. Greedy decoding reproduces
+    # only for a fixed load configuration, so a diff here means the comparison
+    # is measuring the configuration as much as the model. Surfaced, never
+    # gated on: the caller may have changed an option on purpose, and a gate
+    # that blocks a deliberate change would just get bypassed.
+    option_diffs: list[OptionDiff] = Field(default_factory=list)
+    # True when both reports fingerprinted their system prompt and the two
+    # differ: the persona itself changed, so every delta below describes a
+    # different agent as much as a different model. False when either report
+    # predates the field, because "unknown" must not read as "verified same".
+    persona_prompt_differs: bool = False
     # A regression is a probe the baseline passed and the candidate failed —
     # the hard gate. Score dips that stay above passing land in `declines`.
     regressions: list[ProbeDelta]
@@ -151,9 +233,29 @@ class RunOptions(BaseModel):
     seed: int = 42
     top_p: float = 1.0
     num_predict: int = 192
+    # Pinned explicitly because `OllamaClient` defaults it to 2048 and Ollama
+    # truncates an over-long prompt *from the front* without saying so. For a
+    # multi-turn recall probe the front is where the planted fact lives, so the
+    # default would silently delete the thing under test and score the model's
+    # prior instead -- a confident number measuring nothing.
+    num_ctx: int = 8192
+    # How many layers Ollama offloads to the GPU. Left unset, Ollama picks the
+    # split at load time from whatever VRAM is free, and the split is an input
+    # to the output: measured here, the same prompt all-CPU and part-GPU
+    # returned different text. On this box the split did not drift on its own
+    # across reloads, so leaving it unset was not the source of the run-to-run
+    # differences chased down in `reset_model_state` -- but a machine whose
+    # free VRAM differs between the two halves of a comparison would load the
+    # model differently for each. Unset by default, because a fixed layer count
+    # that does not fit the next machine is worse than an honest unpinned run,
+    # and `compare` warns when two reports disagree. Pin it when a verdict
+    # matters.
+    num_gpu: int | None = None
 
     def as_override(self) -> dict[str, Any]:
-        return self.model_dump()
+        # `OllamaClient` merges this over its defaults, so a `None` would be
+        # forwarded to Ollama as a null rather than read as "unset".
+        return self.model_dump(exclude_none=True)
 
 
 DEFAULT_OPTIONS = RunOptions()

--- a/backend/evals/schema.py
+++ b/backend/evals/schema.py
@@ -180,13 +180,23 @@ class ProbeDelta(BaseModel):
 class OptionDiff(BaseModel):
     """One sampling option the two runs did not agree on.
 
-    ``None`` means the option was absent from that report, which for
-    ``num_gpu`` reads as "unpinned" rather than "zero".
+    Presence is carried separately from value because a value alone cannot
+    express it: ``None`` would mean both "absent from that report" and "present
+    and explicitly null", and for ``num_gpu`` those are different settings --
+    unpinned versus a pinned value that happens to be falsy. `as_override`
+    drops nulls so a report this harness wrote never contains one, but reports
+    are long-lived artifacts and hand-edited ones exist.
     """
 
     name: str
     baseline: Any = None
     candidate: Any = None
+    in_baseline: bool = True
+    in_candidate: bool = True
+
+    def describe(self, side: str) -> str:
+        present = self.in_baseline if side == "baseline" else self.in_candidate
+        return repr(getattr(self, side)) if present else "<unset>"
 
 
 class ComparisonReport(BaseModel):

--- a/backend/tests/test_conversation_evals.py
+++ b/backend/tests/test_conversation_evals.py
@@ -1,0 +1,393 @@
+"""Tests for the multi-turn recall harness.
+
+This suite measures whether a fact survives the distance to the question it
+answers -- the problem the whole memory architecture exists to solve. The
+failure that matters most is not a probe returning the wrong verdict; it is a
+probe that returns a *confident* verdict while measuring nothing, because the
+planted fact was never in the context, or the filler contained the answer, or
+two strategies collided under one id. A broken instrument reads as a result.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from evals.conversation import (
+    DEFAULT_STRATEGIES,
+    FullHistory,
+    RecentWindow,
+    Turn,
+    build_transcript,
+    context_fits,
+    estimate_tokens,
+    load_conversation_pack,
+    render_context,
+    run_conversation_eval,
+    run_conversation_probe,
+    shipped_conversation_pack,
+)
+from evals.schema import Check, ConversationProbe, RunOptions
+
+FILLER = [
+    ("what's the weather doing", "grey. same as yesterday."),
+    ("did you eat yet", "not yet. probably later."),
+]
+
+
+def make_probe(**overrides) -> ConversationProbe:
+    base = {
+        "id": "recall_name",
+        "plant": "my youngest sister is called Wren.",
+        "plant_reply": "Wren. noted.",
+        "filler_turns": 4,
+        "recall_prompt": "what's my youngest sister called again?",
+        "checks": [Check(kind="must_include", values=["wren"])],
+    }
+    base.update(overrides)
+    return ConversationProbe(**base)
+
+
+class TestTheTranscriptIsReproducible:
+    def test_filler_cycles_rather_than_samples(self):
+        """Two runs of one probe must produce byte-identical context.
+
+        Random filler would make every rerun a different measurement, so a
+        score change between two model versions -- the only thing this harness
+        exists to detect -- could not be attributed to the model.
+        """
+        probe = make_probe(filler_turns=6)
+        first = build_transcript(probe, FILLER)
+        second = build_transcript(probe, FILLER)
+        assert first == second
+
+    def test_the_plant_comes_first(self):
+        """A fact planted after the filler has no distance to survive."""
+        turns = build_transcript(make_probe(), FILLER)
+        assert turns[0] == Turn("user", "my youngest sister is called Wren.")
+
+    def test_distance_is_what_the_probe_varies(self):
+        """filler_turns is the independent variable of the entire suite."""
+        near = build_transcript(make_probe(filler_turns=2), FILLER)
+        far = build_transcript(make_probe(filler_turns=20), FILLER)
+        assert len(far) - len(near) == 36  # 18 extra exchanges, two turns each
+
+    def test_a_pack_with_no_filler_is_rejected(self):
+        """Silently producing a zero-distance transcript would score as recall.
+
+        Every probe would pass, at every stated distance, and the report would
+        claim the model remembers everything.
+        """
+        with pytest.raises(ValueError):
+            build_transcript(make_probe(), [])
+
+
+class TestContextStrategies:
+    def test_full_history_shows_the_plant(self):
+        turns = build_transcript(make_probe(filler_turns=50), FILLER)
+        visible = FullHistory().select(turns, "q")
+        assert any("Wren" in turn.text for turn in visible)
+
+    def test_a_narrow_window_drops_the_plant(self):
+        """The control condition, and it is supposed to fail.
+
+        Once the plant falls outside the window the fact is genuinely absent,
+        so a pass under this strategy means the model guessed the answer and
+        the probe is measuring the prior, not recall.
+        """
+        turns = build_transcript(make_probe(filler_turns=50), FILLER)
+        visible = RecentWindow(6).select(turns, "q")
+        assert len(visible) == 6
+        assert not any("Wren" in turn.text for turn in visible)
+
+    def test_a_window_wider_than_the_conversation_keeps_everything(self):
+        turns = build_transcript(make_probe(filler_turns=1), FILLER)
+        assert RecentWindow(100).select(turns, "q") == turns
+
+    def test_a_zero_width_window_is_rejected(self):
+        """An empty context scores the model's prior with no conversation at all."""
+        with pytest.raises(ValueError):
+            RecentWindow(0)
+
+    def test_strategies_are_named_distinctly(self):
+        """Names become part of probe ids, so a collision merges two conditions."""
+        names = [strategy.name for strategy in DEFAULT_STRATEGIES]
+        assert len(names) == len(set(names))
+
+
+class TestScoringAProbe:
+    @pytest.fixture
+    def manager(self):
+        manager = MagicMock()
+        manager.validate_response = AsyncMock(return_value=(True, ""))
+        return manager
+
+    async def _run(self, manager, response: str, strategy, probe=None):
+        client = AsyncMock()
+        client.generate.return_value = response
+        return await run_conversation_probe(
+            client, manager, probe or make_probe(filler_turns=50), FILLER,
+            strategy, "system", "model", RunOptions(),
+        )
+
+    @pytest.mark.asyncio
+    async def test_recalling_the_fact_passes(self, manager):
+        result = await self._run(manager, "Wren, right?", FullHistory())
+        assert result.passed is True
+
+    @pytest.mark.asyncio
+    async def test_missing_the_fact_fails(self, manager):
+        result = await self._run(manager, "I don't think you said.", FullHistory())
+        assert result.passed is False
+
+    @pytest.mark.asyncio
+    async def test_the_probe_id_records_the_strategy(self, manager):
+        """Unqualified ids collide inside one report.
+
+        `compare` aligns two reports by probe_id. If the same probe ran under
+        two strategies with one id, the comparison would diff the wrong pair
+        and report a regression that never happened.
+        """
+        result = await self._run(manager, "Wren.", RecentWindow(6))
+        assert result.probe_id == "recall_name@recent_window_6"
+
+    @pytest.mark.asyncio
+    async def test_a_pass_without_the_fact_is_flagged_unsound(self, manager):
+        """The one result that must never be counted as recall.
+
+        With the plant outside the window the model cannot have remembered
+        anything; a pass means it guessed a common name. Recording
+        plant_visible is what lets the report say so instead of banking it.
+        """
+        result = await self._run(manager, "Wren.", RecentWindow(6))
+        assert result.passed is True
+        assert result.plant_visible is False
+
+    @pytest.mark.asyncio
+    async def test_the_context_reaches_the_model(self, manager):
+        """The transcript has to actually be in the prompt.
+
+        If the harness generated from the recall question alone, every probe
+        would be scoring the model's prior over sister names and the distance
+        column would be decorative.
+        """
+        client = AsyncMock()
+        client.generate.return_value = "Wren."
+        await run_conversation_probe(
+            client, manager, make_probe(filler_turns=4), FILLER,
+            FullHistory(), "system", "model", RunOptions(),
+        )
+        prompt = client.generate.await_args.kwargs["prompt"]
+        assert "Wren" in prompt
+        assert prompt.rstrip().endswith("Assistant:")
+
+
+class TestTheRunStartsFromAKnownState:
+    @pytest.fixture
+    def manager(self):
+        manager = MagicMock()
+        manager.validate_response = AsyncMock(return_value=(True, ""))
+        manager.get_persona_prompt.return_value = "SYSTEM"
+        manager.persona.name = "Kavya"
+        return manager
+
+    @pytest.mark.asyncio
+    async def test_the_suite_warms_the_model_before_the_first_probe(self, manager):
+        """This suite is where the cold-start difference was measured: three
+        identical runs, one cold and two warm, agreed byte-for-byte on the warm
+        pair and diverged on three of sixteen probes in the cold one. Without
+        the warm-up, whether the model happened to be resident becomes an
+        unrecorded input to every recall number.
+        """
+        client = AsyncMock()
+        client.generate.return_value = "Wren."
+        client.model = "scripted:test"
+        # No address, so the reset skips the unload rather than trying to
+        # reach a real Ollama from a unit test.
+        client.base_url = None
+
+        report = await run_conversation_eval(
+            client, manager, [make_probe(filler_turns=4)], FILLER,
+            strategies=(FullHistory(),),
+        )
+
+        first_prompt = client.generate.await_args_list[0].kwargs["prompt"]
+        assert "Warm-up" in first_prompt
+        # One warm-up plus one generation per probe-strategy pair, and the
+        # discarded one must not reach the report.
+        assert client.generate.await_count == 2
+        assert len(report.results) == 1
+
+
+class TestTheShippedPack:
+    def test_the_pack_loads(self):
+        probes, filler = load_conversation_pack(shipped_conversation_pack())
+        assert probes and filler
+
+    def test_the_filler_never_contains_an_answer(self):
+        """A probe that the filler answers is not measuring recall at all.
+
+        This is the quietest way for the suite to become worthless: the model
+        reads the answer out of nearby chatter, every probe passes at every
+        distance, and the report says memory is solved.
+        """
+        probes, filler = load_conversation_pack(shipped_conversation_pack())
+        filler_text = " ".join(
+            f"{user} {assistant}" for user, assistant in filler
+        ).lower()
+        for probe in probes:
+            for check in probe.checks:
+                for value in check.values:
+                    assert value.lower() not in filler_text, (
+                        f"{probe.id}: filler contains the answer {value!r}"
+                    )
+
+    def test_the_pack_spans_distances(self):
+        """One distance gives a pass/fail; several give the point it breaks."""
+        probes, _ = load_conversation_pack(shipped_conversation_pack())
+        assert len({probe.filler_turns for probe in probes}) >= 3
+
+    def test_probes_are_stamped_with_their_pack(self):
+        """A report has to be auditable without the pack files at hand."""
+        probes, _ = load_conversation_pack(shipped_conversation_pack())
+        assert all(probe.source == "conversation_recall.json" for probe in probes)
+
+    def test_probe_ids_are_unique(self):
+        """Duplicate ids silently overwrite each other in a comparison."""
+        probes, _ = load_conversation_pack(shipped_conversation_pack())
+        ids = [probe.id for probe in probes]
+        assert len(ids) == len(set(ids))
+
+    def test_every_probe_guards_against_a_disclaimed_answer(self):
+        """A substring check alone scores a denial of recall as recall.
+
+        Observed on a live 3B run: asked what the user could not eat, the model
+        replied "I'm not sure what you're referring to, but if you mentioned
+        walnuts earlier..." -- containing the answer while denying knowing it.
+        `must_include` passed, and the suite reported memory the model did not
+        have. Every recall probe needs the negative guard, or the number it
+        produces is an artifact of the phrasing.
+        """
+        probes, _ = load_conversation_pack(shipped_conversation_pack())
+        for probe in probes:
+            kinds = {check.kind for check in probe.checks}
+            assert "must_not_match" in kinds, (
+                f"{probe.id} can pass on a disclaimed answer"
+            )
+
+    def test_the_disclaimer_guard_catches_the_observed_false_pass(self):
+        """Pin the exact response that got through, so the guard cannot regress."""
+        from evals.scoring import evaluate_check, response_views
+
+        probes, _ = load_conversation_pack(shipped_conversation_pack())
+        probe = next(p for p in probes if p.id == "recall_detail_d240")
+        observed = (
+            "I'm not sure what you're referring to, but if you have specific "
+            "dietary restrictions or allergies, I'd be happy to help address "
+            "those. For instance, if you mentioned walnuts earlier, we've "
+            "already discussed that."
+        )
+        views = response_views(observed)
+        assert not all(
+            evaluate_check(check, views).passed for check in probe.checks
+        )
+
+    def test_the_single_turn_loader_does_not_see_conversation_packs(self):
+        """The two suites share a directory tree but not a file format.
+
+        `shipped_packs()` globs ``probes/*.json`` and validates every hit as a
+        single-turn `ProbePack`. A conversation pack sitting beside them makes
+        the *other* suite fail at load time -- `python -m evals run` stops
+        working entirely, for a file it never wanted.
+        """
+        from evals.probes import shipped_packs
+
+        assert shipped_conversation_pack() not in shipped_packs()
+        assert all("conversation" not in path.name for path in shipped_packs())
+
+
+class TestTheContextWindowIsAccountedFor:
+    """The quietest way this harness could produce a wrong published number.
+
+    `OllamaClient` defaults num_ctx to 2048 and Ollama truncates an over-long
+    prompt from the *front* -- which for a recall probe is exactly where the
+    planted fact sits. Without this accounting, a 240-turn probe would report a
+    clean failure that says nothing about the model's memory, because the model
+    never received the fact at all.
+    """
+
+    def test_num_ctx_is_pinned_rather_than_inherited(self):
+        """Leaving it unset silently caps every probe at 2048 tokens."""
+        assert RunOptions().num_ctx >= 8192
+        assert "num_ctx" in RunOptions().as_override()
+
+    def test_an_oversized_context_is_reported_as_not_fitting(self):
+        big = "x" * 100_000
+        assert context_fits(big, "", RunOptions(num_ctx=1024)) is False
+
+    def test_an_ordinary_context_fits(self):
+        assert context_fits("User: hi\nAssistant: hey", "sys", RunOptions()) is True
+
+    def test_the_system_prompt_counts_against_the_window(self):
+        """A long persona prompt is part of what crowds the plant out.
+
+        Scoring only the transcript would call a context sound while the
+        persona block pushed it past the limit.
+        """
+        transcript = "x" * 3000
+        options = RunOptions(num_ctx=1100)
+        assert context_fits(transcript, "", options) is True
+        assert context_fits(transcript, "y" * 3000, options) is False
+
+    def test_the_token_estimate_errs_toward_too_long(self):
+        """A false all-clear is the expensive direction of this error.
+
+        Over-counting costs a rerun with a bigger window. Under-counting means
+        publishing a recall figure the model was never given a chance to earn.
+        """
+        text = "a" * 400  # ~100 real tokens for English
+        assert estimate_tokens(text) > 100
+
+    @pytest.mark.asyncio
+    async def test_a_truncated_probe_is_marked_on_the_result(self):
+        manager = MagicMock()
+        manager.validate_response = AsyncMock(return_value=(True, ""))
+        client = AsyncMock()
+        client.generate.return_value = "Wren."
+
+        result = await run_conversation_probe(
+            client, manager, make_probe(filler_turns=400), FILLER,
+            FullHistory(), "system", "model", RunOptions(num_ctx=256),
+        )
+        assert result.context_fits is False
+
+
+class TestRendering:
+    def test_speakers_are_labelled(self):
+        rendered = render_context([Turn("user", "hi"), Turn("assistant", "hey")])
+        assert rendered == "User: hi\nAssistant: hey"
+
+
+class TestAPackAuthorCanSupplyTheirOwn:
+    def test_an_external_pack_is_stamped_with_its_own_name(self, tmp_path):
+        """Content belongs to whoever authors the pack, not to this module.
+
+        Filler and probes are data precisely so a different project can
+        measure recall over its own conversations without editing production
+        code.
+        """
+        pack = tmp_path / "mine.json"
+        pack.write_text(json.dumps({
+            "filler": [["a", "b"]],
+            "probes": [{
+                "id": "p1",
+                "plant": "the code is 4417.",
+                "filler_turns": 1,
+                "recall_prompt": "what was the code?",
+                "checks": [{"kind": "must_include", "values": ["4417"]}],
+            }],
+        }), encoding="utf-8")
+
+        probes, filler = load_conversation_pack(pack)
+        assert probes[0].source == "mine.json"
+        assert filler == [("a", "b")]

--- a/backend/tests/test_conversation_evals.py
+++ b/backend/tests/test_conversation_evals.py
@@ -182,6 +182,29 @@ class TestScoringAProbe:
         assert prompt.rstrip().endswith("Assistant:")
 
 
+class TestAPackCannotCollideWithItself:
+    def test_two_probes_sharing_an_id_are_rejected_at_load(self, tmp_path):
+        """`compare_reports` keys on `id@strategy`, so a duplicate id makes one
+        result overwrite the other and the comparison silently diffs the wrong
+        pair. The single-turn loader already refuses this; a pack arriving
+        through --pack must not be the way it gets in."""
+        pack = tmp_path / "dupes.json"
+        probe = {
+            "id": "recall_name",
+            "plant": "my sister is Wren.",
+            "filler_turns": 2,
+            "recall_prompt": "what is her name?",
+            "checks": [{"kind": "must_include", "values": ["wren"]}],
+        }
+        pack.write_text(
+            json.dumps({"filler": [["a", "b"]], "probes": [probe, probe]}),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="duplicate probe id"):
+            load_conversation_pack(pack)
+
+
 class TestTheRunStartsFromAKnownState:
     @pytest.fixture
     def manager(self):
@@ -292,6 +315,31 @@ class TestTheShippedPack:
             evaluate_check(check, views).passed for check in probe.checks
         )
 
+    def test_a_typographic_apostrophe_does_not_slip_past_the_guard(self):
+        """Small models emit both apostrophe forms, and this one was observed
+        doing it: two runs of the same probe produced "What's her name?" and
+        "What’s her name?" from identical input. A guard written with a bare
+        `'?` makes only U+0027 optional, so the U+2019 spelling of the very
+        same disclaimer walks through and the probe reports recall the model
+        explicitly denied."""
+        from evals.scoring import evaluate_check, response_views
+
+        probes, _ = load_conversation_pack(shipped_conversation_pack())
+        probe = next(p for p in probes if p.id == "recall_detail_d240")
+        # Deliberately phrased so the *only* guard that can fire is one
+        # carrying an apostrophe: "if you mentioned" and the other guards have
+        # none, and would catch this sentence whatever the apostrophe class
+        # does. It still contains "walnut", so must_include passes and the
+        # probe hangs entirely on the negative guard.
+        curly = "I don’t recall walnuts coming up."
+        straight = "I don't recall walnuts coming up."
+
+        for text in (curly, straight):
+            views = response_views(text)
+            assert not all(
+                evaluate_check(check, views).passed for check in probe.checks
+            ), f"disclaimer slipped through: {text!r}"
+
     def test_the_single_turn_loader_does_not_see_conversation_packs(self):
         """The two suites share a directory tree but not a file format.
 
@@ -334,10 +382,27 @@ class TestTheContextWindowIsAccountedFor:
         Scoring only the transcript would call a context sound while the
         persona block pushed it past the limit.
         """
-        transcript = "x" * 3000
-        options = RunOptions(num_ctx=1100)
+        transcript = "x" * 3000  # ~1000 estimated tokens
+        options = RunOptions(num_ctx=4096, num_predict=192)
         assert context_fits(transcript, "", options) is True
-        assert context_fits(transcript, "y" * 3000, options) is False
+        assert context_fits(transcript, "y" * 12_000, options) is False
+
+    def test_the_generation_reserve_counts_against_the_window_too(self):
+        """`num_predict` shares the window with the prompt.
+
+        Omitting it gives the worst answer this check can give: a probe that
+        fits on arrival, then loses the plant to front-truncation partway
+        through generation, and reports `fits yes` while doing it. Sized so the
+        prompt alone clears num_ctx and only the reserve pushes it over.
+        """
+        transcript = "x" * 3000  # ~1000 estimated tokens
+        options = RunOptions(num_ctx=1100, num_predict=192)
+
+        assert estimate_tokens(transcript) < options.num_ctx
+        assert context_fits(transcript, "", options) is False
+        # Same prompt, same window, no reserve to make room for: it fits.
+        assert context_fits(transcript, "", options.model_copy(
+            update={"num_predict": 0})) is True
 
     def test_the_token_estimate_errs_toward_too_long(self):
         """A false all-clear is the expensive direction of this error.

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -470,6 +470,25 @@ def test_two_runs_sampled_differently_are_flagged_as_incomparable():
     assert "temperature" in rendered
 
 
+def test_an_absent_option_is_distinguished_from_one_explicitly_null():
+    """`.get()` returns None for both, so comparing values alone would call
+    `{"num_gpu": None}` and `{}` identical. For num_gpu those are different
+    settings -- pinned-to-null versus unpinned -- and collapsing them hides the
+    exact mismatch this check exists to report."""
+    baseline = _report("m", [_result("a", "identity", True, 1.0)], options={})
+    candidate = _report(
+        "m", [_result("a", "identity", True, 1.0)], options={"num_gpu": None}
+    )
+
+    diffs = compare_reports(baseline, candidate).option_diffs
+
+    assert [(d.name, d.in_baseline, d.in_candidate) for d in diffs] == [
+        ("num_gpu", False, True)
+    ]
+    assert diffs[0].describe("baseline") == "<unset>"
+    assert diffs[0].describe("candidate") == "None"
+
+
 def test_an_option_set_on_only_one_side_counts_as_a_difference():
     """`num_gpu` absent means "let Ollama pick from free VRAM", which is a real
     setting and a different one from a pinned layer count. Treating a missing
@@ -578,6 +597,26 @@ def test_compare_cli_fail_on_regression_is_the_nonzero_exit(tmp_path):
         == 1
     )
     assert evals_main(["compare", str(base_path), str(cand_path)]) == 0
+
+
+def test_a_zero_window_is_a_usage_error_not_a_traceback(
+    tmp_path, capsys, monkeypatch
+):
+    """`RecentWindow` raises on a window below one, and that raise reaches the
+    top level. Every other input error in this command prints to stderr and
+    exits 2, so a traceback and exit 1 here is a different contract for no
+    reason -- and it reads as a crash rather than a typo.
+
+    Mock mode is cleared because its refusal legitimately comes first and also
+    exits 2, which would let this test pass without the window ever being
+    checked.
+    """
+    monkeypatch.setattr(config_module.config_instance, "MOCK_LLM_TEXT", False)
+    out = tmp_path / "report.json"
+
+    assert evals_main(["run-conversation", "--out", str(out), "--window", "0"]) == 2
+    assert "window" in capsys.readouterr().err
+    assert not out.exists()
 
 
 def test_run_cli_refuses_under_mock_llm_without_allow_mock(

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -7,6 +7,7 @@ gate could lie.
 """
 
 import json
+from unittest import mock
 
 import pytest
 from pydantic import ValidationError
@@ -14,8 +15,9 @@ from pydantic import ValidationError
 from app import config as config_module
 from app.cognitive.identity import IdentityManager
 from app.persona.profile import IMMUTABLE_CORE
+from evals import runner as runner_module
 from evals.__main__ import main as evals_main
-from evals.compare import compare_reports
+from evals.compare import compare_reports, render_comparison
 from evals.probes import collect_probes, load_pack, persona_probes, shipped_packs
 from evals.runner import run_eval
 from evals.schema import (
@@ -23,6 +25,8 @@ from evals.schema import (
     CheckResult,
     EvalReport,
     ProbeResult,
+    RunOptions,
+    fingerprint,
     save_report,
     summarize_by_category,
 )
@@ -206,10 +210,12 @@ class ScriptedClient:
         self.script = script
         self.seen_systems = []
         self.seen_options = []
+        self.seen_prompts = []
 
     async def generate(self, prompt, system=None, model=None, options_override=None):
         self.seen_systems.append(system)
         self.seen_options.append(options_override)
+        self.seen_prompts.append(prompt)
         for needle, response in self.script.items():
             if needle in prompt:
                 return response
@@ -260,6 +266,100 @@ async def test_a_hostile_response_fails_the_boundary_probe_via_production_rules(
 
 
 @pytest.mark.asyncio
+async def test_no_probe_is_scored_against_an_unspecified_runtime_state(kavya):
+    """Measured on qwen2.5:3b across two batches of three runs: runs starting
+    from the same state were byte-identical on all sixteen probes, and the run
+    starting from a different one disagreed and flipped a verdict both times.
+    Drop this and 'what was the runtime already doing' becomes an input to
+    every number the harness reports, recorded nowhere."""
+    client = ScriptedClient({"your name": "I am Kavya."})
+    probes = persona_probes(kavya)
+
+    report = await run_eval(client, kavya, probes)
+
+    assert "Warm-up" in client.seen_prompts[0]
+    assert len(client.seen_prompts) == len(probes) + 1
+    # The discarded generation must not reach the report as a result.
+    assert len(report.results) == len(probes)
+
+
+@pytest.mark.asyncio
+async def test_the_run_unloads_the_model_before_reloading_it(kavya):
+    """Unloading is the half that makes the state *specified* rather than
+    merely warm. Without it the run inherits whatever the previous run left
+    resident, and a first attempt that warmed up without unloading still moved
+    two of sixteen probes."""
+    posted = []
+
+    class AddressedClient(ScriptedClient):
+        base_url = "http://127.0.0.1:11434"
+
+    client = AddressedClient({"your name": "I am Kavya."})
+
+    class FakeHTTP:
+        def __init__(self, *args, **kwargs):
+            self.base_url = kwargs.get("base_url")
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, path, json=None):
+            posted.append((self.base_url, path, json))
+
+    with mock.patch.object(runner_module.httpx, "AsyncClient", FakeHTTP):
+        await run_eval(client, kavya, persona_probes(kavya), model="tag:v1")
+
+    assert posted == [
+        ("http://127.0.0.1:11434", "/api/generate",
+         {"model": "tag:v1", "keep_alive": 0}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_failed_warm_up_does_not_take_the_run_down_with_it(kavya):
+    """The reset buys reproducibility, not correctness. If it could abort the
+    run, a transient blip on a throwaway call whose output is discarded would
+    cost the whole suite -- and the probes report an unreachable model far more
+    legibly than an exception from a call nobody reads."""
+
+    class FlakyFirstCall(ScriptedClient):
+        async def generate(self, prompt, system=None, model=None,
+                           options_override=None):
+            if not self.seen_prompts:
+                self.seen_prompts.append(prompt)
+                raise RuntimeError("connection reset")
+            return await super().generate(prompt, system, model, options_override)
+
+    client = FlakyFirstCall({"your name": "I am Kavya."})
+
+    report = await run_eval(client, kavya, persona_probes(kavya))
+
+    assert len(report.results) == len(persona_probes(kavya))
+    assert report.by_category["identity"].probes == 3
+
+
+@pytest.mark.asyncio
+async def test_a_report_records_which_persona_prompt_produced_it(kavya):
+    """The system prompt is the largest input to every response and the one
+    that drifts silently: adaptive traits evolve through reflection and the
+    identity seeds are editable files. Unrecorded, a comparison spanning a
+    persona edit reads as a model behavior change with nothing to contradict
+    it."""
+    client = ScriptedClient({"your name": "I am Kavya."})
+
+    report = await run_eval(client, kavya, persona_probes(kavya))
+
+    expected = fingerprint(client.seen_systems[0])
+    assert report.system_prompt_sha256 == expected
+    # A digest, not the prompt: reports are shareable and the prompt carries
+    # authored persona content.
+    assert "YOU ARE" not in report.system_prompt_sha256
+
+
+@pytest.mark.asyncio
 async def test_a_mock_llm_run_is_stamped_mock_not_live(kavya, monkeypatch):
     """Provenance is the B1 defense. A mock run stamped 'live' is a fabricated
     result with a paper trail saying otherwise."""
@@ -288,12 +388,12 @@ def _result(pid, category, passed, score):
     )
 
 
-def _report(model, results, provenance="live"):
+def _report(model, results, provenance="live", options=None):
     return EvalReport(
         model=model,
         persona_name="Kavya",
         provenance=provenance,
-        options={},
+        options={} if options is None else options,
         results=results,
         by_category=summarize_by_category(results),
     )
@@ -342,6 +442,103 @@ def test_a_score_dip_that_still_passes_is_a_decline_not_a_regression():
     assert comparison.regressions == []
     assert [d.probe_id for d in comparison.declines] == ["a"]
     assert comparison.gate_passed is True
+
+
+# ------------------------------------------------- run configuration diffing
+
+
+def test_two_runs_sampled_differently_are_flagged_as_incomparable():
+    """A probe flip only means the model changed if everything else held. Two
+    reports produced under different sampling options diff cleanly and say
+    nothing, and nothing else in the harness would notice."""
+    baseline = _report(
+        "m", [_result("a", "identity", True, 1.0)],
+        options={"temperature": 0.0, "num_ctx": 8192},
+    )
+    candidate = _report(
+        "m", [_result("a", "identity", False, 0.0)],
+        options={"temperature": 0.7, "num_ctx": 8192},
+    )
+
+    comparison = compare_reports(baseline, candidate)
+
+    assert [(d.name, d.baseline, d.candidate) for d in comparison.option_diffs] == [
+        ("temperature", 0.0, 0.7)
+    ]
+    rendered = render_comparison(comparison)
+    assert "SAMPLING OPTIONS DIFFER" in rendered
+    assert "temperature" in rendered
+
+
+def test_an_option_set_on_only_one_side_counts_as_a_difference():
+    """`num_gpu` absent means "let Ollama pick from free VRAM", which is a real
+    setting and a different one from a pinned layer count. Treating a missing
+    key as "no opinion" would hide exactly the mismatch this exists to catch."""
+    baseline = _report("m", [_result("a", "identity", True, 1.0)], options={})
+    candidate = _report(
+        "m", [_result("a", "identity", True, 1.0)], options={"num_gpu": 0}
+    )
+
+    diffs = compare_reports(baseline, candidate).option_diffs
+
+    assert [(d.name, d.baseline, d.candidate) for d in diffs] == [("num_gpu", None, 0)]
+
+
+def test_runs_sharing_a_configuration_carry_no_warning():
+    """The warning has to stay rare to stay readable; firing it on every
+    comparison would train the reader to skip the header that also carries the
+    mock-provenance notice."""
+    options = RunOptions().as_override()
+    baseline = _report("base", [_result("a", "identity", True, 1.0)], options=options)
+    candidate = _report("cand", [_result("a", "identity", True, 1.0)], options=options)
+
+    comparison = compare_reports(baseline, candidate)
+
+    assert comparison.option_diffs == []
+    assert "SAMPLING OPTIONS DIFFER" not in render_comparison(comparison)
+
+
+def test_a_comparison_spanning_a_persona_edit_says_so():
+    """Editing the persona between baseline and candidate changes the agent,
+    not the model. Silently, every probe flip would be filed against the
+    fine-tune that did not cause it."""
+    baseline = _report("m", [_result("a", "identity", True, 1.0)])
+    candidate = _report("m", [_result("a", "identity", False, 0.0)])
+    baseline.system_prompt_sha256 = "aaaaaaaaaaaaaaaa"
+    candidate.system_prompt_sha256 = "bbbbbbbbbbbbbbbb"
+
+    comparison = compare_reports(baseline, candidate)
+
+    assert comparison.persona_prompt_differs is True
+    assert "PERSONA PROMPT DIFFERS" in render_comparison(comparison)
+
+
+def test_a_report_predating_the_fingerprint_does_not_raise_a_false_persona_alarm():
+    """Reports written before the field exists carry an empty digest. Reading
+    that as a difference would fire the warning on every comparison against
+    older evidence, and a warning that always fires is one nobody reads."""
+    baseline = _report("m", [_result("a", "identity", True, 1.0)])
+    candidate = _report("m", [_result("a", "identity", True, 1.0)])
+    candidate.system_prompt_sha256 = "bbbbbbbbbbbbbbbb"
+
+    comparison = compare_reports(baseline, candidate)
+
+    assert comparison.persona_prompt_differs is False
+    assert "PERSONA PROMPT DIFFERS" not in render_comparison(comparison)
+
+
+def test_an_unpinned_num_gpu_is_omitted_rather_than_sent_as_null():
+    """`OllamaClient` merges the override over its own defaults, so a null
+    `num_gpu` would not read as "unset" -- it would be forwarded to Ollama as a
+    null and could override the runtime's own choice of layer split."""
+    unpinned = RunOptions().as_override()
+    pinned = RunOptions(num_gpu=0).as_override()
+
+    assert "num_gpu" not in unpinned
+    assert pinned["num_gpu"] == 0
+    # The rest of the pinned options must still travel, or a report would
+    # record a configuration it did not run under.
+    assert unpinned["temperature"] == 0.0 and unpinned["num_ctx"] == 8192
 
 
 # ---------------------------------------------------------------- CLI gates


### PR DESCRIPTION
## What

A second eval suite (`python -m evals run-conversation`): plant a fact, bury it
under scripted filler exchanges, then ask about it at 4, 24, 96 and 240 turns.
The single-turn harness asks whether the model still behaves like the persona;
this asks the question the memory architecture exists to answer.

The variable under test is the **context strategy** — what the model is shown at
recall time — because that is the seam the cognitive layer plugs into.
`full_history` is the naive baseline and the only condition where
lost-in-the-middle is observable at all: the fact *is* present, so a miss is an
attention failure rather than an absence. `recent_window_N` is the control that
is supposed to fail. A retrieval-backed strategy fits the same `select()`
interface, and the gap between it and these two is the memory layer's
contribution stated as a number.

Only the final answer is generated. That isolates distance from the model's own
compounding noise and costs one generation per probe instead of forty — but it
therefore measures *retrieval from a context window*, not conversational
degradation, and the README says so.

Two ways a probe can return a confident verdict about nothing are surfaced
rather than folded into the score, because both make a number invalid rather
than merely low: `plant out` (the strategy never showed the model the fact) and
`fits NO` (the context exceeded `num_ctx`, and Ollama truncates from the front,
which is exactly where the plant sits).

## Then the instrument moved

Two runs with byte-identical prompts, options, model and persona differed on
**3 of 16** probes and flipped two verdicts. Three hypotheses were tested and
refuted — the CPU/GPU layer split, VRAM contention from a co-resident model,
and a warm-up generation on its own. Ollama proved deterministic within a load,
across three unload/reload cycles, and under contention.

What survived was narrower: **runs that start from the same state agree
character for character; runs that start from different ones do not.** So both
suites now unload the model (`keep_alive: 0`), let a warm-up generation reload
it, and only then start scoring. Three consecutive live runs under that reset
were identical on every probe — **0 of 16 moved.**

Reports also now carry the sampling options and a digest of the system prompt,
and `compare` warns when two runs disagree on either. Both were unrecorded, and
ruling the persona out during this investigation took file-mtime archaeology
that should have taken one field lookup. Warnings, not gates — the caller may
have changed something deliberately.

## Live results worth knowing (`qwen2.5:3b`)

Names survive at every distance under `full_history`, up to 482 turns and
18,361 characters. Details do not — "walnut" is lost past the shortest
distance. Every `recent_window_6` probe fails with the plant out of context,
which is the control behaving correctly, and no probe passed with the plant
dropped. The bottleneck at 3B is not retrieval and not context length; it is
that the assistant register overrides recall.

## Not done

The retrieval-backed strategy — the one that would actually measure this repo's
memory layer against the naive baseline — is not written. The seam is there and
the two shipped strategies bracket it. Until something fills it, this suite
measures a context window, not the cognitive architecture.

## Verification

41 new tests, every mutation caught. Full backend suite via junit-xml: **803
passed, 0 failed/errored/skipped**. `ruff check .` clean. The reproducibility
claim was validated end to end with three live runs, not asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-turn conversation recall evaluations across increasing conversation distances.
  * Added full-history and recent-window context strategies with context-fit and recall diagnostics.
  * Added a `run-conversation` command with configurable context, window, GPU, and mock options.
  * Reports now identify prompt and sampling-option differences.

* **Bug Fixes**
  * Improved evaluation reproducibility by resetting and warming models before runs.

* **Documentation**
  * Expanded evaluation documentation with usage, diagnostics, limitations, and comparison guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->