### PR TITLE
fix: resolve 12 of 18 P2-medium GitHub issues

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -6056,3 +6056,164 @@ above/in-test rather than left as silently non-discriminating coverage.
   behavior-changing potential (whichever one currently "wins" on disagreement
   is implicit, not tested) - real, but not a same-session drive-by next to
   the seven fixes above.
+
+## 2026-08-21 GitHub triage batch 3 (P2 Medium) — 12 of 18 fixed, 4 false positives closed, 2 deferred
+
+Same discipline as batches 1-2: read the code before trusting the scanner's
+description. Four of the eighteen M-numbered findings turned out to be wrong
+or already-resolved on inspection.
+
+**M2/M7 — `UserMentalModel` mutable defaults and unbounded `known_concepts`.**
+M2's premise doesn't hold under this codebase's actual Pydantic version:
+`list = []`/`dict = {}` class-level defaults on a Pydantic v2 `BaseModel` are
+deep-copied per instance (verified directly - two instances' `known_concepts`
+lists are distinct objects, appending to one leaves the other empty), unlike
+the same pattern on a dataclass or plain function signature. Applied
+`Field(default_factory=...)` anyway since it's the idiomatic v2 style and the
+issue's own concern ("error-prone if refactored to standard dataclasses")
+is a real one to guard against, but this is not a live bug today. M7 is real
+and separate: `update_known_concepts` appended forever with no cap, so a
+multi-hour session's vocabulary list - and the state payload serializing it
+on every persist - grew without bound. Added `MAX_KNOWN_CONCEPTS = 200` with
+sliding-window eviction (oldest concepts drop off, not newest).
+
+**M3 — `CameraLink._ensure_cap` leaked video device handles.** Re-assigned
+`self.cap` to a fresh `cv2.VideoCapture(0)` whenever the existing one failed
+`isOpened()`, without releasing it first. On a flaky `/dev/video0` (common on
+Linux when another process briefly grabs it), every recovery attempt leaked
+another handle. Fixed: release the stale handle before replacing it.
+
+**M4 — reflection's fact extraction fragments the graph on wording alone.**
+The extraction prompt leaves `"relation"` as free text
+(`app/cognitive/learning.py`'s LLM schema has no enum for it), so the LLM's
+exact word choice becomes a distinct Cypher relationship *type* -
+`(user)-[:LIKES]->(tea)` and `(user)-[:ENJOYS]->(tea)` are unrelated edges to
+Neo4j, and the existing dedup check (`MATCH (s)-[r:{rel_type}]->(t)`) is an
+exact match on that already-normalized type, so it can't catch synonyms.
+Added a small, deliberately conservative canonical map
+(`_RELATION_SYNONYMS` in `learning.py`) collapsing the handful of everyday
+synonym clusters worth the risk of losing a verb's nuance (LOVES/ENJOYS/
+ADORES/PREFERS → LIKES; HATES/DETESTS → DISLIKES; IS_TYPE_OF/TYPE_OF → IS_A) -
+not a general thesaurus. Broke `test_fact_consolidation`'s assertion that
+"LOVES" was stored verbatim; updated it, since that's exactly the fragmentation
+this fix removes.
+
+**M6 — NATS reconnects had no backoff or jitter.** `nats.connect(reconnect_
+time_wait=2.0)` meant every process in the mesh (brain, system, subconscious,
+surfacing, transport) retried at the same fixed interval - a NATS restart
+would make all of them hammer it in lockstep on every attempt. `nats-py`
+doesn't expose a built-in backoff/jitter option on `reconnect_time_wait`
+itself (it's a static float), but does support a `reconnect_to_server_handler`
+callback that computes the delay per attempt from `server.reconnects`. Added
+`_reconnect_delay_with_backoff` (base 1s, doubling, capped at 30s, plus
+`random.uniform(0, 1)` jitter), returning `None` for server selection since
+there's only ever one configured server - it only takes over delay timing.
+
+**M8 — `SomaticAppraiser._last_spike_at` never shrank.** Refractory timestamps
+for every recognized comfort entity accumulated forever; a term dropped from
+the graph (renamed, decayed, never re-taught) stayed in the dict
+indefinitely. `refresh()` now prunes to the current term set, and additionally
+drops any timestamp already past `SOMATIC_REFRACTORY_SECONDS` regardless of
+whether the term survives - a stale timestamp is dead weight either way,
+since `_in_refractory` would already treat it as expired.
+
+**M9/M12 — `GraphDB` unbounded cache and no startup connectivity signal.**
+`_belief_cache` was a plain dict with no size cap, cleared only on full
+invalidation. Swapped for an `OrderedDict` with `move_to_end` on both read
+and write and `popitem(last=False)` once over `MAX_BELIEF_CACHE_ENTRIES = 500`
+- real LRU, not FIFO (verified: re-touching an entry protects it from the
+next eviction). Separately, M12's filed premise (main.py checks Ollama on
+startup but not Neo4j) doesn't match this codebase - `main.py` is the
+signaling/token server and doesn't own a `GraphDB` at all; the three
+processes that do (`brain_agent`, `subconscious_agent`, `surfacing_agent`)
+already call `await graph_db.initialize()` from the H11 fix (batch 2). The
+real gap was inside `initialize()` itself: `bootstrap_constraints` touches
+the network but logs every failure as a per-constraint `warning`, so
+"index already exists" and "Neo4j is completely unreachable" look identical
+in the log. Added one `RETURN 1` probe before bootstrapping that logs
+`CRITICAL` on an empty result - `execute_query` swallows connection
+exceptions internally and returns `[]`, so the signal is the empty result,
+not a raised exception.
+
+**M10 — `bt.Condition.tick` couldn't await an async callback.** `Action.tick`
+already checked `asyncio.iscoroutinefunction` before deciding whether to
+await; `Condition.tick` just called `self.func(blackboard)` unconditionally.
+A coroutine function passed as a condition produced an un-awaited coroutine
+*object*, which is truthy - so an async condition that should report FAILURE
+silently reported SUCCESS instead. Mirrored `Action`'s branch.
+
+**M14 — silent failure on `/vision/toggle` HTTP errors.** Re-checked the
+premise first: `page.js`'s `toggleVision` only calls `setVisionSource` *after*
+`res.ok` is confirmed, so it was never actually optimistic - there was no UI
+state to roll back on failure, contrary to the issue's framing. The real gap
+was narrower but still real: an `!res.ok` response (e.g. a backend 500) was
+silently swallowed with no console log and no user-facing signal that the
+toggle didn't take effect. Added a `visionError` state surfaced as a
+dismissing banner, covering both the HTTP-error and network-exception paths.
+
+**M17 — unused frontend dependencies.** Checked actual imports before
+removing anything: `@prisma/client` (plus `prisma`/`@prisma/config` in
+devDependencies) is used by `prisma/seed.js` - not unused, contrary to the
+issue's list, and kept. `dotenv` and `lucide-react` have zero imports anywhere
+in the tree and no npm script references either; removed both via
+`npm uninstall`.
+
+**M18 — no CSP headers.** Added a `headers()` block in `next.config.mjs`.
+Backend/LiveKit origins are per-deployment (self-hosted LAN, custom domain,
+`ws://` vs `wss://`), set via `NEXT_PUBLIC_BACKEND_URL`/`NEXT_PUBLIC_LIVEKIT_URL`
+at build time - so `connect-src` is built from those env vars rather than a
+hardcoded `'self'`-only policy that would break every deployment except the
+literal localhost default. `script-src`/`style-src` include `'unsafe-inline'`
+because Next's App Router injects an unnonced inline hydration bootstrap
+script; tightening further needs nonce-based middleware, a separate change.
+Verified via `npm run build` (succeeds) and `curl -I` against `npm run start`
+(header present, page still returns 200) - not a substitute for an actual
+browser CSP-violation check, which this environment has no browser to run.
+
+**Verified:** full backend suite via junit-xml - 909 passed, 0
+failed/errored/skipped - `ruff check .` clean. `npm run lint` and
+`npm run build` clean on the frontend. Every new backend test mutation-tested
+by reverting its fix and confirming failure (`test_fact_consolidation`'s
+updated assertion caught itself needing an update this way - reverting M4
+alone made it fail even though it predates this batch).
+
+**NOT done, closed as false positive / already resolved (no code change):**
+- **M1** (`sqlite_fallback._translate_query`'s `$1`/`$10`-collision claim):
+  `\$\d+` is a greedy quantifier - it already consumes `$10` as one match,
+  verified directly (`re.sub(r'\$\d+', '?', ...)` on a 10-parameter INSERT
+  translates correctly). The narrower CTE/commit concern in the same issue
+  was already fixed in batch 1 (unconditional commit regardless of query
+  shape, replacing the fragile keyword-prefix heuristic).
+- **M5** (hardcoded English constraint in `action.py`): already removed in a
+  prior commit - the current `_CHAT_GUIDELINE` has an explicit comment at the
+  spot explaining why (it contradicted the identity block's own Hinglish
+  instruction; language belongs to the per-agent persona, not a global
+  guideline).
+- **M11** (`conversation_store.log_message`'s self-healing insert
+  "overwriting" trust): `ON CONFLICT (id) DO NOTHING` cannot overwrite an
+  existing row by definition - `DO NOTHING` performs no write on conflict.
+  The only real effect is a *new* session row (when one didn't exist at all)
+  getting schema-default trust values, but `sessions.trust_*` is write-only:
+  grepped the whole app for reads and found none anywhere - the actual trust
+  state lives in `agent_state.py`'s `AgentState`/`StateService`, the
+  single-owner table CLAUDE.md's architecture notes already point to. Not
+  worth wiring live trust into a column nothing reads back.
+- **M13** (lexicon/semantic-recall stores need standardized SQLite query
+  translation): both stores exclusively call through `self.pool.acquire()`
+  with no bespoke pgvector operators (`<->`, `::vector`, etc.) of their own -
+  grepped for both and found none. They already funnel through the same
+  `_translate_query`/commit path batch 1 fixed; there's no separate
+  translation surface to standardize.
+
+**NOT done, deferred:**
+- **M15** (`useWebRTCVoice.js` never transitions to the `'thinking'` state
+  `AssistantCircle.jsx` already animates for) is a real gap, but validating a
+  voice-state-machine change means actually speaking through a live
+  LiveKit/backend session - this environment has no microphone/audio
+  pipeline to exercise it with, and CLAUDE.md is explicit that UI behavior
+  changes need to be verified in a browser before being called done, not
+  inferred from reading the hook.
+- **M16** (static orbit particle animation in `AssistantCircle.jsx`) is a
+  cosmetic/subjective visual-polish request with no functional bug behind
+  it - lowest priority of the eighteen, left for a session where visual
+  changes can actually be watched render.

--- a/backend/app/agents/base.py
+++ b/backend/app/agents/base.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import os
+import random
 import time
 from typing import Any
 
@@ -9,6 +10,29 @@ import nats
 import orjson
 
 logger = logging.getLogger(__name__)
+
+# M6: base/cap for exponential backoff with jitter on NATS reconnect. A static
+# `reconnect_time_wait` means every agent process in the mesh (brain, system,
+# subconscious, surfacing, transport) retries at the same fixed interval, so a
+# NATS restart makes them all hammer it in lockstep on every attempt rather
+# than spreading out.
+_RECONNECT_BASE_DELAY_SECONDS = 1.0
+_RECONNECT_MAX_DELAY_SECONDS = 30.0
+
+
+def _reconnect_delay_with_backoff(servers, _server_info):
+    """`reconnect_to_server_handler` callback for `nats.connect`.
+
+    Must return `(selected_server_or_None, delay_seconds)`; `None` keeps the
+    client's own default server selection (there is only ever one configured
+    server here) and we only take over the delay computation.
+    """
+    attempt = servers[0].reconnects if servers else 0
+    delay = min(
+        _RECONNECT_MAX_DELAY_SECONDS,
+        _RECONNECT_BASE_DELAY_SECONDS * (2**attempt),
+    ) + random.uniform(0, 1)
+    return None, delay
 
 
 class BaseAgent:
@@ -60,7 +84,7 @@ class BaseAgent:
                 self.nats_url,
                 connect_timeout=10,
                 max_reconnect_attempts=-1,
-                reconnect_time_wait=2.0,
+                reconnect_to_server_handler=_reconnect_delay_with_backoff,
                 disconnected_cb=self._on_nats_disconnected,
                 reconnected_cb=self._on_nats_reconnected,
                 error_cb=self._on_nats_error,

--- a/backend/app/cognitive/bt.py
+++ b/backend/app/cognitive/bt.py
@@ -80,5 +80,12 @@ class Condition(Node):
         self.func = func
 
     async def tick(self, blackboard: Any) -> NodeStatus:
-        result = self.func(blackboard)
+        # M10: mirrors Action.tick's coroutine detection above. Without it, a
+        # coroutine function passed as `func` is never awaited - the
+        # coroutine *object* itself is truthy, so the condition always
+        # reports SUCCESS regardless of what it was actually checking.
+        if asyncio.iscoroutinefunction(self.func):
+            result = await self.func(blackboard)
+        else:
+            result = self.func(blackboard)
         return NodeStatus.SUCCESS if result else NodeStatus.FAILURE

--- a/backend/app/cognitive/learning.py
+++ b/backend/app/cognitive/learning.py
@@ -10,6 +10,32 @@ from .json_extract import extract_first_json_value
 
 logger = logging.getLogger("reflection")
 
+# M4: the fact-extraction prompt leaves "relation" free-text, so the LLM's
+# word choice (LIKES vs ENJOYS vs PREFERS) becomes a distinct Cypher
+# relationship *type*. The dedup check right below is an exact match on that
+# type, so synonyms never collide - they fragment into parallel edges between
+# the same two nodes instead of one edge whose weight grows. This is a small,
+# conservative canonicalization, not a general thesaurus: it only collapses
+# clusters common enough in everyday reflection output to be worth the risk
+# of losing the verb's original nuance.
+_RELATION_SYNONYMS: dict[str, str] = {
+    "ENJOYS": "LIKES",
+    "LOVES": "LIKES",
+    "ADORES": "LIKES",
+    "PREFERS": "LIKES",
+    "IS_FOND_OF": "LIKES",
+    "DISLIKES": "DISLIKES",
+    "HATES": "DISLIKES",
+    "DETESTS": "DISLIKES",
+    "IS_A": "IS_A",
+    "IS_TYPE_OF": "IS_A",
+    "TYPE_OF": "IS_A",
+}
+
+
+def _canonicalize_relation(rel_type: str) -> str:
+    return _RELATION_SYNONYMS.get(rel_type, rel_type)
+
 
 class ReflectionService:
     """
@@ -189,7 +215,9 @@ class ReflectionService:
                         category = "social"
 
                     try:
-                        rel_type = GraphDB._safe_relation(relation)
+                        rel_type = _canonicalize_relation(
+                            GraphDB._safe_relation(relation)
+                        )
                         GraphDB._safe_label(subject_type)
                         GraphDB._safe_label(object_type)
                         GraphDB._safe_label(category.capitalize())

--- a/backend/app/cognitive/somatic.py
+++ b/backend/app/cognitive/somatic.py
@@ -132,6 +132,19 @@ class SomaticAppraiser:
 
         self._terms = terms
         self._cache_loaded_at = self._now()
+
+        # M8: `_last_spike_at` otherwise grows forever - a term dropped from
+        # the graph (renamed, decayed away) never leaves the refractory map.
+        # Drop keys no longer in `_terms`, and any timestamp already outside
+        # the refractory window (it's dead weight - `_in_refractory` would
+        # reject it anyway).
+        now = self._now()
+        self._last_spike_at = {
+            term: ts
+            for term, ts in self._last_spike_at.items()
+            if term in terms and (now - ts) < SOMATIC_REFRACTORY_SECONDS
+        }
+
         logger.info("[Somatic] %d learned comfort term(s) loaded.", len(terms))
         return len(terms)
 

--- a/backend/app/cognitive/tom.py
+++ b/backend/app/cognitive/tom.py
@@ -6,7 +6,12 @@ implied goals, and known concepts.
 
 import re
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+# M7: hard cap on `known_concepts` so a multi-hour session can't grow the list
+# (and its serialized state payload) without bound. Sliding-window eviction in
+# `update_known_concepts` keeps the most recently mentioned concepts.
+MAX_KNOWN_CONCEPTS = 200
 
 
 class UserMentalModel(BaseModel):
@@ -17,13 +22,15 @@ class UserMentalModel(BaseModel):
 
     inferred_valence: float = 0.0  # -1.0 (negative) to 1.0 (positive)
     inferred_arousal: float = 0.5  # 0.0 (calm) to 1.0 (excited/angry)
-    implied_goals: list[str] = []  # List of user's inferred immediate goals
-    known_concepts: list[
-        str
-    ] = []  # Unique case-insensitive list of concepts user knows/mentioned
-    user_beliefs: dict[
-        str, str
-    ] = {}  # Concept name -> user's subjective belief/understanding
+    implied_goals: list[str] = Field(
+        default_factory=list
+    )  # List of user's inferred immediate goals
+    known_concepts: list[str] = Field(
+        default_factory=list
+    )  # Unique case-insensitive list of concepts user knows/mentioned
+    user_beliefs: dict[str, str] = Field(
+        default_factory=dict
+    )  # Concept name -> user's subjective belief/understanding
 
 
 def extract_belief_discrepancies(
@@ -107,5 +114,11 @@ def update_known_concepts(current_concepts: list[str], user_input: str) -> list[
         if word.lower() not in stop_words_lower and word.lower() not in seen_lower:
             updated.append(word)
             seen_lower.add(word.lower())
+
+    # Sliding window: drop the oldest concepts once the cap is exceeded, so a
+    # long session's vocabulary tracker still reflects what the user has
+    # recently talked about rather than growing without bound.
+    if len(updated) > MAX_KNOWN_CONCEPTS:
+        updated = updated[-MAX_KNOWN_CONCEPTS:]
 
     return updated

--- a/backend/app/state/graph_db.py
+++ b/backend/app/state/graph_db.py
@@ -5,7 +5,14 @@ import json
 import logging
 import re
 import time
+from collections import OrderedDict
 from typing import Any
+
+# M9: hard cap on the belief cache so a session issuing many distinct
+# use_cache=True queries (different parameter sets) can't grow it without
+# bound. OrderedDict gives us cheap LRU: move a key to the end on access,
+# evict from the front on insert once full.
+MAX_BELIEF_CACHE_ENTRIES = 500
 
 from neo4j import AsyncGraphDatabase
 
@@ -34,11 +41,12 @@ class GraphDB:
                 "A strong, non-default NEO4J_PASSWORD must be provided in your .env file."
             )
 
+        self.uri = uri
         self.driver = AsyncGraphDatabase.driver(uri, auth=(user, password))
         self._bootstrap_task = None
 
-        # Perceptual Belief Cache
-        self._belief_cache = {}
+        # Perceptual Belief Cache (M9: bounded LRU, see MAX_BELIEF_CACHE_ENTRIES)
+        self._belief_cache: OrderedDict[Any, tuple[float, Any]] = OrderedDict()
         self._cache_ttl = getattr(Config, "GRAPH_CACHE_TTL", 300)
 
     async def initialize(self) -> None:
@@ -50,7 +58,24 @@ class GraphDB:
         entity nodes in the window before they existed. Callers must await
         this during their own startup, immediately after constructing
         `GraphDB`.
+
+        M12: also verifies connectivity with one unambiguous `RETURN 1` before
+        bootstrapping. `bootstrap_constraints` already touches the network,
+        but it swallows every failure per-constraint as a `logger.warning`
+        ("index already exists" and "can't reach Neo4j at all" look
+        identical there) - operators need one clear signal at startup rather
+        than mid-session, when a cognitive turn's first graph write fails.
         """
+        # `execute_query` swallows connection failures internally (returns
+        # `[]`, logged only as a query-level error) so a missing result here,
+        # not an exception, is the connectivity signal.
+        probe = await self.execute_query("RETURN 1")
+        if not probe:
+            logger.critical(
+                "Neo4j is unreachable at startup (uri=%s). Cognitive turns "
+                "that touch the graph will fail until this is fixed.",
+                self.uri,
+            )
         self._bootstrap_task = asyncio.ensure_future(self.bootstrap_constraints())
         await self._bootstrap_task
 
@@ -125,6 +150,7 @@ class GraphDB:
         if use_cache and cache_key in self._belief_cache:
             ts, result = self._belief_cache[cache_key]
             if time.time() - ts < self._cache_ttl:
+                self._belief_cache.move_to_end(cache_key)
                 return result
 
         try:
@@ -159,6 +185,9 @@ class GraphDB:
 
                 if use_cache:
                     self._belief_cache[cache_key] = (time.time(), records)
+                    self._belief_cache.move_to_end(cache_key)
+                    if len(self._belief_cache) > MAX_BELIEF_CACHE_ENTRIES:
+                        self._belief_cache.popitem(last=False)
                 return records
         except Exception as e:
             logger.error(f"Neo4j query failed: {e}")

--- a/backend/app/vision/links.py
+++ b/backend/app/vision/links.py
@@ -108,6 +108,11 @@ class CameraLink:
         if cv2 is None:
             raise RuntimeError("cv2 dependency is missing. Camera capture unavailable.")
         if self.cap is None or not self.cap.isOpened():
+            # Release the stale handle before replacing it (M3) - re-assigning
+            # `self.cap` without this leaks the underlying /dev/video0 device
+            # handle every time isOpened() comes back False on a live device.
+            if self.cap is not None:
+                self.cap.release()
             self.cap = cv2.VideoCapture(0)
 
     def capture_frame(self) -> bytes | None:

--- a/backend/tests/test_base_agent_reconnect.py
+++ b/backend/tests/test_base_agent_reconnect.py
@@ -1,0 +1,58 @@
+"""
+NATS reconnect backoff. `BaseAgent.connect` used a static `reconnect_time_wait`,
+so every agent process in the mesh (brain, system, subconscious, surfacing,
+transport) retried at the exact same fixed interval - a NATS restart makes
+them all hammer it in lockstep on every attempt. `_reconnect_delay_with_backoff`
+is the `reconnect_to_server_handler` callback that replaces it.
+"""
+
+from types import SimpleNamespace
+
+from app.agents.base import (
+    _RECONNECT_MAX_DELAY_SECONDS,
+    _reconnect_delay_with_backoff,
+)
+
+
+def _server(reconnects: int):
+    return SimpleNamespace(reconnects=reconnects)
+
+
+def test_delay_grows_with_attempt_count():
+    """M6: successive attempts must wait longer, not the same fixed interval
+    every time. Jitter is bounded to [0, 1) and the base doubles each attempt
+    (1.0, 2.0, 4.0...), so the value ranges for consecutive attempts
+    ([1.0, 2.0), [2.0, 3.0), [4.0, 5.0)) never overlap - ordering is
+    deterministic even with random jitter in play.
+    """
+    _, delay0 = _reconnect_delay_with_backoff([_server(0)], {})
+    _, delay1 = _reconnect_delay_with_backoff([_server(1)], {})
+    _, delay2 = _reconnect_delay_with_backoff([_server(2)], {})
+
+    assert delay0 < delay1 < delay2
+
+
+def test_delay_is_capped_at_the_maximum():
+    """A long outage must not make the wait grow forever."""
+    _, delay = _reconnect_delay_with_backoff([_server(50)], {})
+    assert delay <= _RECONNECT_MAX_DELAY_SECONDS + 1.0  # +1 for jitter headroom
+
+
+def test_delay_includes_jitter_so_concurrent_agents_do_not_align():
+    """Multiple calls at the same attempt count must not produce identical
+    delays - that's the whole point of adding jitter (thundering herd)."""
+    delays = {_reconnect_delay_with_backoff([_server(3)], {})[1] for _ in range(20)}
+    assert len(delays) > 1
+
+
+def test_selected_server_is_left_to_the_client_default():
+    """There is only ever one configured NATS server; this handler should
+    only take over delay computation, not server selection."""
+    selected, _ = _reconnect_delay_with_backoff([_server(0)], {})
+    assert selected is None
+
+
+def test_no_eligible_servers_does_not_raise():
+    selected, delay = _reconnect_delay_with_backoff([], {})
+    assert selected is None
+    assert delay >= 0

--- a/backend/tests/test_bt.py
+++ b/backend/tests/test_bt.py
@@ -1,0 +1,40 @@
+"""
+Behavior Tree leaf nodes. `Action` already distinguished sync vs async
+callbacks; `Condition` did not, which is the gap these tests cover.
+"""
+
+import pytest
+
+from app.cognitive.bt import Condition, NodeStatus
+
+
+@pytest.mark.asyncio
+async def test_condition_awaits_an_async_callback():
+    """M10: `Condition.tick` used to call `self.func(blackboard)` unconditionally.
+    For a coroutine function, that produces a coroutine *object* rather than a
+    boolean, and a coroutine object is truthy - so an async condition that
+    should fail was silently reported as SUCCESS instead of being awaited.
+    """
+
+    async def async_check(blackboard):
+        return blackboard.get("flag", False)
+
+    node = Condition("has_flag", async_check)
+
+    assert await node.tick({"flag": True}) == NodeStatus.SUCCESS
+    assert await node.tick({"flag": False}) == NodeStatus.FAILURE
+
+
+def test_condition_still_supports_a_sync_callback():
+    """Sanity check that the coroutine-detection branch didn't regress the
+    ordinary synchronous condition path."""
+
+    def sync_check(blackboard):
+        return blackboard.get("flag", False)
+
+    node = Condition("has_flag", sync_check)
+
+    import asyncio
+
+    assert asyncio.run(node.tick({"flag": True})) == NodeStatus.SUCCESS
+    assert asyncio.run(node.tick({"flag": False})) == NodeStatus.FAILURE

--- a/backend/tests/test_graph_db_initialize.py
+++ b/backend/tests/test_graph_db_initialize.py
@@ -1,9 +1,11 @@
 import asyncio
+import json
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.state.graph_db import GraphDB
+from app.state.graph_db import MAX_BELIEF_CACHE_ENTRIES, GraphDB
 
 
 def _make_graph_db() -> GraphDB:
@@ -47,3 +49,75 @@ async def test_initialize_waits_for_bootstrap_to_actually_finish():
     await db.initialize()
 
     assert finished is True
+
+
+@pytest.mark.asyncio
+async def test_initialize_logs_critical_when_neo4j_is_unreachable_at_startup(caplog):
+    """M12: `bootstrap_constraints` swallows every failure as a per-constraint
+    `logger.warning`, indistinguishable from "index already exists". Startup
+    needs one unambiguous signal when Neo4j cannot be reached at all, rather
+    than operators discovering it mid-session on a cognitive turn's first
+    graph write.
+    """
+    db = _make_graph_db()
+    db.execute_query = AsyncMock(return_value=[])
+    db.bootstrap_constraints = AsyncMock()
+
+    with caplog.at_level(logging.CRITICAL, logger="graph_db"):
+        await db.initialize()
+
+    assert any("unreachable" in rec.message.lower() for rec in caplog.records)
+    db.bootstrap_constraints.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_initialize_does_not_log_critical_when_neo4j_responds(caplog):
+    db = _make_graph_db()
+    db.execute_query = AsyncMock(return_value=[{"1": 1}])
+    db.bootstrap_constraints = AsyncMock()
+
+    with caplog.at_level(logging.CRITICAL, logger="graph_db"):
+        await db.initialize()
+
+    assert not any("unreachable" in rec.message.lower() for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_belief_cache_evicts_oldest_entry_once_over_capacity():
+    """M9: `_belief_cache` used to be a plain dict with no maximum size - a
+    session issuing many distinct cached queries/parameter sets grew it
+    without bound. Once capacity is exceeded, the oldest entry must be
+    evicted rather than the dict growing past the cap.
+    """
+    db = _make_graph_db()
+    mock_session = db.driver.session.return_value.__aenter__.return_value
+    mock_session.execute_read = AsyncMock(return_value=[])
+
+    for i in range(MAX_BELIEF_CACHE_ENTRIES + 5):
+        await db.execute_query("MATCH (n) RETURN n", {"i": i}, use_cache=True)
+
+    assert len(db._belief_cache) == MAX_BELIEF_CACHE_ENTRIES
+
+
+@pytest.mark.asyncio
+async def test_belief_cache_lru_recency_survives_eviction():
+    """A recently re-accessed entry must not be the one evicted just because
+    it was inserted first - this is LRU, not FIFO.
+    """
+    db = _make_graph_db()
+    mock_session = db.driver.session.return_value.__aenter__.return_value
+    mock_session.execute_read = AsyncMock(return_value=[])
+
+    for i in range(MAX_BELIEF_CACHE_ENTRIES):
+        await db.execute_query("MATCH (n) RETURN n", {"i": i}, use_cache=True)
+
+    # Touch key 0 again so it becomes the most-recently-used entry.
+    await db.execute_query("MATCH (n) RETURN n", {"i": 0}, use_cache=True)
+
+    # One more distinct key forces an eviction.
+    await db.execute_query("MATCH (n) RETURN n", {"i": "new"}, use_cache=True)
+
+    key0 = ("MATCH (n) RETURN n", json.dumps({"i": 0}))
+    key1 = ("MATCH (n) RETURN n", json.dumps({"i": 1}))
+    assert key0 in db._belief_cache  # just re-touched, survives
+    assert key1 not in db._belief_cache  # least-recently-used, evicted

--- a/backend/tests/test_phase5_tom.py
+++ b/backend/tests/test_phase5_tom.py
@@ -5,7 +5,7 @@ import pytest
 from app.cognitive.appraisal import AppraisalVector
 from app.cognitive.decision import ActionPlan, CognitiveEvent, DecisionService
 from app.cognitive.pipeline import CognitivePipeline
-from app.cognitive.tom import UserMentalModel, update_known_concepts
+from app.cognitive.tom import MAX_KNOWN_CONCEPTS, UserMentalModel, update_known_concepts
 from app.state.agent_state import StateService
 
 
@@ -35,6 +35,22 @@ def test_vocabulary_tracker():
     assert "me" not in updated  # < 4
     assert "code" in updated  # 4 chars, valid
     assert "aaaaaaaaaaaaaaaaa" not in updated  # > 15 chars
+
+
+def test_vocabulary_tracker_evicts_oldest_once_the_cap_is_exceeded():
+    """M7: a multi-hour session used to grow `known_concepts` without bound,
+    inflating the state payload serialized on every persist. Once the cap is
+    hit, the oldest entries must fall off so the tracker reflects recent
+    vocabulary rather than everything ever said.
+    """
+    current = [f"conceptword{i}" for i in range(MAX_KNOWN_CONCEPTS)]
+
+    updated = update_known_concepts(current, "brandnewword")
+
+    assert len(updated) == MAX_KNOWN_CONCEPTS
+    assert "conceptword0" not in updated  # oldest, evicted
+    assert "conceptword1" in updated  # next-oldest, retained
+    assert "brandnewword" in updated  # newest, retained
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_reflection.py
+++ b/backend/tests/test_reflection.py
@@ -24,10 +24,12 @@ async def test_fact_consolidation(reflection_service, mock_llm_service, mock_gra
     # For testing, we can directly call _consolidate
     await reflection_service._consolidate(episodes)
 
-    # Updated assertion to handle dynamic properties (extracted_at, confidence)
+    # Updated assertion to handle dynamic properties (extracted_at, confidence).
+    # M4: "LOVES" canonicalizes to "LIKES" so it doesn't fragment the graph
+    # from "LIKES"/"ENJOYS"/"PREFERS" edges extracted in other reflection passes.
     mock_graph_db.create_triplet.assert_called_with(
         "User",
-        "LOVES",
+        "LIKES",
         "Coding",
         properties=ANY,
         subject_label="Entity",
@@ -71,6 +73,35 @@ async def test_fact_rejection_low_confidence(
     )
 
     mock_graph_db.create_triplet.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_synonym_relations_are_canonicalized_before_storage(
+    reflection_service, mock_llm_service, mock_graph_db
+):
+    """M4: the extraction prompt leaves "relation" free-text, so the LLM's
+    exact word choice becomes a distinct Cypher relationship type. Without
+    canonicalization, "ENJOYS" and "LIKES" from separate reflection passes
+    create two parallel edges between the same two nodes instead of one edge
+    whose weight grows - fragmenting the graph on wording alone.
+    """
+    mock_llm_service.generate.return_value = (
+        '[{"subject": "User", "relation": "ENJOYS", "object": "Tea", '
+        '"confidence": 0.9}]'
+    )
+
+    await reflection_service._consolidate(
+        [{"content": "I really enjoy tea", "response": "Noted."}]
+    )
+
+    mock_graph_db.create_triplet.assert_called_once_with(
+        "User",
+        "LIKES",
+        "Tea",
+        properties=ANY,
+        subject_label="Entity",
+        target_label="Entity",
+    )
 
 
 def test_json_extraction_robustness(reflection_service):

--- a/backend/tests/test_somatic_vision.py
+++ b/backend/tests/test_somatic_vision.py
@@ -182,6 +182,40 @@ def test_cache_is_reused_within_ttl_then_refreshed():
     assert appraiser.graph.execute_query.await_count == calls_after_initial + 1
 
 
+def test_refresh_prunes_spike_history_for_terms_no_longer_learned():
+    """M8: `_last_spike_at` used to grow forever - a term dropped from the
+    graph (renamed, forgotten, decayed away) stayed in the refractory map
+    indefinitely. `refresh()` must drop spike history for anything no longer
+    in the current term set.
+    """
+    appraiser, clock = _appraiser([{"name": "chai", "confidence": 1.0}])
+    appraiser.appraise("a cup of chai")
+    assert "chai" in appraiser._last_spike_at
+
+    clock.advance(10_000)  # force the TTL to expire so refresh() re-queries
+    appraiser.graph.execute_query = AsyncMock(
+        return_value=[{"name": "sunlight", "confidence": 1.0}]
+    )
+    asyncio.run(appraiser.refresh())
+
+    assert "chai" not in appraiser._last_spike_at
+
+
+def test_refresh_prunes_spike_timestamps_that_have_already_left_refractory():
+    """Even if a term is still learned, a spike timestamp older than the
+    refractory window is dead weight - `_in_refractory` would already treat
+    it as expired, so keeping it around forever serves no purpose.
+    """
+    appraiser, clock = _appraiser([{"name": "chai", "confidence": 1.0}])
+    appraiser.appraise("a cup of chai")
+    assert "chai" in appraiser._last_spike_at
+
+    clock.advance(SOMATIC_REFRACTORY_SECONDS * 2)
+    asyncio.run(appraiser.refresh(force=True))
+
+    assert "chai" not in appraiser._last_spike_at
+
+
 # --------------------------------------------------------------------------
 # state application
 # --------------------------------------------------------------------------

--- a/backend/tests/test_vision_links.py
+++ b/backend/tests/test_vision_links.py
@@ -1,6 +1,7 @@
 import contextlib
 import importlib
 import sys
+from unittest.mock import MagicMock, patch
 
 import app.vision.links as links_module
 
@@ -45,3 +46,24 @@ def test_screen_link_goes_headless_without_numpy():
 def test_screen_link_still_works_normally_with_numpy_present():
     # Sanity check that the guard didn't regress the ordinary import path.
     assert links_module.np is not None
+
+
+def test_camera_link_releases_stale_handle_before_reopening():
+    """M3: `_ensure_cap` used to reassign `self.cap` to a fresh
+    `VideoCapture` whenever the existing one reported `isOpened() is False`,
+    without releasing it first - leaking the underlying /dev/video0 handle on
+    every such recovery instead of just the first open.
+    """
+    with patch.object(links_module, "cv2", MagicMock()) as mock_cv2:
+        stale_cap = MagicMock()
+        stale_cap.isOpened.return_value = False
+        fresh_cap = MagicMock()
+        mock_cv2.VideoCapture.return_value = fresh_cap
+
+        link = links_module.CameraLink()
+        link.cap = stale_cap
+
+        link._ensure_cap()
+
+        stale_cap.release.assert_called_once()
+        assert link.cap is fresh_cap

--- a/frontend/app/page.js
+++ b/frontend/app/page.js
@@ -10,6 +10,7 @@ const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:800
 export default function Home() {
     const { isConnected, isConnecting, state, startRecording } = useWebRTCVoice();
     const [visionSource, setVisionSource] = useState('screen'); // screen | camera
+    const [visionError, setVisionError] = useState(null);
     const videoRef = useRef(null);
 
     // Automatically start recording once we arrive at this page and socket is connected.
@@ -49,17 +50,32 @@ export default function Home() {
                 method: 'POST'
             });
             if (res.ok) {
+                setVisionError(null);
                 setVisionSource(source);
                 if (source === 'camera') {
                     startWebcamPreview();
                 } else {
                     stopWebcamPreview();
                 }
+            } else {
+                // M14: the backend rejected the switch (e.g. 500) - UI state
+                // was never optimistically changed above, so there is
+                // nothing to roll back, but silently doing nothing here left
+                // the user with no signal the toggle didn't take effect.
+                console.error(`Vision toggle to '${source}' failed: HTTP ${res.status}`);
+                setVisionError(`Could not switch to ${source === 'camera' ? 'Observer 2' : 'Observer 1'}.`);
             }
         } catch (err) {
             console.error("Failed to toggle vision:", err);
+            setVisionError('Vision backend unreachable.');
         }
     };
+
+    useEffect(() => {
+        if (!visionError) return;
+        const timer = setTimeout(() => setVisionError(null), 4000);
+        return () => clearTimeout(timer);
+    }, [visionError]);
 
     return (
         <main className="flex min-h-screen flex-col items-center justify-center bg-black overflow-hidden relative font-sans">
@@ -93,6 +109,20 @@ export default function Home() {
                     Observer 2
                 </button>
             </div>
+
+            {/* Vision Toggle Error Banner */}
+            <AnimatePresence>
+                {visionError && (
+                    <motion.div
+                        initial={{ opacity: 0, y: -10 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: -10 }}
+                        className="absolute top-20 right-6 z-50 px-4 py-2 rounded-xl bg-red-500/10 border border-red-500/20 backdrop-blur-xl text-red-300 text-[10px] tracking-wide"
+                    >
+                        {visionError}
+                    </motion.div>
+                )}
+            </AnimatePresence>
 
             {/* Webcam Preview (Holographic) */}
             <AnimatePresence>

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,8 +1,40 @@
+// M18: backend/LiveKit origins are per-deployment (self-hosted LAN, custom
+// domain, or ws:// vs wss://), set via env at build time - so connect-src is
+// built from those env vars rather than hardcoded, or every deployment but
+// the default localhost one would have its own WebRTC/API calls blocked.
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8000';
+const LIVEKIT_URL = process.env.NEXT_PUBLIC_LIVEKIT_URL || 'ws://localhost:7880';
+
+// 'unsafe-inline' on script-src is required because Next.js's App Router
+// injects an inline bootstrap/hydration script (`self.__next_f.push(...)`)
+// with no nonce attached; tightening this further needs nonce-based
+// middleware generating a per-request nonce, which is a separate change.
+const CSP = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline'",
+  "style-src 'self' 'unsafe-inline'",
+  `connect-src 'self' ${BACKEND_URL} ${LIVEKIT_URL}`,
+  "img-src 'self' data: blob:",
+  "media-src 'self' blob:",
+  "font-src 'self' data:",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+].join('; ');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   /* config options here */
   reactCompiler: true,
   output: 'standalone',
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [{ key: 'Content-Security-Policy', value: CSP }],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,10 +10,8 @@
       "dependencies": {
         "@livekit/components-react": "^2.9.19",
         "@prisma/client": "^7.7.0",
-        "dotenv": "^17.2.3",
         "framer-motion": "^12.38.0",
         "livekit-client": "^2.18.3",
-        "lucide-react": "^0.563.0",
         "next": "^16.2.4",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -3515,18 +3513,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/dotenv": {
-      "version": "17.2.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
-      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -5896,15 +5882,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wellwelwel"
-      }
-    },
-    "node_modules/lucide-react": {
-      "version": "0.563.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.563.0.tgz",
-      "integrity": "sha512-8dXPB2GI4dI8jV4MgUDGBeLdGk8ekfqVZ0BdLcrRzocGgG75ltNEmWS+gE7uokKF/0oSUuczNDT+g9hFJ23FkA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,10 +11,8 @@
   "dependencies": {
     "@livekit/components-react": "^2.9.19",
     "@prisma/client": "^7.7.0",
-    "dotenv": "^17.2.3",
     "framer-motion": "^12.38.0",
     "livekit-client": "^2.18.3",
-    "lucide-react": "^0.563.0",
     "next": "^16.2.4",
     "react": "19.2.4",
     "react-dom": "19.2.4"
@@ -24,12 +22,12 @@
     "tar": "^7.5.7"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3",
+    "@eslint/js": "^9",
     "@prisma/config": "^7.7.0",
     "@tailwindcss/postcss": "^4",
     "babel-plugin-react-compiler": "1.0.0",
     "eslint": "^9",
-    "@eslint/eslintrc": "^3",
-    "@eslint/js": "^9",
     "eslint-config-next": "16.2.4",
     "prisma": "^7.7.0",
     "tailwindcss": "^4"


### PR DESCRIPTION
## Summary
- Fixes M2/M7/M3/M4/M6/M8/M9/M12/M10/M14/M17/M18 (issues #125-127, #129-133, #135, #137, #140-141) — resource leaks, unbounded growth, an un-awaited async condition-node gap, graph relationship fragmentation, NATS reconnect thundering-herd risk, silent Neo4j/vision-toggle failures, unused deps, and CSP headers.
- Closes #124, #128, #134, #136 (M1/M5/M11/M13) as false positives or already resolved — see PR discussion / ledger for the code-level verification behind each.
- Defers #138/#139 (M15/M16) — real but need live browser/voice testing not available in this environment; documented in `.agents/CONTEXT.md`.

Full per-fix reasoning, what was verified, and why the four closures aren't bugs: see the "2026-08-21 GitHub triage batch 3" entry appended to `.agents/CONTEXT.md`.

## Test plan
- [x] Full backend suite via junit-xml: 909 passed, 0 failed/errored/skipped
- [x] `ruff check .` clean
- [x] Every new backend test mutation-tested (fix reverted → test fails, fix restored → test passes)
- [x] `npm run build` and `npm run lint` clean on frontend
- [x] CSP header verified present via `curl -I` against `npm run start`; page still returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)