### PR TITLE
Measure the memory layer against a fifty-line control

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -5537,3 +5537,79 @@ so it failed for a reason unrelated to the fix and would have passed with the
 bug restored. Rewritten to a sentence whose only possible guard carries an
 apostrophe. This is the second time in this repo that mutation testing caught a
 test passing for the wrong reason.
+
+## 2026-08-02 -- The memory layer, measured against a fifty-line control
+
+The recall suite could compare `full_history` against `recent_window`, which
+are two bounds and neither is a system. This adds the seam that measures the
+thing the project is actually built on, and then measures it.
+
+**Two retrievers, because one cannot attribute a result.** `LexicalRetriever`
+is Okapi BM25 over the transcript: no embeddings, no database, no decay.
+`MemoryStoreRetriever` is the real `search_memories`, reached through the
+construction `brain_agent.main` uses -- ACT-R activation, the learned lexicon,
+Qdrant vectors, the Neo4j boost. With only the second, a win over
+`full_history` would say nothing about this architecture, since "something
+filtered the context" explains it just as well.
+
+**Two strategy shapes.** `Retrieved` is budget-matched to `recent_window_N`, so
+a difference is attributable to *which* turns were chosen rather than how many.
+`WindowPlusRetrieved` mirrors what the running system does -- recent context
+always present, memories alongside it -- and is deliberately not budget-matched,
+which is why the matched one exists next to it rather than instead of it.
+
+`ContextStrategy.select` became async: a retrieval strategy has to reach a
+database and an embedding model, and the two trivial strategies pay nothing.
+
+**Live result, `qwen2.5:3b`, 48 probes, real Postgres/Qdrant/Neo4j.**
+
+*Name recall*: `full_history` passes at all four distances, up to 482 turns and
+18,361 characters. Both retrievers also pass at all four -- on ~6 turns and
+~248 characters. Same verdicts on **~74x less context**. `recent_window_6`
+fails all four with the plant out, which is the control behaving.
+
+*The memory layer does not beat BM25 on this pack.* Identical verdicts
+everywhere: equal on names, equal-and-failing on details. On this evidence the
+ACT-R, vector and graph machinery is not yet earning its infrastructure against
+a ranking function that fits on a page. That is a finding about the benchmark
+as much as the architecture -- a planted-fact probe with lexical overlap is
+close to the best case for BM25 -- but it is the measurement that exists.
+
+*The real unsolved problem is the semantic gap.* Every detail probe beyond the
+shortest distance failed with **plant out**: asked "is there anything I
+shouldn't eat?", neither retriever surfaced "I'm allergic to walnuts." They
+share no content words. BM25 cannot bridge that and is not expected to; the
+embedding path is supposed to. A follow-up diagnostic confirmed the vector tier
+is live -- 768-dim embeddings, points in Qdrant -- and that it *does* return the
+plant for that query, ranked **fifth of six, below "what's the weather doing"**.
+Reordered to a lexically-overlapping question it ranks the plant first. So this
+is a ranking failure, not a wiring failure, and at realistic transcript sizes
+generic filler crowds the fact out of a six-turn budget.
+
+Also worth recording: at distance 24 and beyond, `full_history` fails the detail
+probes with the plant demonstrably *in* context. Retrieval cannot fix that one.
+
+**A bug of mine invalidated the first run, and the shape of the failure is
+worth keeping.** `retrieved_memory_store_6` returned *zero turns* on five of
+eight probes, which read as a broken memory layer. It was not. `add_memory`
+deduplicates on content across the whole table rather than within a room, and
+probes share filler verbatim -- so the second probe's writes were swallowed as
+duplicates of the first probe's rows, sitting in the first probe's room, and its
+own room came up empty. A room per transcript documents intent; only a purge
+before each index delivers isolation.
+
+The first diagnostic hid it perfectly by deleting between sizes, so every
+iteration started clean and the layer looked healthy. What actually exposed it
+was noticing that a 194-turn transcript wrote 10 rows.
+
+**NOT done.** The gap that would justify the architecture is unmeasured, because
+this pack cannot show it: a planted fact recalled by a lexically overlapping
+question is where BM25 is strongest and where decay, spreading activation and
+consolidation contribute least. A pack built to need them -- facts referred to
+obliquely, across sessions, competing with contradictory later information --
+is the next thing to write, and until it exists "the memory layer ties BM25"
+should be read as a statement about this benchmark.
+
+Nothing here measures write-side behaviour at all: importance scoring, decay,
+pruning and promotion are all bypassed by indexing a transcript in one burst
+and querying it immediately.

--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -5613,3 +5613,23 @@ should be read as a statement about this benchmark.
 Nothing here measures write-side behaviour at all: importance scoring, decay,
 pruning and promotion are all bypassed by indexing a transcript in one burst
 and querying it immediately.
+
+**Verified**: 22 new tests across the retrieval suite, every mutation caught --
+drop either budget cap (`Retrieved`, and separately `WindowPlusRetrieved`,
+which was genuinely unbounded until review), remove the re-index skip, let
+duplicate filler claim a slot per copy, accumulate instead of replacing an
+index, skip the purge before indexing, write to the `personal` wing, share one
+room across probes, delete rows before reading their ids, and swallow an
+`add_memory` that returned False. Full backend suite via junit-xml: 830 passed,
+0 failed/errored/skipped. `ruff check .` clean. After every live run the
+relational tier held only the 63 real `personal` memories, checked directly.
+
+Three of those mutations initially **survived**, all for the same reason: the
+test aimed at the wrong thing. The budget test exercised `Retrieved`, whose
+slice masks an over-returning retriever, so the unbounded `WindowPlusRetrieved`
+path had no coverage; the re-index test compared fingerprints, which a
+mutation that deletes the skip recomputes identically; and the purge-order test
+asserted on each call separately, so deleting before reading ids satisfied every
+assertion. A fourth needed its fixture rebuilt -- filler repeats verbatim, so
+the over-return it fed the strategy was filtered as already-visible before any
+cap could matter, and the test passed against the bug it was written for.

--- a/backend/evals/__main__.py
+++ b/backend/evals/__main__.py
@@ -86,20 +86,39 @@ async def _build_retrievers(args: argparse.Namespace):
     if "bm25" in args.retrieval:
         retrievers.append(LexicalRetriever())
 
+    # Everything opened here is registered the moment it exists, so a failure
+    # partway through construction still has a handle to close. `GraphDB()`
+    # raises on a weak or placeholder password, and that happens *after* the
+    # connection pool is up -- without this, that pool leaks with nothing left
+    # holding a reference to it.
+    opened: list = []
+
     async def teardown() -> None:
-        return None
+        for closer in reversed(opened):
+            try:
+                await closer()
+            except Exception as exc:
+                print(f"!! teardown step failed: {exc}", file=sys.stderr)
 
     if "memory" in args.retrieval:
         from app.state import ConversationHistoryStore, GraphDB, MemoryStore
 
-        conversation_store = ConversationHistoryStore()
-        await conversation_store.initialize()
-        graph_db = GraphDB()
-        store = MemoryStore(pool=conversation_store.pool, graph_db=graph_db)
-        retrievers.append(MemoryStoreRetriever(store))
+        try:
+            conversation_store = ConversationHistoryStore()
+            await conversation_store.initialize()
+            opened.append(conversation_store.close)
 
