### PR TITLE
Fix P0-critical batch: memory double-count, cognitive_rust fallback, blocking Redis I/O, sqlite fetchval commit

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -5819,3 +5819,99 @@ two are required, and put the recall refresh back. Two pack mutations too:
 leak a content word from an oblique question into its plant, and leak an answer
 into the filler. All caught. After the live run the relational tier held only
 the 63 real `personal` memories, checked directly.
+
+---
+
+## 2026-08-21 GitHub triage batch 1 (P0 Critical) — 4 real fixes, 3 stale findings closed
+
+An automated scanner filed 71 issues against the repo. Before touching code,
+cross-referenced the 7 filed as P0/critical against current code and this
+ledger, since several turned out to already be resolved by earlier entries
+above and the scanner had no way to see that.
+
+**Already fixed, closed without a code change:** CORS-allows-all-with-
+LAN_ONLY=false (the 2026-07-18 C1 entry's `_lan_default`/wildcard-credential
+split in `main.py` is exactly this fix) and Cypher-injection-via-f-string (the
+same date's `_safe_relation`/`_safe_label` regex validation runs before every
+f-string interpolation in `graph_db.py`/`learning.py`, with a regression test
+already guarding it). **Closed as intentional, not a bug:**
+`NEXT_PUBLIC_BACKEND_ACCESS_KEY` shipping in the client bundle — the
+2026-07-18 C1 entry chose a query-param shared secret specifically for a
+single-shared-secret personal deployment and documented the tradeoff; there is
+no way to give a browser a secret it can present without the browser holding
+it, and OAuth2/session-exchange machinery is out of proportion to what this
+deployment model needs.
+
+**Fixed — `_on_memory_surfaced` double-counted a surfacing event
+(`core.py`).** A payload carrying both the contract's `memories` list and a
+legacy top-level `content` fallback appended both, and the 5-item trim that
+follows could evict a legitimate older memory to make room for the dupe. Made
+mutually exclusive (`if memories_list: ... else: content fallback`), matching
+what `SurfacingAgent` actually ever sends (always `memories`, contract has no
+top-level `content` field) while keeping the fallback for other producers.
+Two tests pin both branches; reverting the `if`/`else` to the old
+unconditional double-append fails
+`test_memory_surfaced_does_not_double_count_list_and_content_fallback`.
+
+**Fixed — hard `import cognitive_rust` in `appraisal.py` with no fallback.**
+Unlike `memory_store.py`, which already lazy-imports `cognitive_rust` per call
+with a pure-Python fallback for `personalized_pagerank` (see the 2026-07-18
+F1 entry), `appraisal.py` imported it at module level with nothing to catch
+`ImportError` — a host without the compiled extension can't import
+`AppraisalEngine` at all, taking down cognitive service startup. Added
+`_compute_appraisal_fallback` (plus `_compute_novelty_fallback` and
+`_check_norm_alignment_fallback`), a line-for-line mirror of
+`compute_novelty`/`check_norm_alignment`/`compute_appraisal` in
+`cognitive-rust/src/lib.rs`, wired behind a `try: import cognitive_rust /
+except ImportError` at the call site. `test_appraisal_fallback_matches_*` in
+the new `tests/test_appraisal.py` runs both implementations on identical
+inputs and asserts numeric equality — this only proves anything while the
+extension is still installed, which is why the tests run today rather than
+being deferred; a future edit to either side that lets them drift is caught
+immediately rather than only when someone happens to run on a host without
+the wheel.
+
+**Fixed — blocking Redis/sqlite3 calls in `WorkingMemoryStore` reachable from
+async code.** The class's methods were plain `def`s doing blocking I/O;
+`scripts/research/estimate_realtime_latency.py` calls them directly from
+inside `async def run_latency_profile()`, stalling the event loop for the
+Redis round trip or the disk write. Same shape as the `persist_state` fix in
+the 2026-07-19 entry below, applied the same way: every public method is now
+`async def`, delegating to a `_sync_*` body via `asyncio.to_thread`. The one
+caller updated to `await`. Test asserts the sync body runs on a different
+thread than the caller (`test_add_turn_runs_off_the_calling_thread`) rather
+than only checking behavior, since a mistaken direct call would pass every
+behavioral test while still blocking the loop.
+
+**Also fixed while in the area — `SQLiteConnection.fetchval` never
+committed.** Not the "CTE defeats the `query[:6]` keyword sniff" scenario the
+filed issue described — checked directly, and Python's own `sqlite3` module
+has the identical blind spot in its own implicit-transaction detection, so a
+CTE-prefixed write already runs in autocommit mode with nothing to lose
+either way (verified with a two-connection reproduction before writing a test
+that would not have discriminated anything). The real gap: `fetch`/`fetchrow`
+already committed after every call; `fetchval` never did, so `UPDATE ...
+RETURNING <col>` read through it silently lost the write on reconnect.
+Replaced the three call sites' inconsistent commit logic (heuristic prefix
+check on two paths, nothing on the third) with an unconditional
+`self.conn.commit()` on all three — cheaper to reason about than a keyword
+guess, and a commit after a plain `SELECT` is a no-op per sqlite3's own
+transaction semantics.
+
+**Verification:** full backend suite via junit-xml — 869 passed, 0
+failed/errored/skipped — `ruff check .` clean. Mutation-tested: reverting the
+`core.py` if/else to unconditional double-append, reverting
+`sqlite_fallback.py`'s three commits to the old heuristic, and forcing
+`WorkingMemoryStore.add_turn` to call its sync body directly instead of via
+`to_thread` each independently fail the test written for it.
+
+**NOT done:** no WAL mode or `asyncio.Lock` added to `sqlite_fallback.py` —
+the filed issue's "concurrency protection" framing doesn't hold up against
+the actual code. `SQLiteConnection` is a single connection driven entirely
+from the asyncio event loop with no `await` inside any of its methods, so two
+"concurrent" callers can't interleave mid-statement, and nothing moves this
+connection object across threads (unlike `agent_state.py`'s SQLite path,
+which deliberately opens a fresh per-call connection specifically to allow
+`asyncio.to_thread`). Adding locking or WAL here would be defending against a
+race that doesn't exist in the current call graph, for a class that already
+gets a real fix above for the bug that does exist.

