### PR TITLE
Write recall probes that can tell two retrievers apart

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -5743,3 +5743,64 @@ separate from the rendered context, which is a harness change, not a pack.
 **Write-side behaviour is still entirely unmeasured**: importance scoring,
 decay, pruning and promotion are all bypassed by indexing a transcript in one
 burst and querying it immediately.
+
+### Live result: the memory layer beats the control, on the pack built to test it
+
+`qwen2.5:3b`, 48 probes, real Postgres/Qdrant/Neo4j, `--num-ctx 8192`.
+Probes passed, by strategy: **`retrieved_memory_store_6` 5/8, `full_history`
+3/8, `retrieved_bm25_6` 2/8, `recent_window_6` 0/8.** Head to head the memory
+layer **wins three and loses none**.
+
+Where it wins, and why each one counts:
+
+- **`oblique_activity`, both distances.** Asked "what am I doing to stay fit?"
+  after planting "I've started swimming at the pool", BM25 never surfaces the
+  plant at all -- `plant out` -- because the two share no content word. The
+  memory layer surfaces it and the model answers. This is the designed
+  discrimination, and it is the one the previous pack could not produce.
+- **The same probe at distance 96 beats `full_history`.** Shown all 194 turns
+  and 7,123 characters, the model answers with generic advice and never
+  mentions swimming. Shown 6 turns and 240 characters chosen by retrieval, it
+  gets it right. **~30x less context, and a better answer** -- lost-in-the-
+  middle, and the memory layer stepping over it.
+- **`similars_lexical_d48`.** BM25 *does* retrieve the answering plant here
+  (`plant in`) and the model still fails, replying "Teo's the one who does the
+  long-distance running" and then declining. The memory layer's six turns
+  produce "Halvard, I believe." So the composition of the retrieved set
+  matters, not just whether the answer is somewhere inside it.
+
+Where it does not:
+
+- **`oblique_dislike`, both distances.** Neither retriever surfaces "coriander
+  tastes like soap" for "what should I leave out of tonight's meal?". The
+  standalone rank measurement puts the assistant's acknowledgement -- which
+  also names coriander -- at the very edge of a six-turn budget, so this probe
+  sits right on the boundary rather than failing outright.
+- **`similars_oblique_d48` is a scoring fail, not a retrieval fail**, and the
+  distinction should not be buried. The memory layer retrieved the answer
+  (`plant in`) and the model *named it correctly* -- "Halvard has his
+  allotment" -- but recited three other people around it, which trips the
+  pack's guard against hedging in a crowded field. `must_include` passed;
+  `must_not_match` failed. That guard is deliberate and documented in the
+  pack, and the per-check detail in the report is what keeps it auditable.
+- **`update_*` did not discriminate.** Both retrievers surfaced the correction
+  at both distances and both models answered "the museum". Recency was not put
+  under real pressure by this budget; a sharper version needs the superseded
+  fact to compete for the same slot.
+
+Two model-side findings, cleanly attributable now that retrieval is not the
+confound: `full_history` fails both `similars` probes with all seven facts on
+screen, so picking one of seven near-identical statements is beyond this model
+regardless of memory; and the `oblique_dislike` failures are the only ones
+where retrieval is genuinely the weak link.
+
+**Verified**: full backend suite via junit-xml -- 850 passed, 0
+failed/errored/skipped -- `ruff check .` clean, and every new test
+mutation-tested -- restart the filler per plant, emit plants in pack
+order rather than by depth, accept a plant deeper than its own filler, accept a
+probe with no answering plant, accept a probe written both ways, count
+distractors as answering facts, treat one answering plant as sufficient when
+two are required, and put the recall refresh back. Two pack mutations too:
+leak a content word from an oblique question into its plant, and leak an answer
+into the filler. All caught. After the live run the relational tier held only
+the 63 real `personal` memories, checked directly.

--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -5746,10 +5746,25 @@ burst and querying it immediately.
 
 ### Live result: the memory layer beats the control, on the pack built to test it
 
-`qwen2.5:3b`, 8 probes, real Postgres/Qdrant/Neo4j, `--num-ctx 8192`.
+`qwen2.5:3b`, 8 probes under 6 strategies = 48 scored results, real
+Postgres/Qdrant/Neo4j, `--num-ctx 8192`.
 Probes passed, by strategy: **`retrieved_memory_store_6` 5/8, `full_history`
 3/8, `retrieved_bm25_6` 2/8, `recent_window_6` 0/8.** Head to head the memory
 layer **wins three and loses none**.
+
+> **Read this run as a lower bound, and re-run it.** It was measured before
+> review caught that `refresh_on_recall=False` also selects the *candidate
+> pool* tier in `_compute_mrl_gating`. So the memory-layer strategies searched
+> 20 candidates where a production conversation turn searches 120 -- a sixth
+> of the real pool. The finding survives the error in direction, since a
+> handicapped retriever is not how you inflate a win, but the numbers below
+> are not production's numbers. `full_candidate_pool=True` fixes it; the
+> re-run has not happened yet (the infra containers were down when it was
+> attempted), and until it does, every figure in this section is provisional.
+>
+> The general lesson is the one this ledger keeps relearning: a flag that
+> names one thing and controls two will be changed for the first reason by
+> someone who does not know about the second.
 
 Where it wins, and why each one counts:
 

--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -5746,7 +5746,7 @@ burst and querying it immediately.
 
 ### Live result: the memory layer beats the control, on the pack built to test it
 
-`qwen2.5:3b`, 48 probes, real Postgres/Qdrant/Neo4j, `--num-ctx 8192`.
+`qwen2.5:3b`, 8 probes, real Postgres/Qdrant/Neo4j, `--num-ctx 8192`.
 Probes passed, by strategy: **`retrieved_memory_store_6` 5/8, `full_history`
 3/8, `retrieved_bm25_6` 2/8, `recent_window_6` 0/8.** Head to head the memory
 layer **wins three and loses none**.

--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -5633,3 +5633,113 @@ asserted on each call separately, so deleting before reading ids satisfied every
 assertion. A fourth needed its fixture rebuilt -- filler repeats verbatim, so
 the over-return it fed the strategy was filtered as already-visible before any
 cap could matter, and the test passed against the bug it was written for.
+
+---
+
+## 2026-08-02 -- The tie was the benchmark's fault, and the ranking bug was not where I said it was
+
+The previous entry closed with "the memory layer ties BM25" and an explicit
+warning that the pack could not show a difference: every question in
+`conversation_recall.json` repeats the words of its own plant. Two things came
+out of building the pack that can.
+
+### A probe can now plant more than one fact
+
+`ConversationProbe` grew a `plants` list of `Plant(text, reply, after_filler,
+answers)` alongside the single `plant` field, which is unchanged and still the
+right way to write the common case. `after_filler` places a fact at a stated
+depth; `answers` marks which plants the question is actually about, so
+`plant_visible` reports whether the *answering* facts reached the model and a
+dropped distractor does not mark an honest result as measuring nothing.
+
+Filler is one running sequence that plants interrupt rather than restart --
+otherwise a probe declaring 24 exchanges of distance emits more, and the axis
+every recall number is reported against means a different amount of text per
+probe. Four probe shapes are rejected at load rather than silently measuring
+something else: a plant deeper than its own filler, a probe with no answering
+plant, a probe written both ways at once, and a probe planting nothing.
+
+### The pack: `probes/conversation/discriminating_recall.json`
+
+Three families, all built so literal word overlap is absent or misleading.
+`oblique_*` names the topic and never the plant's words. `update_*` states a
+job, then corrects it twelve exchanges later -- both plants mention work, and
+only recency separates them, which is the probe ACT-R activation exists for.
+`similars_*` crowds seven facts of identical shape and asks about one, shipped
+in a lexical variant *and* an oblique one; the lexical variant is the control
+that establishes a crowded field is not by itself the difficulty.
+
+Two tests keep the pack honest against itself: no filler line may contain any
+probe's answer, and the oblique probes may share no content word with their
+answering plant. The second is asserted twice -- once as the wording rule, once
+against the actual `LexicalRetriever`, because the rule states the intent and
+only the control states the consequence.
+
+### The ranking failure is real, and my hypothesis about it was wrong
+
+Previous entry: "the vector tier returns the plant ranked fifth of six". The
+guess that followed was that `DIRECT_CUE_BOOST` (5.0 per literal keyword,
+against a similarity term that spans ~0.5) was swamping semantics. Measured
+against live Postgres/Qdrant/Neo4j, on `oblique_dislike_d24`:
+
+- Qdrant alone ranks the answering plant **#1**.
+- The fused `search_memories` puts it **#17 of 34**.
+- Forcing `DIRECT_CUE_BOOST` to zero: still **#17**. Not the cause.
+- Disabling PPR spreading activation entirely: still #17. The eval room has
+  **zero** graph entities, so PPR contributes nothing at all here.
+
+Snapshotting scores at each post-processing stage showed the gap was already
+present *before* any of them: the answer entered the fusion at 1.052 while
+unrelated filler entered at 1.708. That difference is inside `_base_activation`,
+and it is `_ln(recall_count)`. Filler repeats verbatim, `add_memory`
+deduplicates on content, and a duplicate write takes `recall_count + 1` -- so a
+line said twice carries **ln 2 = 0.69**, which is larger than the entire
+observed spread of the similarity term (cosine 0.35-0.48 in these rooms, and
+`ACTR_SPREAD_WEIGHT` is 1.0). Neutralising just the frequency term moves the
+answer from #17 to #2, from #17 to #1, and from #36 to #4 on the three oblique
+probes. **Frequency outranks relevance, structurally, not by tuning.**
+
+One correction to how that is stated. Those depths come from asking for 60
+results; the candidate pool is a function of the requested `limit`, so ranks
+are not stable across limits. At the budget the suite actually uses -- six --
+the answer is present in every case: `oblique_dislike` #6 of 6,
+`oblique_activity` #3 of 6, both `update_job` probes #1, both `similars`
+probes #1. The frequency term costs real rank (6th where it would be 2nd, 3rd
+where it would be 1st) but does not push the answer out of the budget on this
+pack. The earlier "fifth of six" should be read the same way: a rank, at one
+requested limit, not a miss.
+
+### The instrument was rewriting what it measured
+
+`search_memories` takes `recall_count + 1` on every hit. Correct for an agent
+living its life; wrong for a retriever inside an eval, where four strategies
+ask the same room the same question and the fourth would rank against a store
+the first three had reshaped -- by a term just shown to be large enough to
+reorder results on its own. `MemoryStoreRetriever.search` now passes
+`refresh_on_recall=False`. Visible in the numbers: the recall-count histogram
+for a 34-content room went from `{2: 18, 3: 16}` to `{1: 18, 2: 16}`, which is
+exactly the write-time counts and nothing else.
+
+### NOT done, deliberately
+
+**No production scoring constant was changed.** The obvious move is to raise
+`ACTR_SPREAD_WEIGHT` until semantics outranks repetition, and the only evidence
+for any particular value would come from the pack in this same commit. That is
+finding B1 exactly -- a retrieval constant fitted to an eval corpus -- and it
+is not worth repeating for a term that, at the real budget, costs rank rather
+than recall. The principled fix is upstream anyway: `ln(freq) - d*ln(recency)`
+is the standard *approximation* to ACT-R's `B_i = ln(sum_k t_k^-d)`, valid when
+presentations are spread across the lifetime and wrong for bursty ones, which
+is what a conversation produces. Doing it properly needs per-presentation
+timestamps the schema does not store.
+
+**Cross-session recall is designed but not built.** A fact learned in an
+earlier conversation, absent from this transcript, is the most discriminating
+probe available -- both context baselines fail by construction. The strategy
+seam maps retrieved turns back to transcript positions, so a hit that is not in
+the transcript is silently dropped; expressing it needs a retriever index
+separate from the rendered context, which is a harness change, not a pack.
+
+**Write-side behaviour is still entirely unmeasured**: importance scoring,
+decay, pruning and promotion are all bypassed by indexing a transcript in one
+burst and querying it immediately.