-        async def teardown() -> None:
-            await graph_db.close()
+            graph_db = GraphDB()
+            opened.append(graph_db.close)
+
+            store = MemoryStore(pool=conversation_store.pool, graph_db=graph_db)
+            # `MemoryStore.__init__` opens its own httpx client for embedding
+            # calls and nothing else ever closes it.
+            opened.append(store._http_client.aclose)
+            retrievers.append(MemoryStoreRetriever(store))
+        except Exception:
+            await teardown()
+            raise
 
     return retrievers, teardown
 
@@ -138,25 +157,37 @@ async def _cmd_run_conversation(args: argparse.Namespace) -> int:
     manager = IdentityManager(base_path=args.base_path)
     client = OllamaClient(base_url=args.url)
 
-    retrievers, teardown = await _build_retrievers(args)
-    for retriever in retrievers:
-        strategies.append(Retrieved(retriever, args.window))
-        strategies.append(
-            WindowPlusRetrieved(retriever, args.window, args.window)
-        )
+    retrievers: list = []
+
+    async def teardown() -> None:
+        return None
 
     try:
+        retrievers, teardown = await _build_retrievers(args)
+        for retriever in retrievers:
+            strategies.append(Retrieved(retriever, args.window))
+            strategies.append(
+                WindowPlusRetrieved(retriever, args.window, args.window)
+            )
+
         report = await run_conversation_eval(
             client, manager, probes, filler,
             strategies=tuple(strategies), model=args.model, options=options,
         )
     finally:
-        await client.close()
-        # Retriever cleanup deletes what the run wrote to the agent's own
-        # database, so it must survive a failed or interrupted run.
+        # Deleting what the run wrote to the agent's own database comes first
+        # and is individually guarded. It was previously sequenced after
+        # `client.close()`, so an error closing an HTTP client -- which costs
+        # nothing -- would have skipped the step that keeps scripted filler out
+        # of the agent's memory.
         for retriever in retrievers:
-            await retriever.close()
+            try:
+                await retriever.close()
+            except Exception as exc:
+                print(f"!! failed to clean eval memories: {exc}",
+                      file=sys.stderr)
         await teardown()
+        await client.close()
 
     out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)
@@ -263,8 +294,12 @@ def main(argv=None) -> int:
                              choices=["bm25", "memory"],
                              help="add retrieval-backed strategies "
                                   "(repeatable). 'bm25' is the infra-free "
-                                  "control; 'memory' is the real MemoryStore "
-                                  "and needs Postgres, Qdrant and Neo4j up")
+                                  "control. 'memory' is the real MemoryStore: "
+                                  "it needs Postgres, Qdrant and Neo4j up and "
+                                  "it WRITES every transcript turn into them, "
+                                  "removing them again at the end -- point it "
+                                  "at the agent's live databases only if that "
+                                  "is what you mean to do")
     conv_parser.add_argument("--allow-mock", action="store_true")
 
     cmp_parser = sub.add_parser("compare", help="diff two reports")

--- a/backend/evals/__main__.py
+++ b/backend/evals/__main__.py
@@ -13,11 +13,14 @@ from .compare import compare_reports, render_comparison
 from .conversation import (
     FullHistory,
     RecentWindow,
+    Retrieved,
+    WindowPlusRetrieved,
     load_conversation_pack,
     run_conversation_eval,
     shipped_conversation_pack,
 )
 from .probes import collect_probes, shipped_packs
+from .retrieval import LexicalRetriever, MemoryStoreRetriever
 from .runner import run_eval
 from .schema import RunOptions, load_report, save_report
 
@@ -69,6 +72,38 @@ async def _cmd_run(args: argparse.Namespace) -> int:
     return 0
 
 