--- a/backend/app/cognitive/appraisal.py
+++ b/backend/app/cognitive/appraisal.py
@@ -17,9 +17,47 @@ import re
 from dataclasses import asdict, dataclass
 from typing import Any
 
-import cognitive_rust
-
 logger = logging.getLogger(__name__)
+
+_NORM_SKIP_WORDS = frozenset({"not", "no", "don't", "never", "without", "isn't"})
+
+
+def _word_set(content: str) -> set[str]:
+    return set(content.lower().split())
+
+
+def _compute_novelty_fallback(content: str, recent_contents: list[str]) -> float:
+    """Mirrors `compute_novelty` in cognitive-rust/src/lib.rs word-for-word."""
+    if not recent_contents:
+        return 0.8
+    content_words = _word_set(content)
+    if not content_words:
+        return 0.5
+    max_overlap = 0.0
+    for recent in recent_contents:
+        recent_words = _word_set(recent)
+        if not recent_words:
+            continue
+        intersection = len(content_words & recent_words)
+        union = len(content_words) + len(recent_words) - intersection
+        if union > 0:
+            max_overlap = max(max_overlap, intersection / union)
+    return min(max(1.0 - max_overlap, 0.0), 1.0)
+
+
+def _check_norm_alignment_fallback(content: str, boundaries: list[str]) -> float:
+    """Mirrors `check_norm_alignment` in cognitive-rust/src/lib.rs word-for-word."""
+    if not boundaries:
+        return 1.0
+    content_lower = content.lower()
+    violations = 0
+    for boundary in boundaries:
+        for keyword in boundary.lower().split():
+            if keyword in _NORM_SKIP_WORDS:
+                continue
+            if len(keyword) > 3 and keyword in content_lower:
+                violations += 1
+    return min(max(1.0 - violations * 0.2, 0.0), 1.0)
 
 
 @dataclass(slots=True)
@@ -47,6 +85,48 @@ class AppraisalVector:
 
     def to_dict(self) -> dict[str, float]:
         return asdict(self)