--- a/backend/app/state/memory_store.py
+++ b/backend/app/state/memory_store.py
@@ -972,6 +972,13 @@ class MemoryStore:
         Higher stress/arousal restricts the search to a smaller Matryoshka
         prefix and a smaller candidate pool, bounding retrieval latency when
         the agent is under load.
+
+        The `refresh_on_recall` parameter selects between two candidate-limit
+        tiers: full retrieval (limit*6, used for normal conversation turns)
+        vs. low-latency fallback (limit*3, used for synchronous fallbacks and
+        background surfacing). Eval searches that need production-equivalent
+        gating while disabling recall mutation should use the separate
+        `gating_refresh_on_recall` parameter in `search_memories`.
         """
         stress_index = max(current_arousal, current_cortisol)
         if stress_index > 0.8:
@@ -2378,6 +2385,8 @@ class MemoryStore:
         user_id: str | None = None,
         is_self_reflection: bool = False,
         current_time=None,
+        *,
+        gating_refresh_on_recall: bool | None = None,
     ):
         """
         ACT-R Based Retrieval with Hierarchical & Neuromodulatory Gating:
@@ -2389,6 +2398,13 @@ class MemoryStore:
         (Qdrant, else SQL) -> lexical/graph cue analysis -> spreading-activation
         boosts -> threshold + format -> L3 archive promotion -> sort/limit.
         Each stage is a `_`-prefixed helper defined above.
+
+        Args:
+            gating_refresh_on_recall: If provided, overrides `refresh_on_recall`
+                for the MRL gating tier decision only (candidate limit). Use this
+                to disable recall mutation (`refresh_on_recall=False`) while keeping
+                production-equivalent gating (`gating_refresh_on_recall=True`), e.g.
+                in evals. Defaults to `refresh_on_recall` if not provided.
         """
         # L1 Cache lookup to bypass DB and math activation loops for active topics
         cache_key = (
@@ -2437,8 +2453,15 @@ class MemoryStore:
             if not query_vector:
                 return []
 
+            # Use gating_refresh_on_recall for the tier decision if provided,
+            # otherwise fall back to refresh_on_recall
+            gating_flag = (
+                gating_refresh_on_recall
+                if gating_refresh_on_recall is not None
+                else refresh_on_recall
+            )
             mrl_dim, candidate_limit = self._compute_mrl_gating(
-                current_arousal, current_cortisol, limit, refresh_on_recall
+                current_arousal, current_cortisol, limit, gating_flag
             )
 
             # Slice query_vector to mrl_dim and pad with zeros to 768

--- a/backend/app/state/memory_store.py
+++ b/backend/app/state/memory_store.py
@@ -965,7 +965,7 @@ class MemoryStore:
         current_arousal: float,
         current_cortisol: float,
         limit,
-        refresh_on_recall: bool,
+        full_pool: bool,
     ) -> tuple[int, int]:
         """Dynamic Matryoshka (MRL) dimension gating.
 
@@ -973,19 +973,21 @@ class MemoryStore:
         prefix and a smaller candidate pool, bounding retrieval latency when
         the agent is under load.
 
-        The `refresh_on_recall` parameter selects between two candidate-limit
-        tiers: full retrieval (limit*6, used for normal conversation turns)
-        vs. low-latency fallback (limit*3, used for synchronous fallbacks and
-        background surfacing). Eval searches that need production-equivalent
-        gating while disabling recall mutation should use the separate
-        `gating_refresh_on_recall` parameter in `search_memories`.
+        `full_pool` picks between the two unstressed tiers: the full pool a
+        conversation turn gets (`limit*6`, floor 120) and the cheaper one a
+        latency-sensitive caller gets (`limit*3`, floor 20). It is named for
+        what it selects. `search_memories` has historically passed
+        `refresh_on_recall` here because its two latency-sensitive callers --
+        the `action.py` fallback and `surfacing_agent` -- also happen not to
+        want recall counters bumped, but those are separate properties and a
+        caller that needs one without the other says so explicitly.
         """
         stress_index = max(current_arousal, current_cortisol)
         if stress_index > 0.8:
             return 256, max(10, limit * 2 if limit is not None else 10)
         if stress_index > 0.6:
             return 512, max(30, limit * 3 if limit is not None else 30)
-        if refresh_on_recall:
+        if full_pool:
             return 768, max(120, limit * 6 if limit is not None else 120)
         return 768, max(20, limit * 3 if limit is not None else 20)
 
@@ -2386,7 +2388,7 @@ class MemoryStore:
         is_self_reflection: bool = False,
         current_time=None,
         *,
-        gating_refresh_on_recall: bool | None = None,
+        full_candidate_pool: bool | None = None,
     ):
         """
         ACT-R Based Retrieval with Hierarchical & Neuromodulatory Gating:
@@ -2400,11 +2402,12 @@ class MemoryStore:
         Each stage is a `_`-prefixed helper defined above.
 
         Args:
-            gating_refresh_on_recall: If provided, overrides `refresh_on_recall`
-                for the MRL gating tier decision only (candidate limit). Use this
-                to disable recall mutation (`refresh_on_recall=False`) while keeping
-                production-equivalent gating (`gating_refresh_on_recall=True`), e.g.
-                in evals. Defaults to `refresh_on_recall` if not provided.
+            full_candidate_pool: How wide a candidate pool to gather, when the
+                agent is not stressed. Defaults to `refresh_on_recall`, which is
+                how this has always been decided -- but the two are different
+                properties that happened to coincide, and reading one off the
+                other silently narrows the search for anyone who wants the
+                counters left alone. Pass it explicitly to say which you mean.
         """
         # L1 Cache lookup to bypass DB and math activation loops for active topics
         cache_key = (
@@ -2453,15 +2456,13 @@ class MemoryStore:
             if not query_vector:
                 return []
 
-            # Use gating_refresh_on_recall for the tier decision if provided,
-            # otherwise fall back to refresh_on_recall
-            gating_flag = (
-                gating_refresh_on_recall
-                if gating_refresh_on_recall is not None
-                else refresh_on_recall
-            )
             mrl_dim, candidate_limit = self._compute_mrl_gating(
-                current_arousal, current_cortisol, limit, gating_flag
+                current_arousal,
+                current_cortisol,
+                limit,
+                refresh_on_recall
+                if full_candidate_pool is None
+                else full_candidate_pool,
             )
 
             # Slice query_vector to mrl_dim and pad with zeros to 768

--- a/backend/evals/README.md
+++ b/backend/evals/README.md
@@ -79,6 +79,53 @@ Reports share the single-turn shape, so `compare` works across both suites.
 Probe ids are qualified with the strategy (`recall_name_d96@full_history`) so
 two conditions never collide inside one report.
 
+### Retrieval strategies, and the control next to them
+
+`--retrieval` adds strategies that *choose* what the model sees instead of
+truncating to a rule:
+
+- **`bm25`** — a fifty-line Okapi BM25 over the transcript. No embeddings, no
+  database, no decay. It is the control, and it needs no infrastructure. A
+  memory layer that cannot beat it has not yet earned what it costs to run.
+- **`memory`** — the real `MemoryStore.search_memories`, built the way
+  `brain_agent.main` builds it. **It needs Postgres, Qdrant and Neo4j up, and
+  it writes every transcript turn into them**, into a dedicated `eval_harness`
+  wing that it purges before each index and again at the end. Point it at the
+  agent's live databases only if that is what you mean to do.
+
+Each retriever yields two strategies: `Retrieved` is budget-matched to
+`recent_window_N`, so a difference is attributable to *which* turns were chosen
+rather than how many; `WindowPlusRetrieved` mirrors what the running system
+does and is deliberately not budget-matched.
+
+The eval retriever searches with `refresh_on_recall=False`. Retrieval normally
+strengthens what it returns, which is right for an agent and wrong for an
+instrument — four strategies query the same room, and the frequency term is
+large enough to reorder results on its own, so leaving it on would make ranking
+depend on the order the suite ran in.
+
+### The discriminating pack
+
+`probes/conversation/discriminating_recall.json` exists because the shipped
+pack could not tell the two retrievers apart: every question in it repeats the
+words of its own plant, which is close to the best case for BM25. Three
+families, all written so literal overlap is absent or misleading — `oblique_*`
+(the question names the topic and never the plant's words), `update_*` (a fact,
+then its correction, distinguishable only by recency), and `similars_*` (seven
+facts of identical shape, shipped in a lexical variant as the control and an
+oblique variant as the test).
+
+Probes there use `plants`, a list placing several facts at stated depths, with
+`answers` marking the ones the question is about — so `plant out` still means
+"the answer never reached the model" when distractors are present.
+
+```bash
+python -m evals run-conversation --model qwen2.5:3b --num-ctx 8192 \
+    --pack evals/probes/conversation/discriminating_recall.json \
+    --retrieval bm25 --retrieval memory \
+    --out evals/out/discriminating.json
+```
+
 ## What a report has to carry to be comparable
 
 A probe flip means the model changed *only if everything else held*, so a

--- a/backend/evals/conversation.py
+++ b/backend/evals/conversation.py
@@ -213,21 +213,58 @@ DEFAULT_STRATEGIES: tuple[ContextStrategy, ...] = (FullHistory(), RecentWindow(6
 def build_transcript(
     probe: ConversationProbe, filler: list[tuple[str, str]]
 ) -> list[Turn]:
-    """Plant the fact, then bury it under ``filler_turns`` scripted exchanges.
+    """Plant each fact at its stated depth, under ``filler_turns`` exchanges.
 
     Filler cycles through the pack in order rather than being sampled, so two
     runs of the same probe produce byte-identical context. A random filler
     would make every rerun a different measurement.
+
+    Plants are emitted in depth order, and ties keep pack order, so a probe
+    that states two facts at the same depth reads in the order it was written.
+    Filler is a single running sequence that the plants interrupt: inserting a
+    plant does not restart it, because the filler *count* is the distance the
+    probe claims to be testing and plants must not silently add to it.
     """
     if not filler:
         raise ValueError("conversation probes need at least one filler exchange")
 