+async def _build_retrievers(args: argparse.Namespace):
+    """Construct the retrievers the caller asked for, plus their teardown.
+
+    The BM25 control needs nothing. The memory-layer retriever needs the real
+    stack, built the way `brain_agent.main` builds it -- a parallel
+    construction here would measure a MemoryStore nobody ships.
+
+    Returns the retrievers and a teardown for the resources *this function*
+    opened; the retrievers clean their own writes.
+    """
+    retrievers = []
+    if "bm25" in args.retrieval:
+        retrievers.append(LexicalRetriever())
+
+    async def teardown() -> None:
+        return None
+
+    if "memory" in args.retrieval:
+        from app.state import ConversationHistoryStore, GraphDB, MemoryStore
+
+        conversation_store = ConversationHistoryStore()
+        await conversation_store.initialize()
+        graph_db = GraphDB()
+        store = MemoryStore(pool=conversation_store.pool, graph_db=graph_db)
+        retrievers.append(MemoryStoreRetriever(store))
+
+        async def teardown() -> None:
+            await graph_db.close()
+
+    return retrievers, teardown
+
+
 async def _cmd_run_conversation(args: argparse.Namespace) -> int:
     if _mock_active() and not args.allow_mock:
         print(
@@ -93,7 +128,7 @@ async def _cmd_run_conversation(args: argparse.Namespace) -> int:
         print("--window needs at least one turn", file=sys.stderr)
         return 2
 
-    strategies = (FullHistory(), RecentWindow(args.window))
+    strategies = [FullHistory(), RecentWindow(args.window)]
     # `num_ctx` is left to the RunOptions default unless the caller sets it, so
     # the two cannot drift apart.
     overrides = {"num_gpu": args.num_gpu}
@@ -102,13 +137,26 @@ async def _cmd_run_conversation(args: argparse.Namespace) -> int:
     options = RunOptions(**overrides)
     manager = IdentityManager(base_path=args.base_path)
     client = OllamaClient(base_url=args.url)
+
+    retrievers, teardown = await _build_retrievers(args)
+    for retriever in retrievers:
+        strategies.append(Retrieved(retriever, args.window))
+        strategies.append(
+            WindowPlusRetrieved(retriever, args.window, args.window)
+        )
+
     try:
         report = await run_conversation_eval(
             client, manager, probes, filler,
-            strategies=strategies, model=args.model, options=options,
+            strategies=tuple(strategies), model=args.model, options=options,
         )
     finally:
         await client.close()
+        # Retriever cleanup deletes what the run wrote to the agent's own
+        # database, so it must survive a failed or interrupted run.
+        for retriever in retrievers:
+            await retriever.close()
+        await teardown()
 
     out = Path(args.out)
     out.parent.mkdir(parents=True, exist_ok=True)
@@ -211,6 +259,12 @@ def main(argv=None) -> int:
     conv_parser.add_argument("--num-gpu", type=int, default=None,
                              help="GPU layers to offload; pin it so both sides "
                                   "of a comparison load the model identically")
+    conv_parser.add_argument("--retrieval", action="append", default=[],
+                             choices=["bm25", "memory"],
+                             help="add retrieval-backed strategies "
+                                  "(repeatable). 'bm25' is the infra-free "
+                                  "control; 'memory' is the real MemoryStore "
+                                  "and needs Postgres, Qdrant and Neo4j up")
     conv_parser.add_argument("--allow-mock", action="store_true")
 
     cmp_parser = sub.add_parser("compare", help="diff two reports")

--- a/backend/evals/conversation.py
+++ b/backend/evals/conversation.py
@@ -60,11 +60,17 @@ class Turn(NamedTuple):
 
 
 class ContextStrategy(Protocol):
-    """How much of the conversation the model gets to see at recall time."""
+    """How much of the conversation the model gets to see at recall time.
+
+    ``select`` is async because a retrieval-backed strategy has to reach a
+    database and an embedding model to answer. The two trivial strategies do
+    not need it and pay nothing for it; making the *interface* async is what
+    keeps the interesting implementations expressible at all.
+    """
 
     name: str
 
-    def select(self, transcript: list[Turn], query: str) -> list[Turn]:
+    async def select(self, transcript: list[Turn], query: str) -> list[Turn]:
         ...
 
 
@@ -79,7 +85,7 @@ class FullHistory:
 
     name = "full_history"
 
-    def select(self, transcript: list[Turn], query: str) -> list[Turn]:
+    async def select(self, transcript: list[Turn], query: str) -> list[Turn]:
         return list(transcript)
 
 
@@ -98,8 +104,101 @@ class RecentWindow:
         self.turns = turns
         self.name = f"recent_window_{turns}"
 
-    def select(self, transcript: list[Turn], query: str) -> list[Turn]:
+    async def select(self, transcript: list[Turn], query: str) -> list[Turn]:
         return list(transcript[-self.turns:])
+
+
+def _matching_indices(transcript: list[Turn], hits: list[Turn]) -> list[int]:
+    """Where each retrieved turn sits in the transcript.
+
+    Retrievers return turn *values*, and filler repeats verbatim -- "bus was
+    late again" appears every fourth exchange. Matching by value alone would
+    let one hit claim every copy, inflating a retrieval budget of six into
+    sixty. Each hit therefore consumes the earliest position not already
+    spoken for.
+    """
+    taken: set[int] = set()
+    for hit in hits:
+        for index, turn in enumerate(transcript):
+            if index not in taken and turn == hit:
+                taken.add(index)
+                break
+    return sorted(taken)
+
+
+def _in_transcript_order(transcript: list[Turn], hits: list[Turn]) -> list[Turn]:
+    return [transcript[index] for index in _matching_indices(transcript, hits)]
+
+
+class Retrieved:
+    """Only what a retriever picked, in a budget matched to the window.
+
+    The budget is the experiment. Given the same number of turns as
+    `recent_window_N`, any difference is attributable to *which* turns were
+    chosen rather than to how many -- and "we showed it more" is not a claim
+    about a memory architecture.
+
+    Selected turns are returned in transcript order, not relevance order,
+    because a conversation read out of sequence is a different thing to
+    comprehend and that would confound the measurement too.
+    """
+
+    def __init__(self, retriever, turns: int):
+        if turns < 1:
+            raise ValueError("a retrieval budget needs at least one turn")
+        self.retriever = retriever
+        self.turns = turns
+        self.name = f"retrieved_{retriever.name}_{turns}"
+
+    async def select(self, transcript: list[Turn], query: str) -> list[Turn]:
+        await self.retriever.index(transcript)
+        hits = await self.retriever.search(query, self.turns)
+        return _in_transcript_order(transcript, hits)[: self.turns]
+
+
+class WindowPlusRetrieved:
+    """The tail of the conversation plus what a retriever surfaced.
+
+    Closer to what the running system does -- recent context is always present
+    and memories arrive alongside it -- and therefore the more honest predictor
+    of production behaviour. It is *not* budget-matched to `recent_window_N`,
+    so a win here is partly a win for having more room; that is why the
+    budget-matched `Retrieved` exists next to it rather than instead of it.
+
+    Retrieved turns already inside the window are not repeated.
+    """
+
+    def __init__(self, retriever, window: int, turns: int):
+        if window < 1 or turns < 1:
+            raise ValueError("window and retrieval budget both need a turn")
+        self.retriever = retriever
+        self.window = window
+        self.turns = turns
+        self.name = f"window{window}_plus_{retriever.name}_{turns}"
+
+    async def select(self, transcript: list[Turn], query: str) -> list[Turn]:
+        await self.retriever.index(transcript)
+        hits = await self.retriever.search(query, self.turns)
+
+        window_start = max(0, len(transcript) - self.window)
+        keep = set(range(window_start, len(transcript)))
+
+        # Filler repeats verbatim, so a hit can carry text that is already on
+        # screen inside the window. Retrieval cannot say *which* occurrence it
+        # meant -- `MemoryStore` stores content, not position -- and showing
+        # the model the identical line twice spends budget on context it
+        # already has. Text the window covers is therefore dropped, and only
+        # the remainder is placed by position.
+        visible_texts = {transcript[index].text for index in keep}
+        novel = [turn for turn in hits if turn.text not in visible_texts]
+        keep.update(
+            index
+            for index in _matching_indices(transcript, novel)
+            if index < window_start
+        )
+        # Transcript order, so the model reads one coherent excerpt rather than
+        # retrieved fragments followed by a jump backwards.
+        return [transcript[index] for index in sorted(keep)]
 
 
 DEFAULT_STRATEGIES: tuple[ContextStrategy, ...] = (FullHistory(), RecentWindow(6))
@@ -172,7 +271,7 @@ async def run_conversation_probe(
     options: RunOptions,
 ) -> ProbeResult:
     transcript = build_transcript(probe, filler)
-    visible = strategy.select(transcript, probe.recall_prompt)
+    visible = await strategy.select(transcript, probe.recall_prompt)
     context = render_context(visible)
     prompt = f"{context}\nUser: {probe.recall_prompt}\nAssistant:"
 
@@ -232,6 +331,11 @@ async def run_conversation_eval(
     results: list[ProbeResult] = []
     # Sequential for the same reason the single-turn runner is: one local
     # model, and concurrent generations on CPU contend for the same cores.
+    #
+    # Probe-major, strategy-minor: every strategy sees one probe before the
+    # next probe is built. Retrievers index per transcript and skip a repeat,
+    # so this ordering means each transcript is embedded and written to the
+    # database once instead of once per strategy.
     for probe in probes:
         for strategy in strategies:
             result = await run_conversation_probe(

--- a/backend/evals/conversation.py
+++ b/backend/evals/conversation.py
@@ -191,11 +191,17 @@ class WindowPlusRetrieved:
         # the remainder is placed by position.
         visible_texts = {transcript[index].text for index in keep}
         novel = [turn for turn in hits if turn.text not in visible_texts]
-        keep.update(
+        # Bounded, because a retriever may return more than it was asked for --
+        # `search_memories` treats `limit` as one input among several. Without
+        # the cap this strategy's context grows with whatever the retriever
+        # felt like returning, and "window plus six" silently becomes "window
+        # plus everything", which is `full_history` wearing a different name.
+        surfaced = [
             index
             for index in _matching_indices(transcript, novel)
             if index < window_start
-        )
+        ][: self.turns]
+        keep.update(surfaced)
         # Transcript order, so the model reads one coherent excerpt rather than
         # retrieved fragments followed by a jump backwards.
         return [transcript[index] for index in sorted(keep)]

--- a/backend/evals/retrieval.py
+++ b/backend/evals/retrieval.py
@@ -177,6 +177,10 @@ class MemoryStoreRetriever:
         self._room = ""
         self._by_content: dict[str, Turn] = {}
         self._fingerprint = ""
+        # Counts from the most recent index, so a caller can tell a real recall
+        # failure from a transcript that never made it into the store.
+        self.indexed = 0
+        self.index_failures = 0
 
     async def index(self, turns: list) -> None:
         fingerprint = transcript_fingerprint(turns)
@@ -199,15 +203,43 @@ class MemoryStoreRetriever:
         self._room = f"probe_{fingerprint}"
         self._by_content = {}
 
+        written = 0
+        failed = 0
         for turn in turns:
             content = turn.text
             self._by_content.setdefault(content, turn)
-            await self.store.add_memory(
-                content=content,
-                wing=self.wing,
-                room=self._room,
-                source="eval",
+            try:
+                ok = await self.store.add_memory(
+                    content=content,
+                    wing=self.wing,
+                    room=self._room,
+                    source="eval",
+                )
+            except Exception as exc:
+                failed += 1
+                logger.warning("[eval] add_memory raised for a turn: %s", exc)
+                continue
+            # `add_memory` reports failure by returning False rather than
+            # raising, so an unchecked call cannot distinguish "stored" from
+            # "silently dropped".
+            written += 1 if ok else 0
+            failed += 0 if ok else 1
+
+        # A partly-written index answers queries from a transcript the model
+        # was never given, and the report has no column that would show it. The
+        # last run this suite produced was invalidated by exactly this shape of
+        # silence -- an empty index read as a memory layer that could not
+        # recall -- so it is said out loud rather than inferred later.
+        if failed:
+            logger.error(
+                "[eval] %d of %d turns failed to index; retrieval results for "
+                "this probe describe an incomplete transcript and are not "
+                "evidence about the memory layer",
+                failed,
+                len(turns),
             )
+        self.indexed = written
+        self.index_failures = failed
 
     async def search(self, query: str, limit: int) -> list:
         results = await self.store.search_memories(

--- a/backend/evals/retrieval.py
+++ b/backend/evals/retrieval.py
@@ -1,0 +1,307 @@
+"""Retrievers the conversation suite can put behind a context strategy.
+
+The recall suite's whole point is the gap between strategies. `full_history`
+shows the model everything and `recent_window` shows it the tail; both are
+bounds, not systems. What this project actually claims is that a memory layer
+picks better than either, and that claim is only testable if something can be
+plugged into the same seam and measured.
+
+Two retrievers, because one is not enough to attribute a result:
+
+- `LexicalRetriever` is a plain BM25 over the transcript. It is the control. If
+  the memory layer cannot beat it, then whatever `full_history` was losing was
+  lost to context length rather than to anything the architecture addresses.
+- `MemoryStoreRetriever` is the real `MemoryStore.search_memories` -- ACT-R
+  activation, the learned lexicon, graph boost, vectors -- reached through the
+  same construction production uses. The gap between it and BM25 is this
+  repo's contribution, stated as a number instead of an intention.
+
+Indexing is idempotent per transcript so two strategies sharing a retriever pay
+for it once, and it is scoped per probe so one probe's filler cannot answer
+another probe's question.
+"""
+
+import hashlib
+import logging
+import math
+import re
+from collections import Counter
+from typing import NamedTuple, Protocol
+
+logger = logging.getLogger("evals.retrieval")
+
+# The wing every eval-written memory lands in. Deliberately not "personal":
+# this suite writes hundreds of scripted filler lines into whatever database it
+# is pointed at, and those must never become things the agent believes about
+# its user. Scoping them here is what makes the cleanup at the end total.
+EVAL_WING = "eval_harness"
+
+_WORD_RE = re.compile(r"\b\w+\b")
+
+
+class Turn(NamedTuple):
+    """Mirrors `conversation.Turn`; redeclared to keep the import one-way."""
+
+    speaker: str
+    text: str
+
+
+def _tokenize(text: str) -> list[str]:
+    return _WORD_RE.findall(text.lower())
+
+
+def transcript_fingerprint(turns: list) -> str:
+    """Identity of a transcript, for skipping a re-index that would be a no-op."""
+    digest = hashlib.sha256()
+    for turn in turns:
+        digest.update(turn.speaker.encode("utf-8"))
+        digest.update(b"\x00")
+        digest.update(turn.text.encode("utf-8"))
+        digest.update(b"\x01")
+    return digest.hexdigest()[:16]
+
+
+class Retriever(Protocol):
+    """Something that can be asked which turns matter for a question."""
+
+    name: str
+
+    async def index(self, turns: list) -> None:
+        ...
+
+    async def search(self, query: str, limit: int) -> list:
+        ...
+
+    async def close(self) -> None:
+        ...
+
+
+class LexicalRetriever:
+    """BM25 over the transcript. The control, and deliberately unclever.
+
+    No embeddings, no database, no decay -- so it isolates "retrieval happened"
+    from "this project's retrieval happened". A memory layer that cannot beat
+    a fifty-line ranking function on a planted-fact probe has not yet earned
+    the infrastructure it costs.
+
+    Okapi BM25 with the usual k1/b; `b` is doing real work here because the
+    turns are short and wildly uneven in length.
+    """
+
+    name = "bm25"
+
+    def __init__(self, k1: float = 1.5, b: float = 0.75):
+        self.k1 = k1
+        self.b = b
+        self._turns: list = []
+        self._docs: list[list[str]] = []
+        self._df: Counter = Counter()
+        self._avg_len = 0.0
+        self._fingerprint = ""
+
+    async def index(self, turns: list) -> None:
+        fingerprint = transcript_fingerprint(turns)
+        if fingerprint == self._fingerprint:
+            return
+        self._fingerprint = fingerprint
+        self._turns = list(turns)
+        self._docs = [_tokenize(turn.text) for turn in turns]
+        self._df = Counter()
+        for doc in self._docs:
+            for term in set(doc):
+                self._df[term] += 1
+        self._avg_len = (
+            sum(len(doc) for doc in self._docs) / len(self._docs)
+            if self._docs
+            else 0.0
+        )
+
+    def _score(self, doc: list[str], query_terms: list[str]) -> float:
+        if not doc or not self._avg_len:
+            return 0.0
+        counts = Counter(doc)
+        total = len(self._docs)
+        score = 0.0
+        for term in query_terms:
+            freq = counts.get(term, 0)
+            if not freq:
+                continue
+            # +0.5 smoothing on both sides keeps the idf of a term appearing in
+            # every turn at zero rather than negative -- filler words are then
+            # merely useless, not actively repellent.
+            idf = math.log(
+                1 + (total - self._df[term] + 0.5) / (self._df[term] + 0.5)
+            )
+            denom = freq + self.k1 * (
+                1 - self.b + self.b * len(doc) / self._avg_len
+            )
+            score += idf * (freq * (self.k1 + 1)) / denom
+        return score
+
+    async def search(self, query: str, limit: int) -> list:
+        query_terms = _tokenize(query)
+        scored = [
+            (self._score(doc, query_terms), index)
+            for index, doc in enumerate(self._docs)
+        ]
+        # Ties break on transcript order, so the ranking is total and a rerun
+        # cannot reorder equally-scored turns.
+        scored.sort(key=lambda pair: (-pair[0], pair[1]))
+        return [
+            self._turns[index] for score, index in scored[:limit] if score > 0
+        ]
+
+    async def close(self) -> None:
+        return None
+
+
+class MemoryStoreRetriever:
+    """The production memory layer, reached the way production reaches it.
+
+    Every turn is written through `add_memory` and recalled through
+    `search_memories`, so this exercises the real path: embeddings into Qdrant,
+    the graph into Neo4j, ACT-R activation and cue expansion over Postgres. A
+    reimplementation here would measure a thing nobody ships.
+
+    Writes are confined to `EVAL_WING` and removed by `close()`. The suite
+    otherwise inserts hundreds of scripted lines into the same database the
+    agent uses to remember its user, which would be a considerably worse bug
+    than anything the suite is trying to detect.
+    """
+
+    name = "memory_store"
+
+    def __init__(self, store, wing: str = EVAL_WING):
+        self.store = store
+        self.wing = wing
+        self._room = ""
+        self._by_content: dict[str, Turn] = {}
+        self._fingerprint = ""
+
+    async def index(self, turns: list) -> None:
+        fingerprint = transcript_fingerprint(turns)
+        if fingerprint == self._fingerprint:
+            return
+        self._fingerprint = fingerprint
+
+        # Purge before writing, and this is load-bearing rather than tidy.
+        # `add_memory` deduplicates on content across the whole table, not
+        # within a room -- measured, after a run where this retriever returned
+        # zero turns on five probes. Probes share filler verbatim, so the
+        # second probe's writes were swallowed as duplicates of the first
+        # probe's rows, which live in the first probe's room. Its own room came
+        # up empty and every result read as a memory-layer failure that was
+        # entirely an artifact of leaving the previous probe in place.
+        #
+        # A room per transcript therefore documents intent; the purge is what
+        # actually delivers isolation.
+        await self._purge()
+        self._room = f"probe_{fingerprint}"
+        self._by_content = {}
+
+        for turn in turns:
+            content = turn.text
+            self._by_content.setdefault(content, turn)
+            await self.store.add_memory(
+                content=content,
+                wing=self.wing,
+                room=self._room,
+                source="eval",
+            )
+
+    async def search(self, query: str, limit: int) -> list:
+        results = await self.store.search_memories(
+            query_text=query,
+            wing=self.wing,
+            room=self._room,
+            limit=limit,
+        )
+        turns: list = []
+        for row in results:
+            content = row.get("content") if isinstance(row, dict) else None
+            if content is None:
+                continue
+            turn = self._by_content.get(content)
+            if turn is not None and turn not in turns:
+                turns.append(turn)
+        return turns
+
+    async def close(self) -> None:
+        """Remove everything this retriever wrote, from every tier it wrote to.
+
+        This is not tidiness. The suite inserts hundreds of scripted filler
+        lines into the same database the agent uses to remember its user, so a
+        cleanup that silently half-worked would leave "the bus was late again"
+        sitting in the agent's autobiography, indistinguishable from something
+        the user actually said.
+        """
+        await self._purge()
+
+    async def _purge(self) -> None:
+        """Delete every eval-written memory, across all three tiers.
+
+        Ids are read back before the delete because `add_memory` returns a
+        bool, and the vector tier is keyed by the same id -- without them,
+        Postgres would be clean while Qdrant still answered queries from the
+        rows it no longer has. Loud on failure: a silent half-clean is how eval
+        filler ends up in the agent's autobiography run after run.
+        """
+        ids: list[str] = []
+        try:
+            async with self.store.pool.acquire() as conn:
+                rows = await conn.fetch(
+                    "SELECT id FROM memories WHERE wing = $1", self.wing
+                )
+                ids = [str(row["id"]) for row in rows]
+                await conn.execute(
+                    "DELETE FROM memories WHERE wing = $1", self.wing
+                )
+        except Exception as exc:
+            logger.error(
+                "[eval] could not clean wing %r from the relational tier: %s "
+                "-- eval filler is still in the agent's memory",
+                self.wing,
+                exc,
+            )
+            return
+
+        client = getattr(self.store.qdrant_store, "client", None)
+        collection = getattr(self.store.qdrant_store, "collection_name", None)
+        if client is not None and collection and ids:
+            try:
+                client.delete(collection_name=collection, points_selector=ids)
+            except Exception as exc:
+                logger.error(
+                    "[eval] %d eval vectors remain in Qdrant collection %r: %s",
+                    len(ids),
+                    collection,
+                    exc,
+                )
+
+        graph = self.store.graph_db
+        if graph is not None:
+            try:
+                await graph.execute_query(
+                    "MATCH (n) WHERE n.wing = $wing DETACH DELETE n",
+                    {"wing": self.wing},
+                    write=True,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "[eval] graph nodes for wing %r may remain: %s",
+                    self.wing,
+                    exc,
+                )
+
+        logger.info(
+            "[eval] cleaned %d eval memories from wing %r", len(ids), self.wing
+        )
+
+
+__all__ = [
+    "EVAL_WING",
+    "LexicalRetriever",
+    "MemoryStoreRetriever",
+    "Retriever",
+    "transcript_fingerprint",
+]

--- a/backend/tests/test_conversation_evals.py
+++ b/backend/tests/test_conversation_evals.py
@@ -83,12 +83,14 @@ class TestTheTranscriptIsReproducible:
 
 
 class TestContextStrategies:
-    def test_full_history_shows_the_plant(self):
+    @pytest.mark.asyncio
+    async def test_full_history_shows_the_plant(self):
         turns = build_transcript(make_probe(filler_turns=50), FILLER)
-        visible = FullHistory().select(turns, "q")
+        visible = await FullHistory().select(turns, "q")
         assert any("Wren" in turn.text for turn in visible)
 
-    def test_a_narrow_window_drops_the_plant(self):
+    @pytest.mark.asyncio
+    async def test_a_narrow_window_drops_the_plant(self):
         """The control condition, and it is supposed to fail.
 
         Once the plant falls outside the window the fact is genuinely absent,
@@ -96,13 +98,14 @@ class TestContextStrategies:
         the probe is measuring the prior, not recall.
         """
         turns = build_transcript(make_probe(filler_turns=50), FILLER)
-        visible = RecentWindow(6).select(turns, "q")
+        visible = await RecentWindow(6).select(turns, "q")
         assert len(visible) == 6
         assert not any("Wren" in turn.text for turn in visible)
 
-    def test_a_window_wider_than_the_conversation_keeps_everything(self):
+    @pytest.mark.asyncio
+    async def test_a_window_wider_than_the_conversation_keeps_everything(self):
         turns = build_transcript(make_probe(filler_turns=1), FILLER)
-        assert RecentWindow(100).select(turns, "q") == turns
+        assert await RecentWindow(100).select(turns, "q") == turns
 
     def test_a_zero_width_window_is_rejected(self):
         """An empty context scores the model's prior with no conversation at all."""

--- a/backend/tests/test_retrieval_strategies.py
+++ b/backend/tests/test_retrieval_strategies.py
@@ -1,0 +1,321 @@
+"""Retrieval-backed context strategies: the seam that measures the memory layer.
+
+`full_history` and `recent_window` are bounds, not systems. These strategies are
+what turns "our memory architecture helps" from a claim into a number, so the
+way they can lie is specific: give retrieval a bigger context than the control
+and any win is just extra room; let one probe's transcript answer another's
+question and the distance axis stops meaning anything; match retrieved turns by
+value against filler that repeats verbatim and a budget of six silently becomes
+sixty.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from test_conversation_evals import FILLER, make_probe
+
+from evals.conversation import (
+    Retrieved,
+    Turn,
+    WindowPlusRetrieved,
+    build_transcript,
+)
+from evals.retrieval import (
+    EVAL_WING,
+    LexicalRetriever,
+    MemoryStoreRetriever,
+    transcript_fingerprint,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class TestTheLexicalControl:
+    async def test_it_surfaces_the_planted_turn_over_filler(self):
+        """The control has to actually work, or it is not a control.
+
+        If BM25 could not find a fact it was shown, a memory layer beating it
+        would prove nothing -- the comparison would be against a broken
+        baseline rather than against retrieval.
+        """
+        turns = build_transcript(make_probe(filler_turns=40), FILLER)
+        retriever = LexicalRetriever()
+        await retriever.index(turns)
+
+        hits = await retriever.search("what is my youngest sister called?", 6)
+
+        assert any("Wren" in turn.text for turn in hits)
+
+    async def test_it_returns_nothing_rather_than_noise_for_an_unmatched_query(self):
+        """A retriever that always fills its budget hands the model six
+        irrelevant turns and calls it recall. Empty is the honest answer when
+        nothing matches, and it makes `plant out` visible in the report."""
+        turns = [Turn("user", "the bus was late"), Turn("assistant", "again?")]
+        retriever = LexicalRetriever()
+        await retriever.index(turns)
+
+        assert await retriever.search("quantum chromodynamics", 6) == []
+
+    async def test_reindexing_the_same_transcript_is_skipped(self):
+        """Two strategies share one retriever. Without the skip, every
+        transcript is embedded and written twice -- doubling the cost of the
+        expensive retriever for no change in result."""
+        turns = build_transcript(make_probe(filler_turns=4), FILLER)
+        retriever = LexicalRetriever()
+        await retriever.index(turns)
+        first = retriever._fingerprint
+
+        await retriever.index(turns)
+        assert retriever._fingerprint == first
+
+        other = build_transcript(make_probe(filler_turns=6), FILLER)
+        await retriever.index(other)
+        assert retriever._fingerprint != first
+
+    async def test_a_different_transcript_replaces_the_index(self):
+        """Probes must not pool their evidence. If indexing accumulated, a fact
+        planted for the 4-turn probe would still be retrievable during the
+        240-turn probe and every distance would look survivable."""
+        first = [Turn("user", "my sister is called Wren.")]
+        second = [Turn("user", "the bus was late again.")]
+        retriever = LexicalRetriever()
+
+        await retriever.index(first)
+        await retriever.index(second)
+
+        assert await retriever.search("wren", 5) == []
+
+
+class TestTheBudgetIsMatched:
+    async def test_retrieved_never_exceeds_its_turn_budget(self):
+        """The budget is the experiment. Given more turns than the window
+        control, a win is attributable to context size rather than to
+        selection, and the comparison answers a question nobody asked.
+
+        The stub deliberately returns more than it was asked for: BM25 caps
+        itself, so testing against it would prove the *retriever* honest and
+        say nothing about whether the strategy enforces its own budget. A
+        retriever that over-returns is exactly what this has to survive --
+        `search_memories` takes `limit` as one input among several.
+        """
+        turns = build_transcript(make_probe(filler_turns=60), FILLER)
+        retriever = AsyncMock()
+        retriever.name = "stub"
+        retriever.search.return_value = list(turns[:20])
+
+        visible = await Retrieved(retriever, 6).select(turns, "q")
+
+        assert len(visible) == 6
+
+    async def test_the_lexical_control_also_respects_the_budget(self):
+        turns = build_transcript(make_probe(filler_turns=60), FILLER)
+        strategy = Retrieved(LexicalRetriever(), 6)
+
+        visible = await strategy.select(turns, "what is my sister called?")
+
+        assert len(visible) <= 6
+
+    async def test_repeated_filler_cannot_inflate_the_budget(self):
+        """Filler repeats verbatim every few exchanges. Matching hits by value
+        would let one retrieved turn claim all of its duplicates, so a budget
+        of two could return twenty turns and quietly become a second
+        full_history."""
+        repeated = Turn("user", "what's the weather doing")
+        turns = [repeated] * 20 + [Turn("user", "my sister is called Wren.")]
+
+        retriever = AsyncMock()
+        retriever.name = "stub"
+        retriever.search.return_value = [repeated, repeated]
+        strategy = Retrieved(retriever, 2)
+
+        visible = await strategy.select(turns, "weather")
+
+        assert len(visible) == 2
+
+    async def test_a_zero_budget_is_rejected(self):
+        """An empty context scores the model's prior with no conversation."""
+        with pytest.raises(ValueError):
+            Retrieved(LexicalRetriever(), 0)
+
+    async def test_selected_turns_are_returned_in_transcript_order(self):
+        """Relevance order would hand the model a conversation that jumps
+        around in time, which is a different comprehension task than the
+        controls face and would confound the comparison."""
+        turns = [
+            Turn("user", "my sister is called Wren."),
+            Turn("assistant", "noted."),
+            Turn("user", "the bus was late."),
+        ]
+        retriever = AsyncMock()
+        retriever.name = "stub"
+        retriever.search.return_value = [turns[2], turns[0]]
+
+        visible = await Retrieved(retriever, 3).select(turns, "q")
+
+        assert visible == [turns[0], turns[2]]
+
+
+class TestTheProductionShapedStrategy:
+    async def test_the_recent_window_is_always_present(self):
+        """This strategy exists to mirror what the running system does: recent
+        context is never dropped, memories arrive alongside it."""
+        turns = build_transcript(make_probe(filler_turns=40), FILLER)
+        retriever = AsyncMock()
+        retriever.name = "stub"
+        retriever.search.return_value = []
+
+        visible = await WindowPlusRetrieved(retriever, 6, 6).select(turns, "q")
+
+        assert visible == turns[-6:]
+
+    async def test_a_retrieved_turn_already_in_the_window_is_not_duplicated(self):
+        """Paying twice for the same turn spends the retrieval budget on
+        context the model already had."""
+        turns = build_transcript(make_probe(filler_turns=20), FILLER)
+        retriever = AsyncMock()
+        retriever.name = "stub"
+        retriever.search.return_value = [turns[-1]]
+
+        visible = await WindowPlusRetrieved(retriever, 6, 6).select(turns, "q")
+
+        assert len(visible) == len({id(t) for t in visible})
+        assert len(visible) == 6
+
+    async def test_it_reaches_past_the_window_for_the_plant(self):
+        """The whole point: the fact is outside the window, so `recent_window`
+        must fail and this must not."""
+        turns = build_transcript(make_probe(filler_turns=40), FILLER)
+        strategy = WindowPlusRetrieved(LexicalRetriever(), 6, 6)
+
+        visible = await strategy.select(turns, "what is my sister called?")
+
+        assert any("Wren" in turn.text for turn in visible)
+
+
+class TestTheMemoryStoreRetrieverDoesNotPolluteTheAgent:
+    def _store(self):
+        store = MagicMock()
+        store.add_memory = AsyncMock(return_value=True)
+        store.search_memories = AsyncMock(return_value=[])
+        return store
+
+    async def test_every_write_is_scoped_to_the_eval_wing(self):
+        """This suite writes hundreds of scripted filler lines into the same
+        database the agent uses to remember its user. Unscoped, "the bus was
+        late again" becomes indistinguishable from something the user said,
+        and the cleanup at the end has nothing to key on."""
+        store = self._store()
+        retriever = MemoryStoreRetriever(store)
+
+        await retriever.index([Turn("user", "my sister is called Wren.")])
+
+        assert store.add_memory.await_count == 1
+        assert store.add_memory.await_args.kwargs["wing"] == EVAL_WING
+        assert EVAL_WING != "personal"
+
+    async def test_indexing_a_new_transcript_purges_the_previous_one_first(self):
+        """`add_memory` deduplicates on content across the whole table, not
+        within a room. Probes share filler verbatim, so without a purge the
+        second probe's writes are swallowed as duplicates of the first probe's
+        rows -- which sit in the first probe's room. Its own room comes up
+        empty and the report shows the memory layer returning nothing.
+
+        That is not hypothetical: it happened, and it made a live run read as a
+        memory-layer failure that was entirely this retriever's fault.
+        """
+        conn = AsyncMock()
+        conn.fetch.return_value = []
+        pool = MagicMock()
+        pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+        pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        store = self._store()
+        store.pool = pool
+        store.graph_db = None
+        store.qdrant_store = MagicMock(client=None, collection_name=None)
+        retriever = MemoryStoreRetriever(store)
+
+        await retriever.index([Turn("user", "probe one")])
+        await retriever.index([Turn("user", "probe two")])
+
+        deletes = [
+            call.args[0] for call in conn.execute.await_args_list
+            if "DELETE" in call.args[0]
+        ]
+        assert len(deletes) == 2, "each index must purge before it writes"
+
+    async def test_each_transcript_gets_its_own_room(self):
+        """Probes share a database but must not share evidence: a fact planted
+        for the 4-turn probe answering the 240-turn probe would make every
+        distance look survivable."""
+        store = self._store()
+        retriever = MemoryStoreRetriever(store)
+
+        await retriever.index([Turn("user", "one")])
+        first = retriever._room
+        await retriever.index([Turn("user", "two")])
+
+        assert first and retriever._room != first
+        assert retriever._room.startswith("probe_")
+
+    async def test_the_search_is_scoped_to_the_indexed_room(self):
+        """An unscoped search reads every probe's turns and the room is
+        decoration."""
+        store = self._store()
+        retriever = MemoryStoreRetriever(store)
+        await retriever.index([Turn("user", "my sister is called Wren.")])
+
+        await retriever.search("sister", 5)
+
+        kwargs = store.search_memories.await_args.kwargs
+        assert kwargs["wing"] == EVAL_WING
+        assert kwargs["room"] == retriever._room
+
+    async def test_results_map_back_to_turns_by_content(self):
+        store = self._store()
+        turn = Turn("user", "my sister is called Wren.")
+        store.search_memories = AsyncMock(
+            return_value=[{"content": "my sister is called Wren."}]
+        )
+        retriever = MemoryStoreRetriever(store)
+        await retriever.index([turn])
+
+        assert await retriever.search("sister", 5) == [turn]
+
+    async def test_cleanup_reads_ids_before_deleting_them(self):
+        """The vector tier is keyed by the same id the relational tier holds.
+        Deleting rows first would leave Qdrant answering queries from records
+        that no longer exist, and nothing left to identify them by."""
+        conn = AsyncMock()
+        conn.fetch.return_value = [{"id": "abc"}]
+        pool = MagicMock()
+        pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+        pool.acquire.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        store = self._store()
+        store.pool = pool
+        store.graph_db = None
+        store.qdrant_store = MagicMock(client=MagicMock(), collection_name="m")
+
+        await MemoryStoreRetriever(store).close()
+
+        assert "SELECT id" in conn.fetch.await_args.args[0]
+        assert "DELETE" in conn.execute.await_args.args[0]
+        assert conn.execute.await_args.args[1] == EVAL_WING
+        store.qdrant_store.client.delete.assert_called_once()
+
+
+class TestTheFingerprint:
+    async def test_reordering_turns_changes_it(self):
+        """Same turns in a different order is a different conversation, and a
+        retriever that skipped re-indexing it would answer from the old one."""
+        a = [Turn("user", "one"), Turn("user", "two")]
+        b = [Turn("user", "two"), Turn("user", "one")]
+        assert transcript_fingerprint(a) != transcript_fingerprint(b)
+
+    async def test_it_does_not_collide_across_a_field_boundary(self):
+        """Concatenating fields without a separator makes ("ab","c") and
+        ("a","bc") the same transcript."""
+        a = [Turn("ab", "c")]
+        b = [Turn("a", "bc")]
+        assert transcript_fingerprint(a) != transcript_fingerprint(b)

--- a/backend/tests/test_retrieval_strategies.py
+++ b/backend/tests/test_retrieval_strategies.py
@@ -63,14 +63,19 @@ class TestTheLexicalControl:
         turns = build_transcript(make_probe(filler_turns=4), FILLER)
         retriever = LexicalRetriever()
         await retriever.index(turns)
-        first = retriever._fingerprint
+
+        # Identity of the rebuilt state, not the fingerprint. Comparing
+        # fingerprints proves nothing: without the skip, `index` recomputes the
+        # same value and reassigns it, and the assertion still holds. The
+        # observable consequence of skipping is that the work is not redone.
+        docs_before = retriever._docs
 
         await retriever.index(turns)
-        assert retriever._fingerprint == first
+        assert retriever._docs is docs_before
 
         other = build_transcript(make_probe(filler_turns=6), FILLER)
         await retriever.index(other)
-        assert retriever._fingerprint != first
+        assert retriever._docs is not docs_before
 
     async def test_a_different_transcript_replaces_the_index(self):
         """Probes must not pool their evidence. If indexing accumulated, a fact
@@ -181,6 +186,27 @@ class TestTheProductionShapedStrategy:
         assert len(visible) == len({id(t) for t in visible})
         assert len(visible) == 6
 
+    async def test_an_over_returning_retriever_cannot_grow_the_context(self):
+        """This strategy is not budget-matched, but it is still bounded.
+        `search_memories` treats `limit` as one input among several and may
+        return more; unbounded, "window plus six" becomes "window plus
+        everything", which is `full_history` under another name -- and the
+        comparison against `full_history` then compares it to itself.
+        """
+        # Every turn distinct on purpose. Built from the shipped filler, the
+        # early turns repeat the window's text verbatim and are dropped as
+        # already-visible before the cap is ever reached -- so the test would
+        # pass with the cap removed and prove nothing.
+        turns = [Turn("user", f"line {index}") for index in range(46)]
+        retriever = AsyncMock()
+        retriever.name = "stub"
+        # Far more than asked for, all from outside the window.
+        retriever.search.return_value = list(turns[:40])
+
+        visible = await WindowPlusRetrieved(retriever, 6, 6).select(turns, "q")
+
+        assert len(visible) == 12
+
     async def test_it_reaches_past_the_window_for_the_plant(self):
         """The whole point: the fact is outside the window, so `recent_window`
         must fail and this must not."""
@@ -258,6 +284,22 @@ class TestTheMemoryStoreRetrieverDoesNotPolluteTheAgent:
         assert first and retriever._room != first
         assert retriever._room.startswith("probe_")
 
+    async def test_a_write_that_silently_failed_is_counted_not_swallowed(self):
+        """`add_memory` reports failure by returning False rather than raising.
+        Unchecked, a probe whose transcript never reached the store returns
+        nothing and the report reads it as a memory layer that could not
+        recall -- which is exactly how the previous run was invalidated."""
+        store = self._store()
+        store.add_memory = AsyncMock(side_effect=[True, False, True])
+        retriever = MemoryStoreRetriever(store)
+
+        await retriever.index(
+            [Turn("user", "a"), Turn("user", "b"), Turn("user", "c")]
+        )
+
+        assert retriever.indexed == 2
+        assert retriever.index_failures == 1
+
     async def test_the_search_is_scoped_to_the_indexed_room(self):
         """An unscoped search reads every probe's turns and the room is
         decoration."""
@@ -303,6 +345,16 @@ class TestTheMemoryStoreRetrieverDoesNotPolluteTheAgent:
         assert "DELETE" in conn.execute.await_args.args[0]
         assert conn.execute.await_args.args[1] == EVAL_WING
         store.qdrant_store.client.delete.assert_called_once()
+
+        # Order is the entire claim, and asserting on the calls individually
+        # does not check it: a `_purge` that deleted first and read ids
+        # afterwards would satisfy every assertion above while leaving Qdrant
+        # holding vectors it can no longer identify. Both land on one
+        # connection mock, so `mock_calls` records which ran first.
+        sequence = [
+            call[0] for call in conn.mock_calls if call[0] in ("fetch", "execute")
+        ]
+        assert sequence == ["fetch", "execute"]
 
 
 class TestTheFingerprint:


### PR DESCRIPTION
## What

The recall suite could compare `full_history` against `recent_window` — two
bounds, neither a system. This adds the seam that measures what the project is
actually built on, and then measures it.

**Two retrievers, because one cannot attribute a result.** `LexicalRetriever`
is Okapi BM25 over the transcript: no embeddings, no database, no decay.
`MemoryStoreRetriever` is the real `search_memories`, constructed the way
`brain_agent.main` constructs it. With only the second, a win over
`full_history` would say nothing about this architecture — "something filtered
the context" explains it equally well.

**Two strategy shapes.** `Retrieved` is budget-matched to `recent_window_N`, so
a difference is attributable to *which* turns were chosen rather than how many.
`WindowPlusRetrieved` mirrors production — recent context always present,
memories alongside — and is deliberately not matched, which is why the matched
one exists next to it rather than instead of it.

`ContextStrategy.select` became async: retrieval has to reach a database and an
embedding model, and the two trivial strategies pay nothing for it.

## Live result — `qwen2.5:3b`, 48 probes, real Postgres/Qdrant/Neo4j

**Name recall:** `full_history` passes at all four distances, up to 482 turns
and 18,361 characters. Both retrievers also pass at all four — on ~6 turns and
~248 characters. **Same verdicts on ~74× less context.** `recent_window_6`
fails all four with the plant out, which is the control behaving.

**The memory layer does not beat BM25 on this pack.** Verdicts are identical
everywhere: equal on names, equal-and-failing on details. On this evidence the
ACT-R, vector and graph machinery is not yet earning its infrastructure against
a ranking function that fits on a page. That is a statement about the benchmark
as much as the architecture — a planted fact recalled by a lexically
overlapping question is close to BM25's best case — but it is the measurement
that exists.

**The real unsolved problem is the semantic gap.** Every detail probe past the
shortest distance fails with `plant out`: asked *"is there anything I shouldn't
eat?"*, neither retriever surfaces *"I'm allergic to walnuts."* They share no
content words. A diagnostic confirmed the vector tier is live (768-dim, points
in Qdrant) and *does* return the plant for that query — ranked **fifth of six,
below "what's the weather doing"**. With a lexically overlapping question it
ranks the plant first. So this is a **ranking failure, not a wiring failure**,
and at realistic transcript sizes generic filler crowds the fact out of a
six-turn budget.

Separately: at distance 24+, `full_history` fails the detail probes with the
plant demonstrably *in* context. No retriever can fix that one.

## Safety: this suite writes to the agent's real database

Every eval write is scoped to an `eval_harness` wing and purged across all
three tiers. Without it, hundreds of scripted filler lines like *"the bus was
late again"* become indistinguishable from things the user actually said.
Verified after each run that only the real `personal` memories remain.

**The purge is load-bearing, not tidy.** `add_memory` deduplicates on content
across the whole table rather than within a room, and probes share filler
verbatim — so without it the second probe's writes are swallowed as duplicates
of the first probe's rows and its own room comes up empty. That invalidated a
full run: `retrieved_memory_store_6` returned *zero turns* on five of eight
probes, which read as a broken memory layer and was entirely this retriever's
fault. The first diagnostic hid it by deleting between sizes, so every
iteration started clean.

## Not done

The gap that would justify the architecture is unmeasured, because this pack
cannot show it: a planted fact recalled by a lexically overlapping question is
where BM25 is strongest and where decay, spreading activation and consolidation
contribute least. A pack built to *need* them — facts referred to obliquely,
across sessions, competing with contradictory later information — is the next
thing to write. Until it exists, "the memory layer ties BM25" should be read as
a statement about this benchmark.

Nothing here measures write-side behaviour: importance scoring, decay, pruning
and promotion are all bypassed by indexing in one burst and querying immediately.

## Verification

20 new tests, all 8 mutations killed. Full backend suite via junit-xml: **828
passed, 0 failed/errored/skipped**. `ruff check .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable BM25 and production memory retrieval strategies for conversation evaluations.
  * Added retrieval-aware context options that combine recent and relevant conversation turns while respecting context limits.
  * Added command-line options for selecting and repeating retrieval evaluations.

* **Bug Fixes**
  * Prevented duplicate conversation turns and cross-transcript contamination during retrieval evaluation.

* **Tests**
  * Added coverage for retrieval accuracy, context limits, ordering, isolation, cleanup, and transcript matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->