+
+
+def _compute_appraisal_fallback(
+    event_content: str,
+    event_type: str,
+    emotional_bias: float,
+    trust: float,
+    recent_contents: list[str],
+    identity_boundaries: list[str],
+    pitch_f0: float | None,
+    energy_rms: float | None,
+) -> AppraisalVector:
+    """Pure-Python mirror of `cognitive_rust::compute_appraisal`.
+
+    Used only when the compiled extension isn't installed (e.g. not built for
+    the host target). Kept in lockstep with cognitive-rust/src/lib.rs by hand;
+    `test_appraisal_fallback_matches_rust_extension` in tests/ pins both
+    implementations against the same inputs whenever the extension is present.
+    """
+    relevance = {"USER_MESSAGE": 1.0, "SYSTEM_TICK": 0.1}.get(event_type, 0.5)
+    novelty = _compute_novelty_fallback(event_content, recent_contents)
+    goal_congruence = min(max(emotional_bias, -1.0), 1.0)
+    agency = 0.8 if event_type == "USER_MESSAGE" else 0.3
+    norm_alignment = _check_norm_alignment_fallback(event_content, identity_boundaries)
+    relationship_impact = emotional_bias * 0.5
+    if trust < 0.3:
+        relationship_impact *= 0.5
+
+    pitch = pitch_f0 if pitch_f0 is not None else 150.0
+    energy = energy_rms if energy_rms is not None else 0.0
+    if energy > 0.15 or pitch > 250.0:
+        goal_congruence = min(max(goal_congruence - 0.3, -1.0), 1.0)
+        relationship_impact = min(max(relationship_impact - 0.2, -1.0), 1.0)
+
+    return AppraisalVector(
+        relevance=relevance,
+        novelty=novelty,
+        goal_congruence=goal_congruence,
+        agency=agency,
+        norm_alignment=norm_alignment,
+        relationship_impact=relationship_impact,
+    )
 
 
 class AppraisalEngine:
@@ -96,17 +176,46 @@ class AppraisalEngine:
                     f"🎙️ [Appraisal] High arousal user vocal cues detected (energy={energy:.3f}, pitch={pitch:.1f}Hz). Raising threat level."
                 )
 
-        # Delegate to Rust
-        vector = cognitive_rust.compute_appraisal(
-            event_content,
-            event_type,
-            emotional_bias,
-            state_snapshot.get("trust", 0.5),
-            self._recent_contents,
-            identity_boundaries or [],
-            pitch,
-            energy,
-        )
+        # Delegate to Rust; fall back to the pure-Python mirror if the
+        # compiled extension isn't installed (e.g. not built for this host).
+        try:
+            import cognitive_rust
+
+            rust_vector = cognitive_rust.compute_appraisal(
+                event_content,
+                event_type,
+                emotional_bias,
+                state_snapshot.get("trust", 0.5),
+                self._recent_contents,
+                identity_boundaries or [],
+                pitch,
+                energy,
+            )
+            vector = AppraisalVector(
+                relevance=rust_vector.relevance,
+                novelty=rust_vector.novelty,
+                goal_congruence=rust_vector.goal_congruence,
+                agency=rust_vector.agency,
+                norm_alignment=rust_vector.norm_alignment,
+                relationship_impact=rust_vector.relationship_impact,
+            )
+        except ImportError:
+            logger.warning(
+                "cognitive_rust extension not installed; using pure-Python "
+                "appraisal fallback. Build it with `maturin build --manifest-path "
+                "crates/cognitive-rust/Cargo.toml --out target/wheels` for the "
+                "native implementation."
+            )
+            vector = _compute_appraisal_fallback(
+                event_content,
+                event_type,
+                emotional_bias,
+                state_snapshot.get("trust", 0.5),
+                self._recent_contents,
+                identity_boundaries or [],
+                pitch,
+                energy,
+            )
 
         # Track content for novelty computation
         self._recent_contents.append(event_content[:100])
@@ -122,14 +231,7 @@ class AppraisalEngine:
             vector.norm_alignment,
             vector.relationship_impact,
         )
-        return AppraisalVector(
-            relevance=vector.relevance,
-            novelty=vector.novelty,
-            goal_congruence=vector.goal_congruence,
-            agency=vector.agency,
-            norm_alignment=vector.norm_alignment,
-            relationship_impact=vector.relationship_impact,
-        )
+        return vector
 
     async def appraise_semantic_drift(
         self, user_utterance: str, llm_client, current_pad: dict[str, float]

--- a/backend/app/cognitive/core.py
+++ b/backend/app/cognitive/core.py
@@ -307,9 +307,13 @@ class CognitiveService:
         """Proactive memory recall (Active influence)."""
         self._record_subject_metric("memory.surfaced", data)
 
-        # Support both the contract shape (list of memories) and direct content fallback
+        # Support both the contract shape (list of memories) and a direct
+        # content fallback for legacy/alternate payloads. Mutually exclusive:
+        # a payload carrying both used to append the list *and* the fallback,
+        # double-counting a single surfacing event into the 5-item trim below
+        # and evicting older, still-relevant memories to make room for a dupe.
         memories_list = data.get("memories", [])
-        if isinstance(memories_list, list):
+        if isinstance(memories_list, list) and memories_list:
             for mem_item in memories_list:
                 if isinstance(mem_item, dict):
                     memory_text = mem_item.get("content", "")
@@ -330,17 +334,17 @@ class CognitiveService:
                                 ),
                             }
                         )