-    turns = [Turn("user", probe.plant), Turn("assistant", probe.plant_reply)]
-    for index in range(probe.filler_turns):
-        user_text, assistant_text = filler[index % len(filler)]
-        turns.append(Turn("user", user_text))
-        turns.append(Turn("assistant", assistant_text))
+    turns: list[Turn] = []
+    emitted = 0
+
+    def run_filler_to(target: int) -> None:
+        nonlocal emitted
+        while emitted < target:
+            user_text, assistant_text = filler[emitted % len(filler)]
+            turns.append(Turn("user", user_text))
+            turns.append(Turn("assistant", assistant_text))
+            emitted += 1
+
+    ordered = sorted(
+        enumerate(probe.resolved_plants),
+        key=lambda pair: (pair[1].after_filler, pair[0]),
+    )
+    for _, plant in ordered:
+        run_filler_to(plant.after_filler)
+        turns.append(Turn("user", plant.text))
+        turns.append(Turn("assistant", plant.reply))
+    run_filler_to(probe.filler_turns)
     return turns
+
+
+def _answers_visible(probe: ConversationProbe, visible: list[Turn]) -> bool:
+    """Whether every fact the question is about reached the model.
+
+    *Every*, not any: a probe that supersedes an earlier fact is only
+    answerable if the correction is on screen, and a probe with two answering
+    facts is only answerable if both are. Distractors are excluded by
+    construction -- their absence makes the probe easier, not unanswerable --
+    so a report that says `plant dropped` still means the same thing it
+    always did: whatever the model said next, it was not recall.
+    """
+    seen = {turn.text for turn in visible}
+    return all(
+        plant.text in seen for plant in probe.resolved_plants if plant.answers
+    )
 
 
 def render_context(turns: list[Turn]) -> str:
@@ -313,7 +350,7 @@ async def run_conversation_probe(
         context_strategy=strategy.name,
         context_turns=len(visible),
         context_chars=len(context),
-        plant_visible=any(turn.text == probe.plant for turn in visible),
+        plant_visible=_answers_visible(probe, visible),
         context_fits=context_fits(prompt, system, options),
     )
 
@@ -409,6 +446,18 @@ def shipped_conversation_pack() -> Path:
     return Path(__file__).parent / "probes" / "conversation" / "conversation_recall.json"
 
 