-
-        memory_text = data.get("content", "")
-        if memory_text:
-            self.surfaced_memories.append(
-                {
-                    "content": memory_text,
-                    "source": data.get("source"),
-                    "timestamp": data.get("timestamp", 0),
-                    "relevance": data.get("relevance", 1.0),
-                }
-            )
+        else:
+            memory_text = data.get("content", "")
+            if memory_text:
+                self.surfaced_memories.append(
+                    {
+                        "content": memory_text,
+                        "source": data.get("source"),
+                        "timestamp": data.get("timestamp", 0),
+                        "relevance": data.get("relevance", 1.0),
+                    }
+                )
 
         self.surfaced_memories = self.surfaced_memories[-5:]
         if self.surfaced_memories:

--- a/backend/app/state/sqlite_fallback.py
+++ b/backend/app/state/sqlite_fallback.py
@@ -371,7 +371,14 @@ class SQLiteConnection:
         cursor = self.conn.cursor()
         cursor.execute(translated, cleaned_args)
         rows = cursor.fetchall()
-        self._commit_if_mutating(translated)
+        # Commits a statement that both writes and returns rows (e.g. `UPDATE
+        # ... RETURNING`), which arrives through the fetch path rather than
+        # execute(). Unconditional rather than prefix-sniffed on the first
+        # keyword: `fetchval` used exactly that check and, having none for
+        # RETURNING statements, never committed one at all. A commit after a
+        # plain SELECT is a no-op -- sqlite3 opens a transaction for DML only
+        # -- so there's no correctness reason to guess whether a query wrote.
+        self.conn.commit()
         return [dict(row) for row in rows]
 
     async def fetchrow(self, query, *args):
@@ -380,20 +387,8 @@ class SQLiteConnection:
         cursor = self.conn.cursor()
         cursor.execute(translated, cleaned_args)
         row = cursor.fetchone()
-        self._commit_if_mutating(translated)
+        self.conn.commit()
         return dict(row) if row else None
-
-    def _commit_if_mutating(self, query: str):
-        """Commit a statement that both writes and returns rows.
-
-        ``UPDATE … RETURNING`` arrives through the fetch path, not execute(),
-        so without this the write sits in sqlite3's implicit transaction and is
-        lost when the connection closes. Only execute() committed, because
-        until RETURNING was used every mutation went through it. A commit after
-        a plain SELECT is a no-op: sqlite3 opens a transaction for DML only.
-        """
-        if query.lstrip()[:6].upper() in ("UPDATE", "INSERT", "DELETE"):
-            self.conn.commit()
 
     async def fetchval(self, query, *args):
         translated = self._translate_query(query)
@@ -401,6 +396,7 @@ class SQLiteConnection:
         cursor = self.conn.cursor()
         cursor.execute(translated, cleaned_args)
         row = cursor.fetchone()
+        self.conn.commit()
         return row[0] if row else None
 
 

--- a/backend/app/state/working_memory_store.py
+++ b/backend/app/state/working_memory_store.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import os
@@ -99,8 +100,21 @@ class WorkingMemoryStore:
             conn.commit()
 
     # --- Real-Time Turns Playout (Last 5–8 turns) ---
+    #
+    # Every public method here is a thin `asyncio.to_thread` wrapper around a
+    # `_sync_*` body. Both the Redis client and the sqlite3 fallback are
+    # blocking I/O; called directly from async code (as
+    # scripts/research/estimate_realtime_latency.py does) they stall the
+    # event loop for a network round trip or a disk write. Off-loading to a
+    # worker thread matches the fix already applied to
+    # `StateService.persist_state` (see the ledger's 2026-07-19 entry).
 
-    def add_turn(
+    async def add_turn(
+        self, role: str, content: str, metadata: dict[str, Any] | None = None
+    ) -> None:
+        await asyncio.to_thread(self._sync_add_turn, role, content, metadata)
+
+    def _sync_add_turn(
         self, role: str, content: str, metadata: dict[str, Any] | None = None
     ):
         """Append a dialogue turn, immediately trimming excess turns to prevent context bloat."""
@@ -143,7 +157,14 @@ class WorkingMemoryStore:
         except Exception as e:
             logger.error(f"SQLite add_turn failed: {e}")
 
-    def get_recent_turns(self, limit: int | None = None) -> list[dict[str, Any]]:
+    async def get_recent_turns(
+        self, limit: int | None = None
+    ) -> list[dict[str, Any]]:
+        return await asyncio.to_thread(self._sync_get_recent_turns, limit)
+
+    def _sync_get_recent_turns(
+        self, limit: int | None = None
+    ) -> list[dict[str, Any]]:
         """Retrieve recent conversation turns in chronological order."""
         limit = limit or self.max_turns
         if self.redis_client:
@@ -188,7 +209,10 @@ class WorkingMemoryStore:
             logger.error(f"SQLite get_recent_turns failed: {e}")
             return []
 
-    def clear_turns(self):
+    async def clear_turns(self) -> None:
+        await asyncio.to_thread(self._sync_clear_turns)
+
+    def _sync_clear_turns(self):
         """Reset the active working memory turns (e.g. on new session starts)."""
         if self.redis_client:
             try:
@@ -207,7 +231,10 @@ class WorkingMemoryStore:
 
     # --- Short-Term Affect / Goals / Variables Synchronization ---
 
-    def set_state_var(self, key: str, value: Any):
+    async def set_state_var(self, key: str, value: Any) -> None:
+        await asyncio.to_thread(self._sync_set_state_var, key, value)
+
+    def _sync_set_state_var(self, key: str, value: Any):
         """Set a synced working memory variable (e.g. goals, short-term emotional states)."""
         val_str = json.dumps(value)
         if self.redis_client:
@@ -230,7 +257,10 @@ class WorkingMemoryStore:
         except Exception as e:
             logger.error(f"SQLite set_state_var failed: {e}")
 
-    def get_state_var(self, key: str, default: Any = None) -> Any:
+    async def get_state_var(self, key: str, default: Any = None) -> Any:
+        return await asyncio.to_thread(self._sync_get_state_var, key, default)
+
+    def _sync_get_state_var(self, key: str, default: Any = None) -> Any:
         """Get a synced working memory variable."""
         if self.redis_client:
             try:

--- a/backend/tests/test_appraisal.py
+++ b/backend/tests/test_appraisal.py
@@ -1,0 +1,124 @@
+import pytest
+
+from app.cognitive.appraisal import (
+    AppraisalVector,
+    _check_norm_alignment_fallback,
+    _compute_appraisal_fallback,
+    _compute_novelty_fallback,
+)
+
+cognitive_rust = pytest.importorskip(
+    "cognitive_rust", reason="compiled extension not built for this host"
+)
+
+
+def test_appraisal_fallback_matches_rust_extension_for_plain_user_message():
+    """Pins the pure-Python fallback to the compiled extension's output.
+
+    If someone edits either implementation without updating the other, this
+    catches the drift while the extension is still installed to compare
+    against - the fallback only ever runs when it is NOT installed, so a
+    silent divergence would otherwise ship unnoticed.
+    """
+    rust_vector = cognitive_rust.compute_appraisal(
+        "I had a great day at the park",
+        "USER_MESSAGE",
+        0.4,
+        0.7,
+        ["yesterday it rained all day"],
+        ["no hate", "no violence"],
+        150.0,
+        0.05,
+    )
+    fallback_vector = _compute_appraisal_fallback(
+        "I had a great day at the park",
+        "USER_MESSAGE",
+        0.4,
+        0.7,
+        ["yesterday it rained all day"],
+        ["no hate", "no violence"],
+        150.0,
+        0.05,
+    )
+
+    assert fallback_vector.relevance == pytest.approx(rust_vector.relevance)
+    assert fallback_vector.novelty == pytest.approx(rust_vector.novelty)
+    assert fallback_vector.goal_congruence == pytest.approx(rust_vector.goal_congruence)
+    assert fallback_vector.agency == pytest.approx(rust_vector.agency)
+    assert fallback_vector.norm_alignment == pytest.approx(rust_vector.norm_alignment)
+    assert fallback_vector.relationship_impact == pytest.approx(
+        rust_vector.relationship_impact
+    )
+
+
+def test_appraisal_fallback_matches_rust_extension_for_high_arousal_and_low_trust():
+    """Same as above but exercises the yell/low-trust branches on both sides."""
+    rust_vector = cognitive_rust.compute_appraisal(
+        "why do you never listen to me",
+        "USER_MESSAGE",
+        -0.6,
+        0.15,
+        ["I was talking about the weather"],
+        ["never insult the user", "no violence"],
+        None,
+        0.2,
+    )
+    fallback_vector = _compute_appraisal_fallback(
+        "why do you never listen to me",
+        "USER_MESSAGE",
+        -0.6,
+        0.15,
+        ["I was talking about the weather"],
+        ["never insult the user", "no violence"],
+        None,
+        0.2,
+    )
+
+    assert fallback_vector.relevance == pytest.approx(rust_vector.relevance)
+    assert fallback_vector.novelty == pytest.approx(rust_vector.novelty)
+    assert fallback_vector.goal_congruence == pytest.approx(rust_vector.goal_congruence)
+    assert fallback_vector.agency == pytest.approx(rust_vector.agency)
+    assert fallback_vector.norm_alignment == pytest.approx(rust_vector.norm_alignment)
+    assert fallback_vector.relationship_impact == pytest.approx(
+        rust_vector.relationship_impact
+    )
+
+
+def test_appraise_falls_back_to_pure_python_when_extension_missing(monkeypatch):
+    """The engine must not crash the whole cognitive service when
+    `cognitive_rust` is unavailable - it should degrade to the heuristic
+    fallback instead of raising an unhandled ImportError."""
+    import builtins
+
+    from app.cognitive.appraisal import AppraisalEngine
+
+    real_import = builtins.__import__
+
+    def blocking_import(name, *args, **kwargs):
+        if name == "cognitive_rust":
+            raise ImportError("simulated: extension not built for this host")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocking_import)
+
+    engine = AppraisalEngine(identity_core_values=[])
+    vector = engine.appraise(
+        event_content="hello there",
+        event_type="USER_MESSAGE",
+        emotional_bias=0.2,
+        state_snapshot={"trust": 0.5},
+    )
+
+    assert isinstance(vector, AppraisalVector)
+    assert vector.relevance == 1.0  # USER_MESSAGE branch
+
+
+def test_novelty_fallback_returns_high_novelty_with_no_history():
+    assert _compute_novelty_fallback("anything", []) == 0.8
+
+
+def test_norm_alignment_fallback_penalizes_each_boundary_keyword_hit():
+    score = _check_norm_alignment_fallback(
+        "I will hurt you", ["never hurt anyone", "no violence"]
+    )
+    assert score < 1.0