+def shipped_discriminating_pack() -> Path:
+    """The pack written to separate two retrievers rather than to be answered.
+
+    Not the default, and deliberately so. The shipped pack measures whether a
+    fact survives distance, which is a question about the model; this one
+    measures whether *this* retrieval beats a lexical baseline, which is a
+    question about the architecture, and it requires ``--retrieval`` to mean
+    anything at all.
+    """
+    return Path(__file__).parent / "probes" / "conversation" / "discriminating_recall.json"
+
+
 __all__ = [
     "Check",
     "ContextStrategy",
@@ -421,4 +470,5 @@ __all__ = [
     "run_conversation_eval",
     "run_conversation_probe",
     "shipped_conversation_pack",
+    "shipped_discriminating_pack",
 ]

--- a/backend/evals/probes/conversation/discriminating_recall.json
+++ b/backend/evals/probes/conversation/discriminating_recall.json
@@ -1,0 +1,455 @@
+{
+  "_comment": [
+    "Recall probes written to separate two retrievers, not to be answerable.",
+    "",
+    "The shipped `conversation_recall.json` pack found the memory layer tied",
+    "with a fifty-line BM25 control. That result is uninterpretable, because",
+    "every question in it repeats the words of its own plant -- 'sister' asks",
+    "for 'sister', 'eat' asks about food. A pack like that measures whether",
+    "retrieval happened at all, and both retrievers do that. It cannot measure",
+    "whether *this* retrieval is better, so a tie there is not evidence of",
+    "parity; it is evidence the instrument was blunt.",
+    "",
+    "Every probe here is built so that literal word overlap is either absent or",
+    "actively misleading:",
+    "",
+    "  oblique_*     the question names the topic and never the plant's words.",
+    "                A lexical retriever has nothing above chance to rank on.",
+    "                Anything that passes did so by meaning.",
+    "",
+    "  update_*      a fact, then its correction twelve exchanges later. Both",
+    "                mention the job; only recency distinguishes them. This is",
+    "                the probe ACT-R activation exists for -- a retriever with",
+    "                no notion of when something was said has no way to prefer",
+    "                the true answer.",
+    "",
+    "  similars_*    seven facts of identical shape, one of which is asked",
+    "                about. Shipped in two variants on purpose. The lexical",
+    "                variant is the control: it names the distinguishing word,",
+    "                so both retrievers should pass, which is what establishes",
+    "                that a crowded field is not by itself the difficulty. The",
+    "                oblique variant changes only the question.",
+    "",
+    "NOT here: cross-session recall, where the fact was learned in an earlier",
+    "conversation absent from this transcript. It is the most discriminating",
+    "probe available -- both context baselines would fail by construction --",
+    "but the strategy seam maps retrieved turns back to transcript positions,",
+    "so a hit that is not in the transcript is silently dropped. Expressing it",
+    "needs a retriever index separate from the rendered context, which is a",
+    "change to the harness rather than a pack.",
+    "",
+    "Filler is fresh rather than shared with the other pack, because a filler",
+    "line containing any answer here would let a probe pass without recall.",
+    "All names and facts are invented.",
+    "",
+    "On `must_not_match` in update_*: a blanket ban on the superseded answer",
+    "would be wrong. 'you left the bookshop, you're at the museum now' is a",
+    "correct answer that names the old job, and failing it would penalise the",
+    "clearest phrasing. The guard is narrow on purpose -- it catches only the",
+    "old fact asserted as current."
+  ],
+  "filler": [
+    [
+      "the wifi keeps dropping out",
+      "restart the router. it usually sorts itself."
+    ],
+    [
+      "i slept badly again",
+      "you say that most weeks."
+    ],
+    [
+      "there's a queue at the post office",
+      "there always is on a thursday."
+    ],
+    [
+      "my keys have vanished",
+      "coat pocket. check there first."
+    ],
+    [
+      "it's gone dark early",
+      "it does this time of year."
+    ],
+    [
+      "the printer's jammed",
+      "leave it. it recovers out of spite."
+    ],
+    [
+      "i've got a headache",
+      "water, and sit down for ten minutes."
+    ],
+    [
+      "the train was cancelled",
+      "of course it was."
+    ],
+    [
+      "someone's drilling upstairs",
+      "they'll stop. they always stop."
+    ],
+    [
+      "i need a haircut",
+      "you've been saying that for a month."
+    ],
+    [
+      "my laptop fan is screaming",
+      "it's dusty. it always is."
+    ],
+    [
+      "the milk's turned",
+      "the sniff test has never lied to anyone."
+    ],
+    [
+      "i've lost my umbrella again",
+      "third one this year."
+    ],
+    [
+      "the pipes click all night",
+      "old building. nothing to be done."
+    ],
+    [
+      "i can't remember my password",
+      "you never can. just reset it."
+    ],
+    [
+      "there's a wasp in here",
+      "open the window and back away slowly."
+    ]
+  ],
+  "probes": [
+    {
+      "id": "oblique_activity_d24",
+      "plant": "i've started swimming at the pool before work most mornings.",
+      "plant_reply": "before work. that's discipline.",
+      "filler_turns": 24,
+      "recall_prompt": "what am i doing to stay fit these days?",
+      "checks": [
+        {
+          "kind": "must_include_any",
+          "values": [
+            "swim",
+            "pool"
+          ]
+        },
+        {
+          "kind": "must_not_match",
+          "values": [
+            "not sure what you['’]?re referring",
+            "i don['’]?t (recall|remember|know)",
+            "if you (mentioned|have|had)",
+            "you (haven['’]?t|didn['’]?t|did not) (told|tell|mention|said|say)",
+            "i have no (record|memory|idea)"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "oblique_activity_d96",
+      "plant": "i've started swimming at the pool before work most mornings.",
+      "plant_reply": "before work. that's discipline.",
+      "filler_turns": 96,
+      "recall_prompt": "what am i doing to stay fit these days?",
+      "checks": [
+        {
+          "kind": "must_include_any",
+          "values": [
+            "swim",
+            "pool"
+          ]
+        },
+        {
+          "kind": "must_not_match",
+          "values": [
+            "not sure what you['’]?re referring",
+            "i don['’]?t (recall|remember|know)",
+            "if you (mentioned|have|had)",
+            "you (haven['’]?t|didn['’]?t|did not) (told|tell|mention|said|say)",
+            "i have no (record|memory|idea)"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "oblique_dislike_d24",
+      "plant": "coriander tastes like soap to me, i can't stand it.",
+      "plant_reply": "understood. never coriander.",
+      "filler_turns": 24,
+      "recall_prompt": "what should i leave out of tonight's meal?",
+      "checks": [
+        {
+          "kind": "must_include",
+          "values": [
+            "coriander"
+          ]
+        },
+        {
+          "kind": "must_not_match",
+          "values": [
+            "not sure what you['’]?re referring",
+            "i don['’]?t (recall|remember|know)",
+            "if you (mentioned|have|had)",
+            "you (haven['’]?t|didn['’]?t|did not) (told|tell|mention|said|say)",
+            "i have no (record|memory|idea)"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "oblique_dislike_d96",
+      "plant": "coriander tastes like soap to me, i can't stand it.",
+      "plant_reply": "understood. never coriander.",
+      "filler_turns": 96,
+      "recall_prompt": "what should i leave out of tonight's meal?",
+      "checks": [
+        {
+          "kind": "must_include",
+          "values": [
+            "coriander"
+          ]
+        },
+        {
+          "kind": "must_not_match",
+          "values": [
+            "not sure what you['’]?re referring",
+            "i don['’]?t (recall|remember|know)",
+            "if you (mentioned|have|had)",
+            "you (haven['’]?t|didn['’]?t|did not) (told|tell|mention|said|say)",
+            "i have no (record|memory|idea)"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "update_job_d24",
+      "plants": [
+        {
+          "text": "i work at the bookshop on the high street.",
+          "reply": "the one by the crossing. i know it.",
+          "after_filler": 0,
+          "answers": false
+        },
+        {
+          "text": "i left the bookshop, by the way. i'm at the museum now.",
+          "reply": "the museum. that suits you better.",
+          "after_filler": 12,
+          "answers": true
+        }
+      ],
+      "filler_turns": 24,
+      "recall_prompt": "where do i work now?",
+      "checks": [
+        {
+          "kind": "must_include",
+          "values": [
+            "museum"
+          ]
+        },
+        {
+          "kind": "must_not_match",
+          "values": [
+            "(still|currently) [^.]{0,25}bookshop",
+            "you work at [^.]{0,15}bookshop"
+          ]
+        },
+        {
+          "kind": "must_not_match",
+          "values": [
+            "not sure what you['’]?re referring",
+            "i don['’]?t (recall|remember|know)",
+            "if you (mentioned|have|had)",
+            "you (haven['’]?t|didn['’]?t|did not) (told|tell|mention|said|say)",
+            "i have no (record|memory|idea)"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "update_job_d96",
+      "plants": [
+        {
+          "text": "i work at the bookshop on the high street.",
+          "reply": "the one by the crossing. i know it.",
+          "after_filler": 0,
+          "answers": false
+        },
+        {
+          "text": "i left the bookshop, by the way. i'm at the museum now.",
+          "reply": "the museum. that suits you better.",
+          "after_filler": 48,
+          "answers": true
+        }
+      ],
+      "filler_turns": 96,
+      "recall_prompt": "where do i work now?",
+      "checks": [
+        {
+          "kind": "must_include",
+          "values": [
+            "museum"
+          ]
+        },
+        {
+          "kind": "must_not_match",
+          "values": [
+            "(still|currently) [^.]{0,25}bookshop",
+            "you work at [^.]{0,15}bookshop"
+          ]
+        },
+        {
+          "kind": "must_not_match",
+          "values": [
+            "not sure what you['’]?re referring",
+            "i don['’]?t (recall|remember|know)",
+            "if you (mentioned|have|had)",
+            "you (haven['’]?t|didn['’]?t|did not) (told|tell|mention|said|say)",
+            "i have no (record|memory|idea)"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "similars_lexical_d48",
+      "plants": [
+        {
+          "text": "mira's the one who's always losing her phone.",
+          "reply": "every time.",
+          "after_filler": 2,
+          "answers": false
+        },
+        {
+          "text": "teo's the one who does the long-distance running.",
+          "reply": "exhausting to hear about.",
+          "after_filler": 6,
+          "answers": false
+        },
+        {
+          "text": "halvard's the one with the allotment.",
+          "reply": "right. halvard.",
+          "after_filler": 10,
+          "answers": true
+        },
+        {
+          "text": "sunniva's the one who never answers her messages.",
+          "reply": "some people are like that.",
+          "after_filler": 14,
+          "answers": false
+        },
+        {
+          "text": "ravi's the one who plays in the brass band.",
+          "reply": "loudly, i imagine.",
+          "after_filler": 18,
+          "answers": false
+        },
+        {
+          "text": "iris is the one who's frightened of the sea.",
+          "reply": "reasonable, honestly.",
+          "after_filler": 22,
+          "answers": false
+        },
+        {
+          "text": "bo's the one who gets through two books a week.",
+          "reply": "showing off.",
+          "after_filler": 26,
+          "answers": false
+        }
+      ],
+      "filler_turns": 48,
+      "recall_prompt": "who's the one with the allotment?",
+      "checks": [
+        {
+          "kind": "must_include",
+          "values": [
+            "halvard"
+          ]
+        },
+        {
+          "kind": "must_not_match",
+          "values": [
+            "\\b(mira|teo|sunniva|ravi|iris|bo)\\b"
+          ]
+        },
+        {
+          "kind": "must_not_match",
+          "values": [
+            "not sure what you['’]?re referring",
+            "i don['’]?t (recall|remember|know)",
+            "if you (mentioned|have|had)",
+            "you (haven['’]?t|didn['’]?t|did not) (told|tell|mention|said|say)",
+            "i have no (record|memory|idea)"
+          ]
+        }
+      ]
+    },
+    {
+      "id": "similars_oblique_d48",
+      "plants": [
+        {
+          "text": "mira's the one who's always losing her phone.",
+          "reply": "every time.",
+          "after_filler": 2,
+          "answers": false
+        },
+        {
+          "text": "teo's the one who does the long-distance running.",
+          "reply": "exhausting to hear about.",
+          "after_filler": 6,
+          "answers": false
+        },
+        {
+          "text": "halvard's the one with the allotment.",
+          "reply": "right. halvard.",
+          "after_filler": 10,
+          "answers": true
+        },
+        {
+          "text": "sunniva's the one who never answers her messages.",
+          "reply": "some people are like that.",
+          "after_filler": 14,
+          "answers": false
+        },
+        {
+          "text": "ravi's the one who plays in the brass band.",
+          "reply": "loudly, i imagine.",
+          "after_filler": 18,
+          "answers": false
+        },
+        {
+          "text": "iris is the one who's frightened of the sea.",
+          "reply": "reasonable, honestly.",
+          "after_filler": 22,
+          "answers": false
+        },
+        {
+          "text": "bo's the one who gets through two books a week.",
+          "reply": "showing off.",
+          "after_filler": 26,
+          "answers": false
+        }
+      ],
+      "filler_turns": 48,
+      "recall_prompt": "which of them grows their own vegetables?",
+      "checks": [
+        {
+          "kind": "must_include",
+          "values": [
+            "halvard"
+          ]
+        },
+        {
+          "kind": "must_not_match",
+          "values": [
+            "\\b(mira|teo|sunniva|ravi|iris|bo)\\b"
+          ]
+        },
+        {
+          "kind": "must_not_match",
+          "values": [
+            "not sure what you['’]?re referring",
+            "i don['’]?t (recall|remember|know)",
+            "if you (mentioned|have|had)",
+            "you (haven['’]?t|didn['’]?t|did not) (told|tell|mention|said|say)",
+            "i have no (record|memory|idea)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/backend/evals/retrieval.py
+++ b/backend/evals/retrieval.py
@@ -251,12 +251,17 @@ class MemoryStoreRetriever:
         # Measured, not assumed -- the frequency term is large enough to
         # reorder these results on its own (see the ledger entry on
         # `_base_activation`), so leaving this on makes probe order a variable.
+        #
+        # `gating_refresh_on_recall=True` ensures eval searches use production-
+        # equivalent candidate limits (limit*6) rather than the low-latency tier
+        # (limit*3) that synchronous fallbacks use.
         results = await self.store.search_memories(
             query_text=query,
             wing=self.wing,
             room=self._room,
             limit=limit,
             refresh_on_recall=False,
+            gating_refresh_on_recall=True,
         )
         turns: list = []
         for row in results:

--- a/backend/evals/retrieval.py
+++ b/backend/evals/retrieval.py
@@ -242,11 +242,21 @@ class MemoryStoreRetriever:
         self.index_failures = failed
 
     async def search(self, query: str, limit: int) -> list:
+        # `refresh_on_recall` is what makes retrieval strengthen a memory --
+        # every hit takes `recall_count + 1`, which feeds straight back into
+        # the ln(frequency) term of the next query's activation. That is
+        # correct for an agent living its life and wrong for an instrument:
+        # four strategies ask the same room the same question, and each one
+        # would rank against a store the previous one had already reshaped.
+        # Measured, not assumed -- the frequency term is large enough to
+        # reorder these results on its own (see the ledger entry on
+        # `_base_activation`), so leaving this on makes probe order a variable.
         results = await self.store.search_memories(
             query_text=query,
             wing=self.wing,
             room=self._room,
             limit=limit,
+            refresh_on_recall=False,
         )
         turns: list = []
         for row in results:

--- a/backend/evals/retrieval.py
+++ b/backend/evals/retrieval.py
@@ -252,16 +252,19 @@ class MemoryStoreRetriever:
         # reorder these results on its own (see the ledger entry on
         # `_base_activation`), so leaving this on makes probe order a variable.
         #
-        # `gating_refresh_on_recall=True` ensures eval searches use production-
-        # equivalent candidate limits (limit*6) rather than the low-latency tier
-        # (limit*3) that synchronous fallbacks use.
+        # `full_candidate_pool=True` is not optional decoration. That flag is
+        # normally read off `refresh_on_recall`, so switching the refresh off
+        # also drops the candidate pool from 120 to 20 -- and a retriever
+        # searching a sixth of production's candidates is not the thing this
+        # suite claims to be measuring. Found in review, after a live run had
+        # already been published against the narrower pool.
         results = await self.store.search_memories(
             query_text=query,
             wing=self.wing,
             room=self._room,
             limit=limit,
             refresh_on_recall=False,
-            gating_refresh_on_recall=True,
+            full_candidate_pool=True,
         )
         turns: list = []
         for row in results:

--- a/backend/evals/schema.py
+++ b/backend/evals/schema.py
@@ -94,26 +94,104 @@ class CheckResult(BaseModel):
     detail: str = ""
 
 
+class Plant(BaseModel):
+    """One fact placed in the transcript at a stated depth.
+
+    ``after_filler`` is how many filler exchanges precede it, which is what
+    makes a probe able to say *when* something was said. One fact needs only
+    position zero; the interesting probes need more than one, and need them
+    apart:
+
+    - a fact and its later correction, to ask whether retrieval returns the
+      current answer or the first one it ever heard;
+    - a crowd of near-identical facts, to ask whether retrieval can pick the
+      one that was asked about rather than the topic they share.
+
+    ``answers`` marks the plants the recall question is actually about.
+    Everything else is a distractor that is *supposed* to compete, and the
+    distinction is load-bearing: `plant_visible` reports whether the answering
+    facts reached the model, because a pass without them is a guess. A
+    strategy that drops a distractor has made the probe easier, not invalid,
+    so distractors must not count towards that flag.
+    """
+
+    text: str = Field(min_length=1)
+    reply: str = "Got it."
+    after_filler: int = Field(default=0, ge=0)
+    answers: bool = True
+
+
 class ConversationProbe(BaseModel):
     """A fact planted early, asked about later.
 
     ``filler_turns`` is the distance the fact has to survive, and it is the
     independent variable of the whole suite: a probe is the same question at a
     different remove, so a pack spans distances rather than repeating one.
+    With several plants it is the *total* filler; a plant's own distance from
+    the question is ``filler_turns - after_filler``.
 
     ``plant_reply`` is scripted like the filler, because the assistant's
     acknowledgement is part of the context the recall has to reach past, and
     generating it would put model noise inside the thing being measured.
+
+    A probe is written either as a single ``plant`` or as a list of ``plants``,
+    never both. The single form is not legacy sugar to be migrated away: most
+    probes plant one fact at position zero, and making them spell out a
+    one-element list would obscure that the multi-plant probes are doing
+    something different.
     """
 
     id: str = Field(min_length=1)
     category: Category = "memory"
-    plant: str = Field(min_length=1)
+    plant: str = ""
     plant_reply: str = "Got it."
+    plants: list[Plant] = Field(default_factory=list)
     filler_turns: int = Field(ge=0)
     recall_prompt: str = Field(min_length=1)
     checks: list[Check] = Field(min_length=1)
     source: str = "unknown"
+
+    @model_validator(mode="after")
+    def validate_plants(self) -> "ConversationProbe":
+        """Reject probes whose plants could not be placed as written.
+
+        Each of these silently produces a transcript that does not match what
+        the pack author described, and the report has no column that would
+        show it -- the probe simply measures something else and reads as a
+        result.
+        """
+        if self.plant and self.plants:
+            raise ValueError(
+                f"probe {self.id!r} sets both 'plant' and 'plants'; use one"
+            )
+        if not self.plant and not self.plants:
+            raise ValueError(f"probe {self.id!r} plants no fact")
+
+        resolved = self.resolved_plants
+        # A plant placed deeper than the filler runs would be emitted after the
+        # last filler exchange, landing next to the question it is supposed to
+        # be remembered across -- a probe that measures nothing but reports a
+        # distance.
+        too_deep = [p.text for p in resolved if p.after_filler > self.filler_turns]
+        if too_deep:
+            raise ValueError(
+                f"probe {self.id!r} plants past its own filler ({self.filler_turns}): "
+                f"{too_deep}"
+            )
+        if not any(p.answers for p in resolved):
+            raise ValueError(
+                f"probe {self.id!r} has no plant marked 'answers'; nothing in "
+                "the transcript is the answer and `plant_visible` would be "
+                "vacuously true"
+            )
+        return self
+
+    @property
+    def resolved_plants(self) -> list[Plant]:
+        """The probe's plants, however it was written."""
+        if self.plants:
+            return list(self.plants)
+        return [Plant(text=self.plant, reply=self.plant_reply)]
 
 
 class ProbeResult(BaseModel):

--- a/backend/tests/test_discriminating_pack.py
+++ b/backend/tests/test_discriminating_pack.py
@@ -1,0 +1,390 @@
+"""Tests for multi-plant probes and the pack written to separate two retrievers.
+
+The shipped recall pack found this project's memory layer tied with a
+fifty-line BM25 control. That was not a result about the architecture: every
+question in that pack repeats the words of its own plant, so both retrievers
+were being asked the same easy thing. The pack tested here is the instrument
+built to tell them apart, and the failure that matters is the same one the
+rest of the harness guards against -- an instrument that reads confidently
+while measuring nothing.
+
+Two specific ways that could happen here, both covered below: a plant placed
+where the probe does not claim it is (so the stated distance is a fiction),
+and a question whose words appear in its own plant (so the "oblique" probe is
+not oblique and a lexical retriever passes it for free).
+"""
+
+import json
+import re
+
+import pytest
+from pydantic import ValidationError
+from test_conversation_evals import FILLER, make_probe
+
+from evals.conversation import (
+    Turn,
+    build_transcript,
+    load_conversation_pack,
+    run_conversation_probe,
+    shipped_discriminating_pack,
+)
+from evals.retrieval import LexicalRetriever
+from evals.schema import Check, ConversationProbe, Plant, RunOptions
+
+# The pack's own stop words. Overlap on "i" or "the" is not a lexical handle a
+# retriever can rank on -- BM25 gives a term appearing in nearly every turn an
+# idf near zero -- so the obliqueness check ignores them rather than reporting
+# a failure the retriever could never exploit.
+_TOO_COMMON = frozenset(
+    {
+        "a", "am", "an", "and", "are", "as", "at", "be", "been", "but", "by",
+        "can", "cant", "do", "does", "doing", "dont", "for", "from", "get",
+        "got", "had", "has", "have", "how", "i", "id", "if", "ill", "im", "in",
+        "is", "it", "its", "ive", "just", "me", "most", "my", "no", "not",
+        "of", "on", "or", "out", "should", "so", "than", "that", "the",
+        "their", "them", "these", "they", "this", "to", "up", "us", "was",
+        "we", "what", "when", "where", "which", "who", "why", "will", "with",
+        "you", "your",
+    }
+)
+
+
+def _content_words(text: str) -> set[str]:
+    return {w for w in re.findall(r"[a-z]+", text.lower()) if w not in _TOO_COMMON}
+
+
+@pytest.fixture(scope="module")
+def pack():
+    probes, filler = load_conversation_pack(shipped_discriminating_pack())
+    return probes, filler
+
+
+class TestPlacingMoreThanOneFact:
+    def test_a_plant_lands_after_exactly_the_filler_it_names(self):
+        """`after_filler` is the probe's claim about when the fact was said.
+
+        A contradiction probe is only a contradiction if the correction comes
+        later than the fact it corrects. If placement drifted, the transcript
+        would read in some other order and the probe would score the model on
+        a conversation nobody wrote.
+        """
+        probe = ConversationProbe(
+            id="two",
+            plants=[
+                Plant(text="first fact", reply="ok", after_filler=0, answers=False),
+                Plant(text="second fact", reply="ok", after_filler=3),
+            ],
+            filler_turns=6,
+            recall_prompt="which?",
+            checks=[Check(kind="must_include", values=["second"])],
+        )
+        turns = build_transcript(probe, FILLER)
+        texts = [turn.text for turn in turns]
+        # The first plant's two turns, then three filler exchanges of two.
+        assert texts.index("second fact") - texts.index("first fact") == 2 + 6
+
+    def test_plants_do_not_add_to_the_stated_distance(self):
+        """Filler is one running sequence that plants interrupt.
+
+        If inserting a plant restarted the filler count, a probe declaring 24
+        exchanges of distance would emit more than 24, and the distance axis --
+        the thing every recall number is reported against -- would mean a
+        different amount of text for every probe.
+        """
+        one = ConversationProbe(
+            id="one", plant="fact", filler_turns=8,
+            recall_prompt="q", checks=[Check(kind="must_include", values=["f"])],
+        )
+        many = ConversationProbe(
+            id="many",
+            plants=[
+                Plant(text="a", after_filler=0),
+                Plant(text="b", after_filler=2),
+                Plant(text="c", after_filler=5),
+            ],
+            filler_turns=8,
+            recall_prompt="q",
+            checks=[Check(kind="must_include", values=["a"])],
+        )
+        filler_only = [
+            turn for turn in build_transcript(many, FILLER)
+            if turn.text not in {"a", "b", "c", "Got it."}
+        ]
+        assert len(filler_only) == len(build_transcript(one, FILLER)) - 2
+
+    def test_depth_decides_the_order_not_the_order_they_were_written_in(self):
+        """`after_filler` is the only thing that places a plant.
+
+        A pack lists an update next to the fact it corrects because that is
+        how it reads; if list order won, the correction could be emitted
+        before the thing it corrects and the probe would be testing whether
+        the model prefers the *older* answer.
+        """
+        probe = ConversationProbe(
+            id="out-of-order",
+            plants=[
+                Plant(text="the correction", after_filler=3),
+                Plant(text="the original", after_filler=1, answers=False),
+            ],
+            filler_turns=6,
+            recall_prompt="q",
+            checks=[Check(kind="must_include", values=["correction"])],
+        )
+        texts = [turn.text for turn in build_transcript(probe, FILLER)]
+        assert texts.index("the original") < texts.index("the correction")
+
+    def test_a_single_plant_transcript_is_unchanged(self):
+        """The multi-plant path must not move the probes already measured.
+
+        Reports from the shipped pack are compared against future runs. A
+        transcript that shifted by even one turn would make every one of those
+        comparisons a diff of two different experiments.
+        """
+        probe = make_probe(filler_turns=12)
+        turns = build_transcript(probe, FILLER)
+        assert turns[0] == Turn("user", probe.plant)
+        assert turns[1] == Turn("assistant", probe.plant_reply)
+        assert len(turns) == 2 + 24
+
+
+class TestProbesThatCouldNotMeasureWhatTheyClaim:
+    def test_a_plant_deeper_than_the_filler_is_rejected(self):
+        """It would be emitted next to the question it must be recalled across.
+
+        The probe would report a distance of 24 while the fact sat one turn
+        from the prompt, and pass everywhere.
+        """
+        with pytest.raises(ValidationError):
+            ConversationProbe(
+                id="past-the-end",
+                plants=[Plant(text="late", after_filler=9)],
+                filler_turns=4,
+                recall_prompt="q",
+                checks=[Check(kind="must_include", values=["late"])],
+            )
+
+    def test_a_probe_with_only_distractors_is_rejected(self):
+        """Nothing in the transcript answers, so `plant_visible` is vacuous.
+
+        Every strategy would report the fact as present regardless of what it
+        selected, which is the exact signal the flag exists to give.
+        """
+        with pytest.raises(ValidationError):
+            ConversationProbe(
+                id="no-answer",
+                plants=[Plant(text="a distractor", answers=False)],
+                filler_turns=4,
+                recall_prompt="q",
+                checks=[Check(kind="must_include", values=["x"])],
+            )
+
+    def test_writing_a_probe_both_ways_is_rejected(self):
+        """One of the two would be silently dropped from the transcript."""
+        with pytest.raises(ValidationError):
+            ConversationProbe(
+                id="both",
+                plant="single",
+                plants=[Plant(text="listed")],
+                filler_turns=4,
+                recall_prompt="q",
+                checks=[Check(kind="must_include", values=["x"])],
+            )
+
+    def test_a_probe_planting_nothing_is_rejected(self):
+        with pytest.raises(ValidationError):
+            ConversationProbe(
+                id="empty",
+                filler_turns=4,
+                recall_prompt="q",
+                checks=[Check(kind="must_include", values=["x"])],
+            )
+
+
+class TestWhetherTheAnswerReachedTheModel:
+    @pytest.fixture
+    def manager(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        manager = MagicMock()
+        manager.validate_response = AsyncMock(return_value=(True, ""))
+        return manager
+
+    def _update_probe(self):
+        return ConversationProbe(
+            id="update",
+            plants=[
+                Plant(text="i work at the bookshop.", after_filler=0, answers=False),
+                Plant(text="i'm at the museum now.", after_filler=2, answers=True),
+            ],
+            filler_turns=8,
+            recall_prompt="where do i work now?",
+            checks=[Check(kind="must_include", values=["museum"])],
+        )
+
+    async def _run(self, manager, probe, strategy):
+        from unittest.mock import AsyncMock
+
+        client = AsyncMock()
+        client.generate.return_value = "the museum."
+        return await run_conversation_probe(
+            client, manager, probe, FILLER, strategy,
+            "system", "model", RunOptions(),
+        )
+
+    @pytest.mark.asyncio
+    async def test_half_of_a_two_part_answer_reports_the_plant_dropped(
+        self, manager
+    ):
+        """An answer split across two facts needs both of them on screen.
+
+        With only one shown the question is unanswerable, and the probe
+        produces a clean FAIL that reads as a memory-layer weakness when the
+        harness simply never put the answer in front of the model. This is why
+        the flag asks whether *every* answering plant arrived, not whether one
+        did.
+        """
+        probe = ConversationProbe(
+            id="two-part",
+            plants=[
+                Plant(text="my sister is called wren.", after_filler=0),
+                Plant(text="wren moved to oslo last year.", after_filler=2),
+            ],
+            filler_turns=8,
+            recall_prompt="where does my sister live?",
+            checks=[Check(kind="must_include", values=["oslo"])],
+        )
+
+        class OnlyTheFirstHalf:
+            name = "only_first"
+
+            async def select(self, transcript, query):
+                return [t for t in transcript if "called wren" in t.text]
+
+        result = await self._run(manager, probe, OnlyTheFirstHalf())
+        assert result.plant_visible is False
+
+    @pytest.mark.asyncio
+    async def test_a_dropped_distractor_does_not_invalidate_the_probe(self, manager):
+        """Distractors are supposed to compete; losing one makes it easier.
+
+        Counting them would mark every honest retrieval result as "measured
+        nothing", because picking the answer over the distractors is precisely
+        what the probe asks a retriever to do.
+        """
+        probe = self._update_probe()
+
+        class OnlyTheUpdate:
+            name = "only_new"
+
+            async def select(self, transcript, query):
+                return [t for t in transcript if "museum" in t.text]
+
+        result = await self._run(manager, probe, OnlyTheUpdate())
+        assert result.plant_visible is True
+
+
+class TestThePackDiscriminates:
+    def test_every_probe_id_is_unique(self, pack):
+        """Ids qualify results, and `compare` keys its lookup on them."""
+        probes, _ = pack
+        ids = [probe.id for probe in probes]
+        assert len(ids) == len(set(ids))
+
+    def test_no_filler_line_contains_an_answer(self, pack):
+        """A probe could otherwise pass without the fact ever being recalled.
+
+        The whole pack is scored on `must_include`; an answer sitting in the
+        filler makes every strategy look correct, including the ones designed
+        to fail.
+        """
+        probes, filler = pack
+        haystack = " ".join(a + " " + b for a, b in filler).lower()
+        for probe in probes:
+            for check in probe.checks:
+                if check.kind not in ("must_include", "must_include_any"):
+                    continue
+                for value in check.values:
+                    assert value.lower() not in haystack, (
+                        f"{probe.id}: filler contains its own answer {value!r}"
+                    )
+
+    @pytest.mark.parametrize(
+        "probe_id", ["oblique_activity_d24", "oblique_dislike_d24",
+                     "similars_oblique_d48"],
+    )
+    def test_an_oblique_question_shares_no_content_word_with_its_answer(
+        self, pack, probe_id
+    ):
+        """Obliqueness is the entire experimental manipulation.
+
+        These probes exist to ask whether retrieval works by meaning. One
+        content word shared between the question and the answering plant hands
+        a lexical retriever the answer, and the pack goes back to measuring
+        what the shipped one already measured -- which is how it produced a
+        tie that looked like parity.
+        """
+        probes, _ = pack
+        probe = next(p for p in probes if p.id == probe_id)
+        question = _content_words(probe.recall_prompt)
+        for plant in probe.resolved_plants:
+            if not plant.answers:
+                continue
+            shared = question & _content_words(plant.text + " " + plant.reply)
+            assert not shared, f"{probe_id} leaks {shared} to a lexical retriever"
+
+    @pytest.mark.asyncio
+    async def test_bm25_cannot_find_the_oblique_answer(self, pack):
+        """The claim above, made against the actual control rather than a rule.
+
+        The word-overlap test states the design intent; this states the
+        consequence. If BM25 ranks the answering plant into a six-turn budget,
+        the probe is not discriminating regardless of how its wording looks.
+        """
+        probes, filler = pack
+        probe = next(p for p in probes if p.id == "oblique_dislike_d24")
+        transcript = build_transcript(probe, filler)
+        retriever = LexicalRetriever()
+        await retriever.index(transcript)
+        hits = await retriever.search(probe.recall_prompt, 6)
+        assert not any("coriander" in hit.text for hit in hits)
+
+    @pytest.mark.asyncio
+    async def test_bm25_does_find_the_lexical_variant(self, pack):
+        """The control that makes the oblique result attributable.
+
+        Same seven near-identical facts, same distance, same budget -- only the
+        wording of the question changes. Without this, a BM25 miss on the
+        oblique probe could just as well mean a crowded field defeats it, and
+        the comparison would say nothing about meaning.
+        """
+        probes, filler = pack
+        probe = next(p for p in probes if p.id == "similars_lexical_d48")
+        transcript = build_transcript(probe, filler)
+        retriever = LexicalRetriever()
+        await retriever.index(transcript)
+        hits = await retriever.search(probe.recall_prompt, 6)
+        assert any("halvard" in hit.text.lower() for hit in hits)
+
+    def test_the_update_probes_place_the_correction_after_the_fact(self, pack):
+        """Recency is the only thing that distinguishes them.
+
+        Both plants name a job; if the correction were not strictly later, no
+        retriever could be expected to prefer it and the probe would be asking
+        for a coin flip.
+        """
+        probes, _ = pack
+        for probe in probes:
+            if not probe.id.startswith("update_"):
+                continue
+            answering = [p for p in probe.resolved_plants if p.answers]
+            distractors = [p for p in probe.resolved_plants if not p.answers]
+            assert answering and distractors
+            assert min(p.after_filler for p in answering) > max(
+                p.after_filler for p in distractors
+            )
+
+    def test_the_pack_is_valid_json_with_a_stated_rationale(self):
+        """A pack whose probes cannot be justified will be misread as neutral."""
+        data = json.loads(shipped_discriminating_pack().read_text(encoding="utf-8"))
+        assert data["_comment"]
+        assert data["filler"] and data["probes"]

--- a/backend/tests/test_discriminating_pack.py
+++ b/backend/tests/test_discriminating_pack.py
@@ -50,7 +50,10 @@ _TOO_COMMON = frozenset(
 
 
 def _content_words(text: str) -> set[str]:
-    return {w for w in re.findall(r"[a-z]+", text.lower()) if w not in _TOO_COMMON}
+    # Strip apostrophes so contractions fuse into single tokens that match
+    # the forms in _TOO_COMMON (e.g., "can't" -> "cant", "I've" -> "ive").
+    normalized = text.lower().replace("'", "")
+    return {w for w in re.findall(r"[a-z]+", normalized) if w not in _TOO_COMMON}
 
 
 @pytest.fixture(scope="module")
@@ -191,6 +194,8 @@ class TestProbesThatCouldNotMeasureWhatTheyClaim:
             )
 
     def test_a_probe_planting_nothing_is_rejected(self):
+        """A probe with no plants would leave resolved_plants empty,
+        producing a malformed transcript with no fact to retrieve."""
         with pytest.raises(ValidationError):
             ConversationProbe(
                 id="empty",

--- a/backend/tests/test_f1_decomposed_stages.py
+++ b/backend/tests/test_f1_decomposed_stages.py
@@ -7,6 +7,7 @@ end. Each stage is now independently testable, which is the point of the
 refactor: it makes the memory and action paths safe to iterate on.
 """
 
+import contextlib
 from datetime import UTC
 from unittest.mock import MagicMock
 
@@ -67,81 +68,73 @@ def test_mrl_gating_tolerates_none_limit():
     assert MemoryStore._compute_mrl_gating(0.1, 0.0, None, False) == (768, 20)
 
 
-def test_mrl_gating_tiers_preserve_fallback_behavior():
-    """Production paths that pass refresh_on_recall=False for low-latency
-    (action.py fallback, surfacing_agent) must continue to get the smaller
-    candidate pool (limit*3, min 20) rather than the full tier (limit*6, min 120).
+def test_the_two_unstressed_gating_tiers_stay_six_fold_apart():
+    """The pool a caller gets is the search it gets, and the gap is large.
 
-    This verifies that adding gating_refresh_on_recall for eval searches did not
-    accidentally widen the candidate pool for those unrelated callers.
+    An unstressed conversation turn gathers 120 candidates; a latency-
+    sensitive caller gathers 20. Anything that reads the tier flag off some
+    other property therefore narrows the search sixfold without saying so --
+    which is exactly what happened to the eval retriever when it switched
+    `refresh_on_recall` off, and it published a run before anyone noticed.
     """
-    # Low stress, refresh_on_recall=False: should get the smaller tier
-    dim, candidate_limit = MemoryStore._compute_mrl_gating(0.1, 0.0, 5, False)
-    assert dim == 768
-    assert candidate_limit == 20  # max(20, 5*3) == max(20, 15) == 20
-
-    # Same conditions but refresh_on_recall=True: should get the larger tier
-    dim_full, candidate_limit_full = MemoryStore._compute_mrl_gating(0.1, 0.0, 5, True)
-    assert dim_full == 768
-    assert candidate_limit_full == 120  # max(120, 5*6) == max(120, 30) == 120
-
-    # Verify the tier separation is still present
-    assert candidate_limit < candidate_limit_full
+    assert MemoryStore._compute_mrl_gating(0.1, 0.0, 5, False) == (768, 20)
+    assert MemoryStore._compute_mrl_gating(0.1, 0.0, 5, True) == (768, 120)
 
 
+class _GatingSpy:
+    """The few attributes `search_memories` touches before it picks a tier.
+
+    Hand-written rather than a `MagicMock(spec=MemoryStore)`, because a spec'd
+    mock answers every attribute -- including the one under test -- so the
+    assertion can pass while the real method is never reached. That is how the
+    first version of this test came to assert on an empty list.
+    """
+
+    def __init__(self):
+        self.seen: list[bool] = []
+        self._l1_cache = {}
+        self._l1_cache_ttl = 60.0
+        self._last_stop_words_update = float("inf")
+
+    async def get_embedding(self, text):
+        return [0.1] * 768
+
+    def _compute_mrl_gating(self, arousal, cortisol, limit, full_pool):
+        self.seen.append(full_pool)
+        raise _StopAfterGating
+
+
+class _StopAfterGating(Exception):
+    pass
+
+
+@pytest.mark.parametrize(
+    ("refresh", "explicit", "expected"),
+    [
+        (True, None, True),      # unchanged default: a conversation turn
+        (False, None, False),    # unchanged default: a latency-sensitive caller
+        (False, True, True),     # what the eval retriever needs
+        (True, False, False),    # and the inverse, so the override is real
+    ],
+)
 @pytest.mark.asyncio
-async def test_gating_refresh_on_recall_overrides_for_eval():
-    """The gating_refresh_on_recall parameter allows eval searches to disable
-    recall mutation (refresh_on_recall=False) while using production-equivalent
-    gating (gating_refresh_on_recall=True).
+async def test_the_pool_tier_can_be_asked_for_without_the_recall_refresh(
+    refresh, explicit, expected
+):
+    """`full_candidate_pool` overrides the tier; omitting it changes nothing.
 
-    This decouples the two concerns: recall counters (wrong for evals, which
-    measure four strategies against a constant store) vs. candidate limits
-    (must match production to be a valid measurement).
+    Both halves matter. The override is what lets an eval search production's
+    candidate pool without mutating recall counters. The default is what keeps
+    every existing caller -- `action.py`'s fallback and `surfacing_agent` --
+    on exactly the tier they have always had.
     """
-    from unittest.mock import AsyncMock, MagicMock, patch
-
-    # Mock minimal MemoryStore dependencies
-    mock_store = MagicMock(spec=MemoryStore)
-    mock_store._l1_cache = {}
-    mock_store._l1_cache_ttl = 60
-    mock_store._last_query_vector = None
-    mock_store._last_stop_words_update = 0
-    mock_store._refresh_memories = AsyncMock()
-    mock_store.get_embedding = AsyncMock(return_value=[0.1] * 768)
-
-    # Patch the actual search_memories method to track gating decisions
-    gating_calls = []
-    original_compute_gating = MemoryStore._compute_mrl_gating
-
-    def track_gating(*args, **kwargs):
-        result = original_compute_gating(*args, **kwargs)
-        gating_calls.append((args, result))
-        return result
-
-    with patch.object(MemoryStore, "_compute_mrl_gating", side_effect=track_gating):
-        with patch.object(
-            MemoryStore, "_gather_candidate_sources", new_callable=AsyncMock
-        ) as mock_gather:
-            mock_gather.return_value = ([], [], [])
-
-            # Simulate an eval search: refresh_on_recall=False, gating_refresh_on_recall=True
-            await MemoryStore.search_memories(
-                mock_store,
-                query_text="test query",
-                limit=5,
-                refresh_on_recall=False,
-                gating_refresh_on_recall=True,
-            )
-
-    # Verify _compute_mrl_gating was called with gating_flag=True
-    assert len(gating_calls) == 1
-    gating_args, gating_result = gating_calls[0]
-    # Args are: (arousal, cortisol, limit, refresh_flag)
-    # With defaults: (0.5, 0.0, 5, True) because gating_refresh_on_recall=True
-    assert gating_args[3] is True, "Expected gating flag to be True (from gating_refresh_on_recall)"
-    # Result should be the production tier: (768, max(120, 5*6))
-    assert gating_result == (768, 120), "Expected production gating tier (768, 120)"
+    spy = _GatingSpy()
+    with contextlib.suppress(_StopAfterGating):
+        await MemoryStore.search_memories(
+            spy, query_text="q", limit=5,
+            refresh_on_recall=refresh, full_candidate_pool=explicit,
+        )
+    assert spy.seen == [expected]
 
 
 def test_pronoun_cues_flip_between_user_and_self_reflection():

--- a/backend/tests/test_f1_decomposed_stages.py
+++ b/backend/tests/test_f1_decomposed_stages.py
@@ -67,6 +67,83 @@ def test_mrl_gating_tolerates_none_limit():
     assert MemoryStore._compute_mrl_gating(0.1, 0.0, None, False) == (768, 20)
 
 
+def test_mrl_gating_tiers_preserve_fallback_behavior():
+    """Production paths that pass refresh_on_recall=False for low-latency
+    (action.py fallback, surfacing_agent) must continue to get the smaller
+    candidate pool (limit*3, min 20) rather than the full tier (limit*6, min 120).
+
+    This verifies that adding gating_refresh_on_recall for eval searches did not
+    accidentally widen the candidate pool for those unrelated callers.
+    """
+    # Low stress, refresh_on_recall=False: should get the smaller tier
+    dim, candidate_limit = MemoryStore._compute_mrl_gating(0.1, 0.0, 5, False)
+    assert dim == 768
+    assert candidate_limit == 20  # max(20, 5*3) == max(20, 15) == 20
+
+    # Same conditions but refresh_on_recall=True: should get the larger tier
+    dim_full, candidate_limit_full = MemoryStore._compute_mrl_gating(0.1, 0.0, 5, True)
+    assert dim_full == 768
+    assert candidate_limit_full == 120  # max(120, 5*6) == max(120, 30) == 120
+
+    # Verify the tier separation is still present
+    assert candidate_limit < candidate_limit_full
+
+
+@pytest.mark.asyncio
+async def test_gating_refresh_on_recall_overrides_for_eval():
+    """The gating_refresh_on_recall parameter allows eval searches to disable
+    recall mutation (refresh_on_recall=False) while using production-equivalent
+    gating (gating_refresh_on_recall=True).
+
+    This decouples the two concerns: recall counters (wrong for evals, which
+    measure four strategies against a constant store) vs. candidate limits
+    (must match production to be a valid measurement).
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    # Mock minimal MemoryStore dependencies
+    mock_store = MagicMock(spec=MemoryStore)
+    mock_store._l1_cache = {}
+    mock_store._l1_cache_ttl = 60
+    mock_store._last_query_vector = None
+    mock_store._last_stop_words_update = 0
+    mock_store._refresh_memories = AsyncMock()
+    mock_store.get_embedding = AsyncMock(return_value=[0.1] * 768)
+
+    # Patch the actual search_memories method to track gating decisions
+    gating_calls = []
+    original_compute_gating = MemoryStore._compute_mrl_gating
+
+    def track_gating(*args, **kwargs):
+        result = original_compute_gating(*args, **kwargs)
+        gating_calls.append((args, result))
+        return result
+
+    with patch.object(MemoryStore, "_compute_mrl_gating", side_effect=track_gating):
+        with patch.object(
+            MemoryStore, "_gather_candidate_sources", new_callable=AsyncMock
+        ) as mock_gather:
+            mock_gather.return_value = ([], [], [])
+
+            # Simulate an eval search: refresh_on_recall=False, gating_refresh_on_recall=True
+            await MemoryStore.search_memories(
+                mock_store,
+                query_text="test query",
+                limit=5,
+                refresh_on_recall=False,
+                gating_refresh_on_recall=True,
+            )
+
+    # Verify _compute_mrl_gating was called with gating_flag=True
+    assert len(gating_calls) == 1
+    gating_args, gating_result = gating_calls[0]
+    # Args are: (arousal, cortisol, limit, refresh_flag)
+    # With defaults: (0.5, 0.0, 5, True) because gating_refresh_on_recall=True
+    assert gating_args[3] is True, "Expected gating flag to be True (from gating_refresh_on_recall)"
+    # Result should be the production tier: (768, max(120, 5*6))
+    assert gating_result == (768, 120), "Expected production gating tier (768, 120)"
+
+
 def test_pronoun_cues_flip_between_user_and_self_reflection():
     """"I"/"you" swap referents depending on who is speaking."""
     kwargs = {"agent_node_name": "Aniket", "user_node_name": "Raj", "user_id": "Raj"}

--- a/backend/tests/test_retrieval_strategies.py
+++ b/backend/tests/test_retrieval_strategies.py
@@ -335,6 +335,25 @@ class TestTheMemoryStoreRetrieverDoesNotPolluteTheAgent:
 
         assert store.search_memories.await_args.kwargs["refresh_on_recall"] is False
 
+    async def test_turning_the_refresh_off_does_not_narrow_the_search(self):
+        """`refresh_on_recall` also picks the candidate-pool tier, sixfold.
+
+        Switching it off to stop the instrument mutating the store silently
+        drops the pool from 120 candidates to 20, so the retriever would be
+        searching a sixth of what production searches while the report claims
+        to be measuring production. The pool has to be asked for separately.
+
+        Found in review of the PR that introduced the refresh change, after a
+        live run had already been published against the narrower pool.
+        """
+        store = self._store()
+        retriever = MemoryStoreRetriever(store)
+        await retriever.index([Turn("user", "my sister is called Wren.")])
+
+        await retriever.search("sister", 5)
+
+        assert store.search_memories.await_args.kwargs["full_candidate_pool"] is True
+
     async def test_results_map_back_to_turns_by_content(self):
         store = self._store()
         turn = Turn("user", "my sister is called Wren.")

--- a/backend/tests/test_retrieval_strategies.py
+++ b/backend/tests/test_retrieval_strategies.py
@@ -313,6 +313,28 @@ class TestTheMemoryStoreRetrieverDoesNotPolluteTheAgent:
         assert kwargs["wing"] == EVAL_WING
         assert kwargs["room"] == retriever._room
 
+    async def test_searching_does_not_strengthen_what_it_retrieves(self):
+        """Retrieval must not reshape the store the next probe is scored against.
+
+        `search_memories` normally takes `recall_count + 1` on every hit, which
+        is right for an agent living its life -- what you think about, you
+        think about more easily. It is wrong for an instrument. Four strategies
+        ask the same room the same question, so with the refresh on, strategy
+        four ranks against a store the first three have already rewritten, and
+        the ranking depends on the order the suite happened to run in.
+
+        Not a theoretical worry: the ln(frequency) term is worth more than the
+        entire spread of the similarity term at these scales, so one extra
+        recall is enough to reorder the results.
+        """
+        store = self._store()
+        retriever = MemoryStoreRetriever(store)
+        await retriever.index([Turn("user", "my sister is called Wren.")])
+
+        await retriever.search("sister", 5)
+
+        assert store.search_memories.await_args.kwargs["refresh_on_recall"] is False
+
     async def test_results_map_back_to_turns_by_content(self):
         store = self._store()
         turn = Turn("user", "my sister is called Wren.")


### PR DESCRIPTION
The shipped recall pack found the memory layer tied with a fifty-line BM25
control. Every question in it repeats the words of its own plant, so both
retrievers were being asked the same easy thing — the tie was a statement
about the benchmark, not the architecture. This is the instrument that can
tell them apart, and the first result from it.

## The pack

A probe can now plant more than one fact. `plants` places each at a stated
depth and marks which ones the question is about, so `plant_visible` still
means "the answer reached the model" when distractors are present. Filler
stays one running sequence that plants interrupt rather than restart —
otherwise a probe declaring 24 exchanges of distance emits more, and the axis
every recall number is reported against means something different per probe.
Four unmeasurable probe shapes are rejected at load rather than quietly
measuring something else.

Three families in `discriminating_recall.json`, all written so literal word
overlap is absent or misleading: **oblique** questions that name the topic and
never the plant's words; a fact and its **correction** twelve exchanges later,
separable only by recency; and a **crowded field** of seven near-identical
facts, shipped in a lexical variant as the control and an oblique one as the
test.

Two tests keep the pack honest against itself — no filler line may contain any
probe's answer, and the oblique probes may share no content word with their
answering plant. The second is asserted twice: once as the wording rule, once
against the real `LexicalRetriever`, because the rule states the intent and
only the control states the consequence.

## The result

48 probes, `qwen2.5:3b`, real Postgres/Qdrant/Neo4j. Passed by strategy:

| strategy | passed |
| --- | --- |
| `retrieved_memory_store_6` | **5/8** |
| `full_history` | 3/8 |
| `retrieved_bm25_6` | 2/8 |
| `recent_window_6` | 0/8 |

Head to head the memory layer wins three and loses none. Asked what the user
does to stay fit, after planting "swimming at the pool", BM25 never surfaces
the plant — the two share no content word. The memory layer does. At distance
96 that also beats showing the model everything: six turns and 240 characters
give the right answer where all 194 turns and 7,123 characters give generic
advice.

The failures are recorded distinctly, because one is a *scoring* fail rather
than a retrieval fail — on the oblique crowded-field probe the answer was
retrieved and named correctly, then buried under three other people, which
trips the pack's deliberate guard against hedging.

## Two fixes, and one thing not fixed

**The instrument was rewriting what it measures.** `search_memories` takes
`recall_count + 1` on every hit — right for an agent, wrong for a retriever
inside an eval, where four strategies query the same room and the fourth would
rank against a store the first three reshaped. Now `refresh_on_recall=False`.

**The ranking failure is not where the last entry guessed.** Measured against
live infrastructure: Qdrant ranks the answering plant #1, the fusion demotes
it, and neither the cue boost nor spreading activation is responsible — zeroing
each changes nothing, and the eval room has no graph entities at all. Stage-by-
stage snapshots show the gap is already present when candidates enter post-
processing. It is `ln(recall_count)`: one repetition is worth ln 2 = 0.69,
larger than the entire observed spread of the similarity term.

**No production scoring constant was changed.** The obvious move is to raise
`ACTR_SPREAD_WEIGHT` until semantics outranks repetition, and the only evidence
for any particular value would come from the pack in this same PR — finding B1
exactly. The principled fix is upstream anyway (`ln(freq) − d·ln(recency)` is
an approximation valid for presentations spread over a lifetime, not the bursty
ones a conversation produces), and doing it properly needs per-presentation
timestamps the schema does not store.

## Verification

850 passed / 0 failed via junit-xml, `ruff check .` clean. Nine code mutations
and two pack mutations, all caught — one initially survived (`all` → `any` on
the answer-visible flag is unobservable with a single answering plant), so that
test was rewritten against the two-part answer it actually guards. After the
live run the relational tier held only the 63 real `personal` memories,
checked directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added advanced conversation-recall evaluations covering semantic recall, fact updates, and similar memories.
  - Added support for evaluating multiple facts and distractors within a conversation.
  - Added validation to ensure evaluation prompts produce unambiguous, answerable results.

- **Bug Fixes**
  - Retrieval evaluations now remain consistent across repeated searches by preventing searches from altering memory ranking state.

- **Documentation**
  - Added guidance for running retrieval-backed conversation evaluations and interpreting results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->