--- a/backend/tests/test_regressions.py
+++ b/backend/tests/test_regressions.py
@@ -697,3 +697,36 @@ def test_brain_agent_concurrent_chat_inputs_prevent_lost_task_ownership():
     # If the race existed, one task would be orphaned (created but lost ownership)
     for task in created_tasks:
         assert task.done(), "All created tasks should have completed or been cancelled"
+
+
+def test_memory_surfaced_does_not_double_count_list_and_content_fallback():
+    """A payload carrying both `memories` and a top-level `content` fallback
+    must ingest only the structured list, not both. Before the fix, a single
+    surfacing event with both fields present appended twice, and the 5-item
+    trim in `_on_memory_surfaced` could evict a legitimate older memory to make
+    room for the duplicate.
+    """
+    service = CognitiveService(llm_service=None, memory_store=None, graph_db=None)
+
+    asyncio.run(
+        service._on_memory_surfaced(
+            {
+                "memories": [{"content": "structured memory"}],
+                "content": "fallback memory",
+            }
+        )
+    )
+
+    assert len(service.surfaced_memories) == 1
+    assert service.surfaced_memories[0]["content"] == "structured memory"
+
+
+def test_memory_surfaced_uses_content_fallback_when_list_is_empty():
+    service = CognitiveService(llm_service=None, memory_store=None, graph_db=None)
+
+    asyncio.run(
+        service._on_memory_surfaced({"memories": [], "content": "fallback memory"})
+    )
+
+    assert len(service.surfaced_memories) == 1
+    assert service.surfaced_memories[0]["content"] == "fallback memory"

--- a/backend/tests/test_sqlite_fallback.py
+++ b/backend/tests/test_sqlite_fallback.py
@@ -1,0 +1,62 @@
+import asyncio
+import sqlite3
+
+from app.state.sqlite_fallback import SQLiteConnection
+
+
+def test_update_returning_persists_after_reconnect(tmp_path):
+    """A plain `UPDATE ... RETURNING` write must survive a reconnect.
+
+    `fetchrow`/`fetch` run `RETURNING` statements, which sqlite3 opens an
+    implicit transaction for just like any other DML. Without an explicit
+    commit the write sits uncommitted and is lost when the connection
+    (re)opens - which is exactly what happens on process restart.
+    """
+    db_path = str(tmp_path / "fallback.db")
+    conn = SQLiteConnection(db_path)
+    asyncio.run(conn.execute("INSERT INTO sessions (id) VALUES ($1)", "s1"))
+
+    asyncio.run(
+        conn.fetchrow(
+            "UPDATE sessions SET trust_benevolence = $1 WHERE id = $2 RETURNING id",
+            0.9,
+            "s1",
+        )
+    )
+
+    # Simulate a fresh process picking the file back up.
+    reopened = sqlite3.connect(db_path)
+    row = reopened.execute(
+        "SELECT trust_benevolence FROM sessions WHERE id = 's1'"
+    ).fetchone()
+    reopened.close()
+
+    assert row[0] == 0.9
+
+
+def test_fetchval_on_mutating_returning_statement_persists(tmp_path):
+    """`fetchval` never committed at all, unlike `fetch`/`fetchrow`, so an
+    `UPDATE ... RETURNING <col>` read through it (a normal way to read back a
+    single updated value) ran successfully and then silently lost the write
+    on reconnect - regardless of the query's keyword prefix.
+    """
+    db_path = str(tmp_path / "fallback.db")
+    conn = SQLiteConnection(db_path)
+    asyncio.run(conn.execute("INSERT INTO sessions (id) VALUES ($1)", "s1"))
+
+    result = asyncio.run(
+        conn.fetchval(
+            "UPDATE sessions SET trust_competence = $1 WHERE id = $2 RETURNING trust_competence",
+            0.42,
+            "s1",
+        )
+    )
+    assert result == 0.42
+
+    reopened = sqlite3.connect(db_path)
+    row = reopened.execute(
+        "SELECT trust_competence FROM sessions WHERE id = 's1'"
+    ).fetchone()
+    reopened.close()
+
+    assert row[0] == 0.42

--- a/backend/tests/test_working_memory_store.py
+++ b/backend/tests/test_working_memory_store.py
@@ -1,0 +1,89 @@
+import asyncio
+import threading
+
+from app.state.working_memory_store import WorkingMemoryStore
+
+
+def _make_store(db_path: str) -> WorkingMemoryStore:
+    """A store with no reachable Redis, forced onto the SQLite fallback."""
+    return WorkingMemoryStore(
+        redis_host="127.0.0.1",
+        redis_port=1,  # nothing listens here; connect fails fast
+        db_path=db_path,
+        max_turns=8,
+    )
+
+
+def test_add_turn_and_get_recent_turns_do_not_block_the_event_loop(tmp_path):
+    """`add_turn`/`get_recent_turns` must run their blocking I/O off the loop.
+
+    Regression for C7: these were plain `def` methods doing blocking sqlite3
+    (and, with Redis reachable, blocking `redis.Redis`) calls. Called directly
+    from async code (as scripts/research/estimate_realtime_latency.py does),
+    they stalled the event loop for the duration of the I/O. A concurrently
+    scheduled task should keep making progress while add_turn runs.
+    """
+    store = _make_store(str(tmp_path / "working.db"))
+    progress = []
+
+    async def ticker():
+        for i in range(20):
+            progress.append(i)
+            await asyncio.sleep(0.001)
+
+    async def run():
+        ticker_task = asyncio.create_task(ticker())
+        await store.add_turn(role="user", content="hello", metadata={"i": 0})
+        await asyncio.sleep(0)  # let the ticker get scheduled at least once
+        await ticker_task
+        return await store.get_recent_turns(limit=8)
+
+    turns = asyncio.run(run())
+
+    assert len(progress) == 20
+    assert len(turns) == 1
+    assert turns[0]["content"] == "hello"
+
+
+def test_add_turn_runs_off_the_calling_thread(tmp_path):
+    """The blocking work must happen in a worker thread, not inline on the
+    caller's thread - otherwise wrapping it in `async def` is theater."""
+    store = _make_store(str(tmp_path / "working.db"))
+    caller_thread = threading.current_thread()
+    seen_threads = []
+
+    original = store._sync_add_turn
+
+    def spy(*args, **kwargs):
+        seen_threads.append(threading.current_thread())
+        return original(*args, **kwargs)
+
+    store._sync_add_turn = spy
+
+    asyncio.run(store.add_turn(role="user", content="hi"))
+
+    assert len(seen_threads) == 1
+    assert seen_threads[0] is not caller_thread
+
+
+def test_state_var_roundtrip_via_sqlite_fallback(tmp_path):
+    store = _make_store(str(tmp_path / "working.db"))
+
+    async def run():
+        await store.set_state_var("mood", {"valence": 0.4})
+        return await store.get_state_var("mood")
+
+    result = asyncio.run(run())
+    assert result == {"valence": 0.4}
+
+
+def test_clear_turns_empties_the_store(tmp_path):
+    store = _make_store(str(tmp_path / "working.db"))
+
+    async def run():
+        await store.add_turn(role="user", content="hi")
+        await store.clear_turns()
+        return await store.get_recent_turns()
+
+    turns = asyncio.run(run())
+    assert turns == []

--- a/scripts/research/estimate_realtime_latency.py
+++ b/scripts/research/estimate_realtime_latency.py
@@ -75,7 +75,7 @@ async def run_latency_profile():
     append_runs = []
     for i in range(50):
         start = time.perf_counter()
-        working_store.add_turn(
+        await working_store.add_turn(
             role="user" if i % 2 == 0 else "assistant",
             content=f"This is turn {i} in the latency benchmark simulation.",
             metadata={"index": i, "timestamp": time.time()},
@@ -89,7 +89,7 @@ async def run_latency_profile():
     fetch_runs = []
     for _ in range(50):
         start = time.perf_counter()
-        _ = working_store.get_recent_turns(limit=8)
+        _ = await working_store.get_recent_turns(limit=8)
         fetch_runs.append((time.perf_counter() - start) * 1000.0)
 
     avg_fetch = np.mean(fetch_runs)


### PR DESCRIPTION
## Summary

First batch of a triage pass over the 71 auto-filed issues. Before implementing anything, cross-referenced the P0/critical batch (#105-#111) against current code and `.agents/CONTEXT.md` — several were already resolved by earlier audits the scanner couldn't see.

### Fixed
- **#109** — `_on_memory_surfaced` double-counted a surfacing event when a payload carried both the contract's `memories` list and a legacy `content` fallback, letting the 5-item trim evict a legitimate memory to make room for a duplicate. Made the two paths mutually exclusive.
- **#110** — `appraisal.py` had a hard top-level `import cognitive_rust` with no fallback, unlike `memory_store.py`'s established lazy-import + pure-Python-fallback pattern. A host without the compiled extension can't import `AppraisalEngine` at all. Added a pure-Python mirror of `compute_appraisal`/`compute_novelty`/`check_norm_alignment`, numerically pinned against the real Rust extension in tests.
- **#111** — `WorkingMemoryStore`'s Redis/sqlite3 calls were blocking `def`s reachable from async code (`scripts/research/estimate_realtime_latency.py` calls them directly inside an `async def`), stalling the event loop. Wrapped via `asyncio.to_thread`, matching the precedent already set for `StateService.persist_state`.
- **#107** (partial) — found a real but narrower bug than filed: `SQLiteConnection.fetchval` never committed, silently losing writes made via `UPDATE ... RETURNING <col>`. The issue's "CTE defeats the `query[:6]` commit heuristic" scenario doesn't actually reproduce — Python's own `sqlite3` module has the identical blind spot in its implicit-transaction detection, so those queries already run in autocommit mode. Verified with a two-connection repro before writing tests, so the CTE test I initially wrote (which passed regardless of the fix) was removed rather than kept as false coverage.

### Closed without a code change
- **#105** (CORS allows all with `LAN_ONLY=false`) — already fixed; `main.py`'s `_lan_default`/wildcard-credential split is exactly this.
- **#108** (Cypher injection via f-string) — already fixed; `_safe_relation`/`_safe_label` regex validation runs before every f-string interpolation, with an existing regression test.
- **#106** (`NEXT_PUBLIC_BACKEND_ACCESS_KEY` in the client bundle) — intentional, documented tradeoff for the single-shared-secret personal-deployment auth model added in a prior audit.

### Deliberately not done
No WAL mode or `asyncio.Lock` added to `sqlite_fallback.py`. `SQLiteConnection` runs entirely on the asyncio event loop with no `await` inside its methods (so callers can't interleave mid-statement) and nothing moves it across threads — the "concurrency protection" framing in the filed issue doesn't match the actual call graph.

## Test plan
- [x] Full backend suite via junit-xml: 869 passed, 0 failed/errored/skipped
- [x] `ruff check .` clean
- [x] Every new test mutation-tested (reverted the fix, confirmed the test fails, restored the fix)
- [x] Appraisal fallback numerically verified against the real `cognitive_rust` extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)