### PR TITLE
fix: resolve P3-low and architecture/production-readiness GitHub issues

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -6217,3 +6217,115 @@ alone made it fail even though it predates this batch).
   cosmetic/subjective visual-polish request with no functional bug behind
   it - lowest priority of the eighteen, left for a session where visual
   changes can actually be watched render.
+
+## 2026-08-21 GitHub triage batch 4 (P3 Low) — 7 of 9 fixed, 2 false positives closed
+
+Smallest batch, but one finding (L9) turned into the most interesting
+investigation of the whole triage - a fix that looked obviously correct on
+paper and turned out to be a genuine no-op once actually tested.
+
+**L1 — f-string evaluation in disabled debug logs.** Python evaluates an
+f-string's interpolation before `logger.debug` is even called, unlike lazy
+`%s` formatting, which `Logger.debug` only does after confirming the level is
+enabled. Bounded scope (grepped first): exactly 23 `logger.debug(f"...")`
+call sites across 9 files, all simple single/double-value interpolations in
+exception-handler or diagnostic paths. Converted all 23 to lazy `%s`/`%.1f`
+formatting - mechanical, no behavior change, nothing to test (the log output
+is byte-identical, only when the formatting cost is paid changes).
+
+**L2 — `WorkingMemoryStore`'s SQLite fallback opened a connection per call.**
+Confirmed it was worse than just "redundant instantiation": `with self.
+_get_sqlite_connection() as conn:` never closed anything either -
+`sqlite3.Connection.__exit__` only commits/rolls back, it doesn't close - so
+every fallback call opened a handle and then just let it fall out of scope
+uncollected until GC. Added one connection cached for the store's lifetime
+(`check_same_thread=False`, since each call arrives via a different
+`asyncio.to_thread` worker thread) guarded by a `threading.Lock` at every
+call site, since SQLite doesn't support concurrent writers regardless of
+thread-safety settings.
+
+**L3 — "learning.py bypasses PersonaProfile schema".** False premise: line
+239's `self.identity.personality.get("name")` reads from `IdentityManager`
+(`cognitive/identity.py`), not `PersonaProfile` (`persona/profile.py`) - two
+deliberately separate systems per this ledger's own "Persona and identity"
+section. `IdentityManager.personality`/`.history` are plain dicts loaded from
+JSON with no typed schema to bypass; the issue's suggested replacement
+(`self.identity.persona.name`) doesn't correspond to any real attribute on
+either class. Closed as false positive.
+
+**L4 — no OpenGraph/Twitter metadata.** Added both blocks to `layout.js`'s
+`metadata` export, reusing the existing title/description. No `og:image` -
+`public/` only has the unmodified Next.js starter SVGs, and a fabricated
+image reference would be worse than none. Verified via `curl` against
+`npm run start` that the tags actually render in the served HTML.
+
+**L5 — `Config` had no range validation.** Pydantic-settings already
+validates *type* (a non-numeric env value fails to load at all) but not
+*range*. Deliberately did not sweep all ~40 numeric fields - added one
+`model_validator` covering a short, curated list where an out-of-range value
+causes a specific concrete failure: the two phasic hormone halflives and
+`LLM_STREAM_MAX_SECONDS`/`TOKEN_RATE_LIMIT_WINDOW_SECONDS` must be `> 0`
+(zero divides by zero in decay math), `ACTR_DECAY_RATE` must be `>= 0`
+(negative would make memories strengthen with time instead of decaying - an
+inversion, not an edge case), tick interval/rate-limit-count/queue-size
+fields must be `>= 1` (zero busy-loops or blocks everything), and
+`QDRANT_PORT` must be a valid port number. Most of the other ~40 settings
+have no comparable failure mode and were left alone rather than bounded
+speculatively.
+
+**L7 — `GraphDB.close()` didn't wait for in-flight queries.** Added an
+in-flight counter (`_inflight_queries`) and an `asyncio.Event` that's set
+whenever the count reaches zero; `close()` awaits it (bounded by
+`GRAPHDB_CLOSE_DRAIN_TIMEOUT_SECONDS = 10.0`, a module constant specifically
+so a test can shrink it instead of actually waiting out a real timeout) after
+cancelling the bootstrap task and before calling `driver.close()`. A stuck
+query still can't hang shutdown forever - the timeout logs a warning with the
+in-flight count and proceeds anyway.
+
+**L8 — incomplete stop-word list in `update_known_concepts`.** Added the
+issue's own named examples (also/even/still/well) plus a modest additional
+set of clearly-generic filler/connector words (really, actually, maybe,
+kind, sort, much, many, does, doing, because, before, during, while, same,
+only, over, into, under, until) - deliberately not a full NLTK/spaCy import,
+since this is a lightweight zero-LLM-latency tracker, not an NLP pipeline,
+and a full stopword list risks removing more than it should for a set this
+size already gets right.
+
+**L9 — investigated, found to be a genuine no-op, not applied.** The filed
+concern (`float("nan")` bypasses the existing `except (TypeError, ValueError)`
+guard and could propagate into spike arithmetic) is correct as a general
+claim about NaN. But this specific code's clamp, `max(0.0, min(1.0,
+confidence))`, already deterministically resolves NaN to `1.0` - verified
+directly (1000 runs, stable) and reasoned through: NaN compares `False`
+against everything, so `min(1.0, nan)` always keeps the first (non-NaN)
+argument, and the outer `max` repeats the pattern. Wrote the `math.isnan()`
+guard the issue asked for, mutation-tested it by removing it, and the test
+still passed - a real no-op, not a coincidence of the test's inputs. Reverted
+the guard rather than ship dead code with a comment claiming to prevent
+something it structurally cannot affect; kept the regression test (renamed
+to describe what it actually verifies) as a tripwire in case the clamp's
+shape ever changes.
+
+**L6 — git history secret scan.** Ran `gitleaks detect --source . --log-
+opts="--all"` against the full history (957 commits, ~54MB). Two distinct
+findings, both false positives on inspection: (1) `expected_tokens_sha256`
+in `backend/scripts/bootstrap/provision_models.py` is a model-file integrity
+checksum, not a credential - high entropy hex is exactly what a SHA-256
+looks like, which is why the generic-api-key rule flagged it. (2) `sk_live_
+abc123` against `https://api.example.com/...` in a since-renamed
+`API_SPEC.md` (now `docs/API_SPEC.md`, which no longer contains this text at
+all) is an unambiguous documentation placeholder - fake domain, textbook
+fake-token shape. No real secret found; nothing to rotate.
+
+**Verified:** full backend suite via junit-xml - 931 passed, 0
+failed/errored/skipped - `ruff check .` clean. `npm run build` and
+`npm run lint` clean on the frontend; OpenGraph/Twitter tags confirmed
+present in served HTML via `curl`. Every new test mutation-tested by
+reverting its fix and confirming failure - including L9's, which is the one
+that failed to discriminate and led to reverting the "fix" instead of the
+test.
+
+**NOT done, closed as false positive (no code change):**
+- **L3** - reads a different class than the one named in the issue; see above.
+- **L9** - the existing clamp already prevents this; see above. The only
+  applied artifact from this finding is the regression test, not a code fix.

--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -6329,3 +6329,196 @@ test.
 - **L3** - reads a different class than the one named in the issue; see above.
 - **L9** - the existing clamp already prevents this; see above. The only
   applied artifact from this finding is the regression test, not a code fix.
+
+## 2026-08-21 GitHub triage batch 5 (Architecture/Production-Readiness, #151-175) — 7 fixed, 6 already resolved, 12 deferred
+
+The last batch of the 71-issue triage: 25 thematic/architectural findings,
+much larger in scope than P0-P3. Several turned out to already be resolved
+by earlier, unrelated work - this batch's main job was checking that before
+building anything new.
+
+**#153 - no SIGTERM handling anywhere in the mesh.** Traced what actually
+happens: `main.py`'s FastAPI server gets graceful shutdown for free from
+`uvicorn.run()`, which installs its own signal handling and drives the
+`lifespan` context manager's shutdown phase. Every other agent process
+(`brain_agent`, `system_agent`, `subconscious_agent`, `surfacing_agent`,
+`transport_agent`, `vision/agent.py`) runs via plain `asyncio.run(main())`
+with no signal handling at all - `except KeyboardInterrupt`/`except
+asyncio.CancelledError` blocks only catch SIGINT (which Python's default
+handler already turns into a catchable exception); SIGTERM has no such
+default translation, so it kills the process outright with no exception
+raised, meaning `agent.stop()` (NATS unsubscribe, `GraphDB.close()` with its
+new L7 in-flight-query drain, task cancellation) never ran under the exact
+signal Docker/Kubernetes send to stop a container. Added
+`install_shutdown_signal_handlers()` to `base.py` - wires both SIGTERM and
+SIGINT to the same `asyncio.Event`-based shutdown path - and applied it
+uniformly across all six `main()` functions, replacing each one's ad hoc
+try/except variant. Verified with a real `os.kill(os.getpid(),
+signal.SIGTERM)` inside the test process itself; mutation-testing this one
+was unusually conclusive - removing the handler didn't just fail the test,
+it let the unhandled SIGTERM kill the whole pytest run.
+
+**#160 - JSON logging existed but its toggle was dead.** `main.py` already
+called `setup_logging(json_format=getattr(Config, "LOG_JSON", False))`, and
+`logging_config.py`'s `CustomJsonFormatter` was already correct - but
+`LOG_JSON` was never declared as an `AppSettings` field. With
+`extra="ignore"`, setting `LOG_JSON=true` in `.env` had silently zero
+effect, always falling through to the `getattr` default. Verified directly
+(env var set, field didn't exist on the instantiated settings object) before
+fixing. Added the field; one line closed a gap that no amount of `.env`
+editing could have.
+
+**#169 - `ScreenLink` never retried after going headless.** Compared it
+against `CameraLink`, fixed for the same class of problem back in batch 3
+(M3): `CameraLink._ensure_cap()` already retries `cv2.VideoCapture(0)` on
+every single call. `ScreenLink` decided `headless` once in `__init__` and
+`capture_frame()` just returned `None` forever after - a display attached
+after startup, or a headless container later given one, left the agent
+blind for the rest of the process's life. Added `_ensure_sct()` mirroring
+the camera fix's retry-every-call pattern. First test attempt called
+`_ensure_sct()` directly and passed even with the fix removed from
+`capture_frame()` - not discriminating. Fixed by asserting through
+`capture_frame()` itself, the real call site the capture loop actually uses.
+
+**#171 - CI secret scanning was regex-only, no gitleaks.** The existing
+`security-audit.yml` credential-scan job greps for suspicious *variable
+names* in the current tree; it doesn't look at actual leaked *values* or at
+history. Added a `gitleaks-scan` job using `gitleaks/gitleaks-action@v2`
+against each push/PR's diff - the tool already used for the manual full-
+history scan in batch 4 (L6), now running on every future change instead of
+once. Did not add a pre-commit hook (the issue's other suggestion) - this
+repo has no pre-commit framework in place today, and adopting one changes
+every contributor's local workflow by default, which is a bigger decision
+than a CI-side addition.
+
+**#172 - `ORDER BY rand()` full-graph-scan in the dream sequence.**
+`MATCH (e:Entity) WITH e, rand() as r ORDER BY r LIMIT 3` evaluates a random
+value for every node before sorting - O(N log N) on every dream cycle.
+Confirmed APOC is already provisioned in this deployment
+(`docker-compose.infra.yml`'s `NEO4J_PLUGINS`), so replaced it with
+`apoc.coll.randomItems` over a single `collect()` pass - O(N), no sort -
+keeping the query's returned shape (`{name: ...}` rows) identical so the
+surrounding Python needed no changes.
+
+**#173 - inbound WebRTC audio published to NATS inline.**
+`_process_remote_audio` awaited `self.publish("audio.inbound", ...)`
+directly inside LiveKit's `AudioStream` iteration loop - a slow NATS publish
+stalls that await, delaying every subsequent frame. The fix pattern already
+existed in the same file for the *opposite* direction: `_on_nats_audio` /
+`_audio_playback_worker` already decouple NATS-to-WebRTC playback via a
+bounded queue with oldest-frame-drop overflow. Mirrored it exactly for
+WebRTC-to-NATS: new `inbound_audio_queue` /
+`_inbound_audio_worker`, wired into `start()`/`stop()` alongside the
+existing worker.
+
+**#174 - investigated, the specific claim was false; a narrower true
+observation was left as-is.** The consolidation loop's pairing check
+(`chrono_episodes[i + 1].get("role") == "assistant"`) is role-aware, not
+index-parity-based - traced by hand and confirmed by test that a burst of
+three consecutive user messages before one assistant reply never
+misattributes any message's `speaker` field. What *is* true: only the last
+of the three gets the reply attached, the other two get `response: ""`.
+Left that as-is rather than "fixing" it - attaching one assistant reply to
+three separate reflection episodes would triple-count that single
+exchange's relationship_delta and fact extraction, arguably worse than the
+current behavior.
+
+**#175 - already resolved.** `base.py` already has `_ack_heartbeat()`
+(calls `msg.in_progress()` every 15s for `chat.*` subjects, keeping
+JetStream's AckWait from expiring mid-turn) and `MESH_MAX_DELIVER`-bounded
+poison-message handling - this is finding A1/A3 from an earlier audit,
+already shipped. Confirmed present in current `base.py` before closing.
+
+**Verified:** full backend suite via junit-xml - 941 passed, 0
+failed/errored/skipped - `ruff check .` clean. Every new test mutation-
+tested by reverting its fix and confirming failure, including #169's
+non-discriminating first attempt (caught and fixed) and #153's, where the
+mutation didn't produce a clean test failure but killed the test process
+outright - the strongest possible confirmation available for that one.
+
+**NOT done, closed as already resolved (no code change needed):**
+- **#157** (container hardening): non-root users already in both
+  Dockerfiles, `healthcheck:` directives already on every service in
+  `docker-compose.infra.yml`/`docker-compose.prod.yml` (NATS, Postgres,
+  Neo4j, Redis, LiveKit, Ollama, Qdrant, TTS). One resource cap
+  (`brain_agent`, 2048M) already exists with a comment explaining it was
+  measured, not guessed. The other seven services remain uncapped - left
+  alone rather than adding unverified memory limits that could OOM-kill a
+  service nobody has profiled; more caps isn't strictly better without data.
+- **#163** (CI pipeline): `.github/workflows/ci.yml` already runs pytest,
+  ruff, frontend lint/build, and a Rust `cargo check` on every push/PR - the
+  issue's entire ask.
+- **#165** (TTS warmup): the Rust `voice-agent` crate already has
+  `probe_synthesis()` / `spawn_readiness_probe()` - a periodic (default 45s)
+  background probe that synthesizes a fixed phrase and checks for real
+  audio bytes, not just a 200 status. The narrow gap the issue actually
+  describes - blocking startup readiness on the *first* probe succeeding,
+  rather than monitoring in the background from the start - remains open,
+  but wasn't implemented: it's a behavior change to a compiled binary with
+  no live GPT-SoVITS server in this environment to verify against.
+- **#166** (async ACT-R decay): false premise. Decay scoring is not a
+  synchronous Python loop blocking retrieval - it's computed either inside
+  the `surface_actr_memories()` Postgres function as part of the single
+  retrieval query, or via the compiled `cognitive_rust.score_memories_actr_
+  sqlite` extension for the SQLite fallback. There's no separate expensive
+  step to move to a background job.
+- **#170** (grounding gate regression suite): `tests/test_self_knowledge_
+  grounding.py` already has ~46 tests covering exactly this (fabricated
+  names/hometowns/institutions, gap recording, ranking, claim races). The
+  "calibrate the thresholds" half of the issue was intentionally left
+  undone - there's no held-out dataset to calibrate against, and fitting
+  constants without one is exactly what B1 already forbids.
+
+**NOT done, deferred (large scope, infra decisions, or contradicts the
+documented deployment model):**
+- **#151** (Factor VI - move all runtime psychological state to Redis/
+  Postgres for horizontal scaling) contradicts the single-process
+  personal/family deployment this codebase is actually built for (see
+  `require_session_auth`'s own docstring, and H3/M6's framing throughout
+  batches 2-3). A full statelessness migration serves a multi-instance
+  deployment nobody is running.
+- **#152** duplicates **H2** (batch 2): `IdentityManager.save()` writing to
+  git-tracked files by default. Still bundled with issue #152 for the same
+  reason - one correct pass, not two partial ones.
+- **#154** (accessibility/a11y) is real but needs actual screen-reader
+  testing to verify, which this environment cannot do - CLAUDE.md is
+  explicit that frontend behavior changes need browser verification, not
+  markup added on faith.
+- **#155** (HTTPS/WSS enforcement + HSTS) needs a deployment-topology
+  decision this codebase doesn't currently encode anywhere (behind a
+  reverse proxy that terminates TLS, or not) - redirect logic guessed at
+  either shape risks being wrong for the shape not guessed.
+- **#156** (unified `/healthz` aggregating Neo4j/Postgres/Redis/Ollama/NATS)
+  - `main.py` is the signaling/token server; it doesn't own connections to
+  any of those (the agent processes do, per the mesh's separation of
+  concerns - same finding as M12, batch 3). Per-service Docker healthchecks
+  already cover this at the infra level; centralizing it in `main.py` would
+  mean giving the signaling server new client connections that exist only
+  to answer this endpoint.
+- **#158** (Alembic) is a new framework adoption across a dual Postgres/
+  SQLite backend that Alembic doesn't naturally support well for the SQLite
+  side - a design decision, not a drive-by fix.
+- **#159** (OpenTelemetry tracing across the NATS mesh) is a new dependency
+  plus wiring through every agent and message - large, and needs a tracing
+  backend decision (Jaeger, Tempo, a vendor) this repo hasn't made.
+- **#161** (LiveKit TURN/STUN for production) is an infra/ops decision
+  requiring a real Coturn deployment target - nothing to configure against
+  without one.
+- **#162** (crash on placeholder secrets in production) - no `ENVIRONMENT`/
+  production signal exists anywhere in `Config` (only `DEBUG`, which
+  defaults to `False` even for casual local/CI runs), and `POSTGRES_
+  PASSWORD` isn't a distinct `Config` field to check (only the composed
+  `DATABASE_URL` is). A naive check gated on `DEBUG=False` would fire in
+  every CI run and most local dev sessions; this needs the same missing-
+  signal problem solved first, a design decision.
+- **#164** (multi-session/tenant isolation for `AgentConfig` and `GraphDB`'s
+  belief cache) contradicts the documented single-family-deployment model
+  as directly as #151 - this system is one agent belonging to one
+  family, not a multi-tenant service.
+- **#167** (E2E WebRTC/NATS pipeline test suite) is a large testing-infra
+  investment (mocking full LiveKit audio ingress through the whole
+  cognitive loop) - a project, not a fix.
+- **#168** (real-time security event alerting) needs an external sink
+  decision (webhook URL, Slack/Discord channel, Sentry project) that
+  doesn't exist in this repo's config today - the alerting *mechanism*
+  could be built, but would have nowhere real to send anything yet.

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -10,6 +10,28 @@ on:
     branches: [main, master]
 
 jobs:
+  gitleaks-scan:
+    name: Gitleaks Secret Scan
+    # #171: the credential-scan job below is a hand-rolled regex over the
+    # current tree - it catches suspicious variable *names* but not actual
+    # leaked *values*, and it never looks at history. gitleaks does both: it
+    # scans the diff introduced by this push/PR against its own signature
+    # and entropy rules, so a real key pasted into any changed file (not
+    # just ones matching "password ="-style patterns) gets caught. A full
+    # history scan was run manually for the initial audit (see .agents/
+    # CONTEXT.md) - this job's job is catching *new* leaks going forward,
+    # not re-scanning the past on every push.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   credential-scan:
     name: Credential Leak Prevention
     runs-on: ubuntu-latest

--- a/backend/app/agents/base.py
+++ b/backend/app/agents/base.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import random
+import signal
 import time
 from typing import Any
 
@@ -10,6 +11,31 @@ import nats
 import orjson
 
 logger = logging.getLogger(__name__)
+
+
+def install_shutdown_signal_handlers(shutdown_event: asyncio.Event) -> None:
+    """Make SIGTERM trigger the same graceful-shutdown path SIGINT already
+    reaches by accident (#153).
+
+    Worker agent processes run via plain `asyncio.run(main())`, not under a
+    framework like uvicorn (which installs its own signal handling for
+    main.py's FastAPI server for free). Python's default disposition for
+    SIGTERM is to kill the process outright - no exception is raised, so no
+    `except`/`finally` block runs, unlike SIGINT, which Python's default
+    handler turns into a catchable `KeyboardInterrupt`. Docker/Kubernetes
+    send SIGTERM to stop a container, not SIGINT, so every agent's `stop()`
+    (which unsubscribes from NATS, closes GraphDB - see L7's in-flight-query
+    drain - and cancels background tasks) was unreachable in that exact,
+    everyday-deployment scenario.
+    """
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, shutdown_event.set)
+        except NotImplementedError:
+            # add_signal_handler is POSIX-only (e.g. unavailable on Windows'
+            # default proactor loop); fall back to the plain signal module.
+            signal.signal(sig, lambda *_args: shutdown_event.set())
 
 # M6: base/cap for exponential backoff with jitter on NATS reconnect. A static
 # `reconnect_time_wait` means every agent process in the mesh (brain, system,

--- a/backend/app/agents/base.py
+++ b/backend/app/agents/base.py
@@ -99,7 +99,7 @@ class BaseAgent:
                 try:
                     await self.subscribe("cache.sync", self._on_cache_sync_received)
                 except Exception as se:
-                    logger.debug(f"Cache sync auto-subscribe skipped: {se}")
+                    logger.debug("Cache sync auto-subscribe skipped: %s", se)
         except Exception as e:
             logger.error(f"Failed to connect agent '{self.name}': {e}")
             raise
@@ -158,9 +158,9 @@ class BaseAgent:
                             f"✅ Stream '{stream_name}' synchronized successfully."
                         )
                 except Exception as update_err:
-                    logger.debug(f"Stream update note: {update_err}")
+                    logger.debug("Stream update note: %s", update_err)
             except Exception as e:
-                logger.debug(f"Stream bootstrap note: {e}")
+                logger.debug("Stream bootstrap note: %s", e)
 
     async def publish(
         self, subject: str, data: Any, metadata: dict[str, Any] | None = None
@@ -455,7 +455,7 @@ class BaseAgent:
             "state.update",
             {"agent": self.name, "state": state, "timestamp": time.time()},
         )
-        logger.debug(f"Agent '{self.name}' state set to: {state}")
+        logger.debug("Agent '%s' state set to: %s", self.name, state)
 
     async def stop(self):
         """Shutdown the agent."""

--- a/backend/app/agents/brain_agent.py
+++ b/backend/app/agents/brain_agent.py
@@ -26,7 +26,7 @@ from ..utils.conversational_runtime import ConversationalRuntime
 from ..utils.interruption_classifier import InterruptionClassifier
 from ..utils.segmentation import HybridSegmenter
 from ..utils.speech import SpeechCoordinator
-from .base import BaseAgent
+from .base import BaseAgent, install_shutdown_signal_handlers
 
 logger = logging.getLogger(__name__)
 
@@ -757,11 +757,10 @@ async def main():
 
     await agent.start()
 
-    try:
-        shutdown_trigger = asyncio.Event()
-        await shutdown_trigger.wait()
-    except asyncio.CancelledError:
-        await agent.stop()
+    shutdown_trigger = asyncio.Event()
+    install_shutdown_signal_handlers(shutdown_trigger)
+    await shutdown_trigger.wait()
+    await agent.stop()
 
 
 if __name__ == "__main__":

--- a/backend/app/agents/subconscious_agent.py
+++ b/backend/app/agents/subconscious_agent.py
@@ -4,7 +4,7 @@ import time
 import uuid
 from typing import Any
 
-from app.agents.base import BaseAgent
+from app.agents.base import BaseAgent, install_shutdown_signal_handlers
 from app.cognitive.subconscious import SubconsciousEngine
 from app.config import Config
 from app.contracts import ChatInput, ChatInputMetadata, Topics
@@ -437,7 +437,16 @@ class SubconsciousAgent(BaseAgent):
     async def _run_dream_sequence(self):
         try:
             logger.info("[Subconscious] Running dream sequence...")
-            query = "MATCH (e:Entity) WITH e, rand() as r ORDER BY r LIMIT 3 RETURN e.name as name"
+            # `ORDER BY rand()` evaluates a random value for every node before
+            # sorting - O(N log N) over the whole graph on every dream cycle.
+            # apoc.coll.randomItems samples after a single collect() pass,
+            # O(N) with no sort (APOC ships by default, see
+            # docker-compose.infra.yml's NEO4J_PLUGINS).
+            query = (
+                "MATCH (e:Entity) WITH collect(e.name) AS names "
+                "UNWIND apoc.coll.randomItems(names, 3, false) AS name "
+                "RETURN name"
+            )
             records = await self.graph_db.execute_query(query)
             nodes = [record["name"] for record in records]
 
@@ -518,11 +527,10 @@ class SubconsciousAgent(BaseAgent):
 async def main():
     agent = SubconsciousAgent()
     await agent.start()
-    try:
-        shutdown_trigger = asyncio.Event()
-        await shutdown_trigger.wait()
-    except asyncio.CancelledError:
-        await agent.stop()
+    shutdown_trigger = asyncio.Event()
+    install_shutdown_signal_handlers(shutdown_trigger)
+    await shutdown_trigger.wait()
+    await agent.stop()
 
 
 if __name__ == "__main__":

--- a/backend/app/agents/surfacing_agent.py
+++ b/backend/app/agents/surfacing_agent.py
@@ -26,7 +26,7 @@ from ..contracts import (
     Topics,
 )
 from ..state import ConversationHistoryStore, GraphDB, MemoryStore
-from .base import BaseAgent
+from .base import BaseAgent, install_shutdown_signal_handlers
 
 logger = logging.getLogger("surfacing_agent")
 
@@ -678,15 +678,10 @@ async def main():
     )
 
     await agent.start()
-    try:
-        shutdown_trigger = asyncio.Event()
-        await shutdown_trigger.wait()
-    except asyncio.CancelledError:
-        pass
-    except KeyboardInterrupt:
-        pass
-    finally:
-        await agent.stop()
+    shutdown_trigger = asyncio.Event()
+    install_shutdown_signal_handlers(shutdown_trigger)
+    await shutdown_trigger.wait()
+    await agent.stop()
 
 
 if __name__ == "__main__":

--- a/backend/app/agents/system_agent.py
+++ b/backend/app/agents/system_agent.py
@@ -3,7 +3,7 @@ import logging
 import time
 
 from ..config import Config
-from .base import BaseAgent
+from .base import BaseAgent, install_shutdown_signal_handlers
 
 logger = logging.getLogger("system_agent")
 
@@ -64,11 +64,10 @@ class SystemAgent(BaseAgent):
 async def main():
     agent = SystemAgent()
     await agent.start()
-    try:
-        shutdown_trigger = asyncio.Event()
-        await shutdown_trigger.wait()
-    except KeyboardInterrupt:
-        await agent.stop()
+    shutdown_trigger = asyncio.Event()
+    install_shutdown_signal_handlers(shutdown_trigger)
+    await shutdown_trigger.wait()
+    await agent.stop()
 
 
 if __name__ == "__main__":

--- a/backend/app/agents/system_agent.py
+++ b/backend/app/agents/system_agent.py
@@ -46,7 +46,7 @@ class SystemAgent(BaseAgent):
 
                 # 2. Broadcast to Mesh
                 await self.publish("system.tick", tick_data)
-                logger.debug(f"[Pulse] system.tick broadcasted | Uptime: {uptime:.1f}s")
+                logger.debug("[Pulse] system.tick broadcasted | Uptime: %.1fs", uptime)
 
                 # 3. Wait for next heartbeat
                 await asyncio.sleep(self.tick_interval)

--- a/backend/app/agents/transport_agent.py
+++ b/backend/app/agents/transport_agent.py
@@ -7,7 +7,7 @@ from livekit import rtc
 from livekit.api import AccessToken, VideoGrants
 
 from ..config import Config
-from .base import BaseAgent
+from .base import BaseAgent, install_shutdown_signal_handlers
 
 logger = logging.getLogger("transport_agent")
 
@@ -47,6 +47,20 @@ class TransportAgent(BaseAgent):
         )
         self.audio_worker_task = None
         self.dropped_audio_frames = 0
+
+        # #173: mirrors the outbound queue above, for the opposite direction.
+        # `_process_remote_audio` used to `await self.publish(...)` directly
+        # inside LiveKit's `AudioStream` iteration loop - if NATS publishing
+        # stalls (network delay, JetStream backpressure), that await stalls
+        # right there, delaying every subsequent frame the WebRTC stack hands
+        # over. Decoupling capture from publish with a bounded queue and a
+        # dedicated worker means a slow NATS publish drops frames instead of
+        # stalling audio capture.
+        self.inbound_audio_queue = asyncio.Queue(
+            maxsize=max(32, int(getattr(Config, "TRANSPORT_AUDIO_QUEUE_SIZE", 256)))
+        )
+        self.inbound_audio_worker_task = None
+        self.dropped_inbound_audio_frames = 0
 
     async def _connect_livekit_with_retry(self, token: str):
         """Connect to LiveKit with bounded retries for transient SFU startup gaps."""
@@ -91,6 +105,10 @@ class TransportAgent(BaseAgent):
 
         # Capture frames on a dedicated worker so NATS callback can return fast.
         self.audio_worker_task = asyncio.create_task(self._audio_playback_worker())
+        # #173: drains inbound WebRTC frames independently of NATS publish speed.
+        self.inbound_audio_worker_task = asyncio.create_task(
+            self._inbound_audio_worker()
+        )
 
         # 3. Subscribe to NATS Audio Stream (Outbound - AI Speech)
         await self.subscribe(
@@ -120,7 +138,13 @@ class TransportAgent(BaseAgent):
             asyncio.create_task(self._process_remote_audio(track))
 
     async def _process_remote_audio(self, track: rtc.RemoteAudioTrack):
-        """Convert WebRTC audio frames to NATS events for STT"""
+        """Convert WebRTC audio frames to NATS events for STT.
+
+        #173: enqueues rather than publishing inline, so a slow NATS publish
+        never stalls draining `audio_stream` - only the queue backs up, and
+        overflow drops the oldest frame (matching `_on_nats_audio`'s policy)
+        rather than blocking capture.
+        """
         audio_stream = rtc.AudioStream(track)
         async for event in audio_stream:
             frame = event.frame
@@ -131,9 +155,43 @@ class TransportAgent(BaseAgent):
                 "participant": track.sid,
                 "captured_at": time.time(),
             }
-            # Publish raw PCM to the binary mesh path. STT still accepts the
-            # legacy JSON/base64 shape for compatibility.
-            await self.publish("audio.inbound", audio_data, metadata=metadata)
+            try:
+                self.inbound_audio_queue.put_nowait((audio_data, metadata))
+            except asyncio.QueueFull:
+                try:
+                    _ = self.inbound_audio_queue.get_nowait()
+                    self.inbound_audio_queue.task_done()
+                except asyncio.QueueEmpty:
+                    pass
+
+                try:
+                    self.inbound_audio_queue.put_nowait((audio_data, metadata))
+                except asyncio.QueueFull:
+                    pass
+
+                self.dropped_inbound_audio_frames += 1
+                if self.dropped_inbound_audio_frames % 50 == 1:
+                    logger.warning(
+                        "Inbound transport audio queue overloaded; dropped %s frames.",
+                        self.dropped_inbound_audio_frames,
+                    )
+
+    async def _inbound_audio_worker(self):
+        """Drain queued inbound frames and publish to NATS at publish pace."""
+        while True:
+            try:
+                audio_data, metadata = await self.inbound_audio_queue.get()
+                try:
+                    # Publish raw PCM to the binary mesh path. STT still
+                    # accepts the legacy JSON/base64 shape for compatibility.
+                    await self.publish("audio.inbound", audio_data, metadata=metadata)
+                finally:
+                    self.inbound_audio_queue.task_done()
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"Inbound transport audio worker error: {e}")
+                await asyncio.sleep(0.01)
 
     async def _on_nats_audio(self, data, metadata: dict | None = None):
         """Convert NATS audio events to WebRTC frames for User."""
@@ -234,6 +292,12 @@ class TransportAgent(BaseAgent):
                 await self.audio_worker_task
             except asyncio.CancelledError:
                 pass
+        if self.inbound_audio_worker_task:
+            self.inbound_audio_worker_task.cancel()
+            try:
+                await self.inbound_audio_worker_task
+            except asyncio.CancelledError:
+                pass
         await self.room.disconnect()
         await super().stop()
         logger.info("Transport Agent Stopped.")
@@ -241,12 +305,11 @@ class TransportAgent(BaseAgent):
 
 async def main():
     agent = TransportAgent()
-    try:
-        await agent.start()
-        shutdown_trigger = asyncio.Event()
-        await shutdown_trigger.wait()
-    except KeyboardInterrupt:
-        await agent.stop()
+    await agent.start()
+    shutdown_trigger = asyncio.Event()
+    install_shutdown_signal_handlers(shutdown_trigger)
+    await shutdown_trigger.wait()
+    await agent.stop()
 
 
 if __name__ == "__main__":

--- a/backend/app/cognitive/action.py
+++ b/backend/app/cognitive/action.py
@@ -859,7 +859,7 @@ class ActionService:
         try:
             await self.self_knowledge.record_gap(gaps, user_message)
         except Exception as e:
-            logger.debug(f"[Action] Could not record self-knowledge gap: {e}")
+            logger.debug("[Action] Could not record self-knowledge gap: %s", e)
 
     def _unanswered_self_question_gaps(self, user_message: str, surfaced) -> list[str]:
         """Terms from a question about her own life that her biography cannot meet.
@@ -908,7 +908,7 @@ class ActionService:
         try:
             await self.self_knowledge.record_gap(gaps, user_message)
         except Exception as e:
-            logger.debug(f"[Action] Could not record unanswered self-question: {e}")
+            logger.debug("[Action] Could not record unanswered self-question: %s", e)
 
     async def _build_wondering_block(self) -> str:
         """Offer her one thing to ask about her own life, or nothing.
@@ -929,7 +929,7 @@ class ActionService:
         try:
             gap = await self.self_knowledge.claim_next_gap_to_ask()
         except Exception as e:
-            logger.debug(f"[Action] Could not claim next self-knowledge gap: {e}")
+            logger.debug("[Action] Could not claim next self-knowledge gap: %s", e)
             return ""
         if not gap or not gap.get("term"):
             return ""

--- a/backend/app/cognitive/perception.py
+++ b/backend/app/cognitive/perception.py
@@ -53,7 +53,7 @@ class PerceptionService:
             else:
                 intent = "CHAT"
 
-        logger.debug(f"[Perception] Extracted intent '{intent}' from {event_type}")
+        logger.debug("[Perception] Extracted intent '%s' from %s", intent, event_type)
 
         return CognitiveEvent(
             event_id=event_id,

--- a/backend/app/cognitive/tom.py
+++ b/backend/app/cognitive/tom.py
@@ -105,6 +105,31 @@ def update_known_concepts(current_concepts: list[str], user_input: str) -> list[
         "very",
         "just",
         "here",
+        # L8: common conversational filler/connector words that otherwise get
+        # tracked as if they were distinctive user vocabulary.
+        "also",
+        "even",
+        "still",
+        "well",
+        "really",
+        "actually",
+        "maybe",
+        "kind",
+        "sort",
+        "much",
+        "many",
+        "does",
+        "doing",
+        "because",
+        "before",
+        "during",
+        "while",
+        "same",
+        "only",
+        "over",
+        "into",
+        "under",
+        "until",
     }
 
     updated = list(current_concepts)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -12,6 +12,13 @@ class AppSettings(BaseSettings):
     )
 
     DEBUG: bool = False
+    # #160: `main.py` already reads this via `getattr(Config, "LOG_JSON",
+    # False)` to pick JSON vs plain-text logging, but the field was never
+    # actually declared here - `extra="ignore"` meant setting LOG_JSON=true
+    # in .env had silently no effect at all, always falling through to the
+    # getattr default. The JSON formatter itself (logging_config.py) was
+    # already correct; only the toggle to reach it was dead.
+    LOG_JSON: bool = False
     TESTING_CONSOLIDATION_BYPASS_SILENCE: bool = False
     ALLOWED_ORIGINS_STR: str = Field(default="*", alias="ALLOWED_ORIGINS")
     LAN_ONLY: bool = True

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -181,6 +181,49 @@ class AppSettings(BaseSettings):
     STATE_SENSORY_WEIGHT: float = 0.20
     STATE_SENSORY_PERSIST_INTERVAL: float = 2.0
 
+    # L5: pydantic-settings already validates *type* (a non-numeric
+    # TOKEN_RATE_LIMIT_WINDOW_SECONDS fails to load at all), but not *range* -
+    # a negative timeout or a zero halflife loads fine and only breaks
+    # something at runtime. This is deliberately a short, curated list of
+    # fields where an out-of-range value causes a specific concrete failure
+    # (division by zero in decay math, a busy-loop tick, a rate limiter that
+    # blocks everything or nothing), not an exhaustive sweep of every numeric
+    # setting - most of the ~40 others have no failure mode worth guarding.
+    _POSITIVE_FLOAT_FIELDS = (
+        "DOPAMINE_PHASIC_HALFLIFE_S",
+        "CORTISOL_PHASIC_HALFLIFE_S",
+        "TOKEN_RATE_LIMIT_WINDOW_SECONDS",
+        "LLM_STREAM_MAX_SECONDS",
+    )
+    _NON_NEGATIVE_FLOAT_FIELDS = ("ACTR_DECAY_RATE",)
+    _POSITIVE_INT_FIELDS = (
+        "SYSTEM_TICK_INTERVAL",
+        "TOKEN_RATE_LIMIT_MAX_REQUESTS",
+        "MAX_VOICE_QUEUE_SIZE",
+        "VOICE_SYNTH_CONCURRENCY",
+        "TRANSPORT_AUDIO_QUEUE_SIZE",
+        "STT_WHISPER_QUEUE_SIZE",
+        "STT_PERCEPTION_QUEUE_SIZE",
+    )
+
+    @model_validator(mode="after")
+    def validate_numeric_ranges(self):
+        for name in self._POSITIVE_FLOAT_FIELDS:
+            value = getattr(self, name)
+            if not (value > 0):
+                raise ValueError(f"{name} must be > 0 (got {value!r})")
+        for name in self._NON_NEGATIVE_FLOAT_FIELDS:
+            value = getattr(self, name)
+            if value < 0:
+                raise ValueError(f"{name} must be >= 0 (got {value!r})")
+        for name in self._POSITIVE_INT_FIELDS:
+            value = getattr(self, name)
+            if value < 1:
+                raise ValueError(f"{name} must be >= 1 (got {value!r})")
+        if not (0 < self.QDRANT_PORT <= 65535):
+            raise ValueError(f"QDRANT_PORT must be a valid port (got {self.QDRANT_PORT!r})")
+        return self
+
     @model_validator(mode="after")
     def set_defaults(self):
         if not self.LLM_CHAT_MODEL:

--- a/backend/app/state/graph_db.py
+++ b/backend/app/state/graph_db.py
@@ -14,6 +14,12 @@ from typing import Any
 # evict from the front on insert once full.
 MAX_BELIEF_CACHE_ENTRIES = 500
 
+# L7: how long close() waits for in-flight Cypher queries to drain before
+# closing the driver anyway. A module-level constant (rather than a literal
+# inline) so tests can shrink it instead of actually waiting out a real
+# multi-second timeout.
+GRAPHDB_CLOSE_DRAIN_TIMEOUT_SECONDS = 10.0
+
 from neo4j import AsyncGraphDatabase
 
 from ..config import Config
@@ -48,6 +54,12 @@ class GraphDB:
         # Perceptual Belief Cache (M9: bounded LRU, see MAX_BELIEF_CACHE_ENTRIES)
         self._belief_cache: OrderedDict[Any, tuple[float, Any]] = OrderedDict()
         self._cache_ttl = getattr(Config, "GRAPH_CACHE_TTL", 300)
+
+        # L7: lets close() wait for in-flight Cypher queries instead of
+        # yanking the driver out from under them.
+        self._inflight_queries = 0
+        self._all_queries_done = asyncio.Event()
+        self._all_queries_done.set()
 
     async def initialize(self) -> None:
         """Bootstrap schema constraints/indexes and wait for it to finish.
@@ -94,7 +106,7 @@ class GraphDB:
                         return await tx.run(query)
 
                     await session.execute_write(_tx)
-                logger.debug(f"Graph Store Schema: Constraint initialized ({query})")
+                logger.debug("Graph Store Schema: Constraint initialized (%s)", query)
             except Exception as e:
                 logger.warning(
                     f"Graph Store Schema: Optional index/constraint initialization skipped ({query}): {e}"
@@ -122,6 +134,27 @@ class GraphDB:
                 await self._bootstrap_task
             except asyncio.CancelledError:
                 pass
+
+        # L7: wait for any in-flight Cypher queries to finish before tearing
+        # down the driver. Closing underneath a concurrent execute_query()
+        # call (e.g. a background reflection/decay task) previously raised
+        # unhandled connection errors in whatever task issued it, instead of
+        # letting it finish or fail cleanly on its own. Bounded so a stuck
+        # query can't hang shutdown forever.
+        if self._inflight_queries > 0:
+            try:
+                await asyncio.wait_for(
+                    self._all_queries_done.wait(),
+                    timeout=GRAPHDB_CLOSE_DRAIN_TIMEOUT_SECONDS,
+                )
+            except TimeoutError:
+                logger.warning(
+                    "GraphDB.close(): %d Cypher quer(y/ies) still in flight "
+                    "after %.0fs, closing the driver anyway.",
+                    self._inflight_queries,
+                    GRAPHDB_CLOSE_DRAIN_TIMEOUT_SECONDS,
+                )
+
         await self.driver.close()
 
     async def invalidate_cache(self, affected_entity: str | None = None):
@@ -153,6 +186,8 @@ class GraphDB:
                 self._belief_cache.move_to_end(cache_key)
                 return result
 
+        self._inflight_queries += 1
+        self._all_queries_done.clear()
         try:
             async with self.driver.session() as session:
                 attempt = 0
@@ -192,6 +227,10 @@ class GraphDB:
         except Exception as e:
             logger.error(f"Neo4j query failed: {e}")
             return []
+        finally:
+            self._inflight_queries -= 1
+            if self._inflight_queries == 0:
+                self._all_queries_done.set()
 
     async def consolidate_relationship(
         self,

--- a/backend/app/state/lexicon_store.py
+++ b/backend/app/state/lexicon_store.py
@@ -74,7 +74,7 @@ class MentalLexicon:
                 await self._seed_innate()
                 self._ready = True
             except Exception as e:  # never let lexicon setup break a memory op
-                logger.debug(f"MentalLexicon not ready ({e}); expansion disabled")
+                logger.debug("MentalLexicon not ready (%s); expansion disabled", e)
 
     async def _ensure_schema(self):
         """Portable safety-net DDL. Production uses db/schema.sql (Postgres) and
@@ -176,7 +176,7 @@ class MentalLexicon:
                         )
                         self._bump_cache(a, b, 1.0)
         except Exception as e:
-            logger.debug(f"MentalLexicon.learn_from_text skipped: {e}")
+            logger.debug("MentalLexicon.learn_from_text skipped: %s", e)
 
     # ---- expansion (recall hot path) --------------------------------------
 
@@ -212,7 +212,7 @@ class MentalLexicon:
             await self._ensure_ready()
             await self._load_cache()
         except Exception as e:
-            logger.debug(f"MentalLexicon.refresh skipped: {e}")
+            logger.debug("MentalLexicon.refresh skipped: %s", e)
 
     async def _load_cache(self):
         cache: dict[str, dict[str, float]] = {}

--- a/backend/app/state/memory_store.py
+++ b/backend/app/state/memory_store.py
@@ -440,7 +440,7 @@ class MemoryStore:
                     wing,
                 )
         except Exception as e:
-            logger.debug(f"Dedup lookup failed, proceeding to insert: {e}")
+            logger.debug("Dedup lookup failed, proceeding to insert: %s", e)
             return None
         if isinstance(rows, list) and rows:
             return rows[0]["id"]
@@ -945,7 +945,7 @@ class MemoryStore:
                     else:
                         self._db_stop_words = set()
         except Exception as e:
-            logger.debug(f"Failed to load dynamic stop words: {e}")
+            logger.debug("Failed to load dynamic stop words: %s", e)
             self._db_stop_words = set()
 
     # ------------------------------------------------------------------
@@ -1005,7 +1005,7 @@ class MemoryStore:
                     )
                     self.goal_buffer.flush()
             except Exception as ts_err:
-                logger.debug(f"Topic-shift calculation failed: {ts_err}")
+                logger.debug("Topic-shift calculation failed: %s", ts_err)
         self._last_query_vector = query_vector
 
     async def _gather_candidate_sources(self, mrl_query_vector, candidate_limit):
@@ -2550,7 +2550,7 @@ class MemoryStore:
                     entity_records, entity_names, adj, user_id
                 )
             except Exception as e:
-                logger.debug(f"Failed to process entities: {e}")
+                logger.debug("Failed to process entities: %s", e)
 
             resolved_cues = self._resolve_pronoun_cues(
                 query_text,

--- a/backend/app/state/self_knowledge_store.py
+++ b/backend/app/state/self_knowledge_store.py
@@ -107,7 +107,7 @@ class SelfKnowledgeStore:
                         pass
                 self._ready = True
             except Exception as e:
-                logger.debug(f"SelfKnowledgeStore not ready ({e}); gaps not recorded")
+                logger.debug("SelfKnowledgeStore not ready (%s); gaps not recorded", e)
 
     # ---- known terms -------------------------------------------------------
 
@@ -127,7 +127,7 @@ class SelfKnowledgeStore:
                     "SELECT content FROM memories WHERE source = $1", "biography"
                 )
         except Exception as e:
-            logger.debug(f"Could not refresh self-knowledge terms ({e})")
+            logger.debug("Could not refresh self-knowledge terms (%s)", e)
             return len(self._known_terms)
 
         terms = set(self._seed_terms)
@@ -178,7 +178,7 @@ class SelfKnowledgeStore:
                     )
                     written += 1
         except Exception as e:
-            logger.debug(f"Could not record self-knowledge gap ({e})")
+            logger.debug("Could not record self-knowledge gap (%s)", e)
 
         if written:
             logger.info(
@@ -227,7 +227,7 @@ class SelfKnowledgeStore:
                     int(min_hits),
                 )
         except Exception as e:
-            logger.debug(f"Could not claim next self-knowledge gap ({e})")
+            logger.debug("Could not claim next self-knowledge gap (%s)", e)
             return None
         return dict(row) if row else None
 
@@ -245,5 +245,5 @@ class SelfKnowledgeStore:
                 )
             return [dict(r) for r in rows or ()]
         except Exception as e:
-            logger.debug(f"Could not read self-knowledge gaps ({e})")
+            logger.debug("Could not read self-knowledge gaps (%s)", e)
             return []

--- a/backend/app/state/working_memory_store.py
+++ b/backend/app/state/working_memory_store.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import sqlite3
+import threading
 from typing import Any
 
 import redis
@@ -45,6 +46,12 @@ class WorkingMemoryStore:
         self.max_turns = max_turns
         self.db_path = db_path
         self.redis_client: redis.Redis | None = None
+        # L2: one connection reused for the lifetime of the store rather than
+        # opening/closing a fresh handle on every fallback call; guarded by a
+        # lock since each call arrives on a different asyncio.to_thread
+        # worker thread and SQLite doesn't support concurrent writers anyway.
+        self._sqlite_conn: sqlite3.Connection | None = None
+        self._sqlite_lock = threading.Lock()
 
         # 1. Attempt Redis Connection
         try:
@@ -72,15 +79,23 @@ class WorkingMemoryStore:
         self._initialize_sqlite()
 
     def _get_sqlite_connection(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self.db_path)
-        conn.row_factory = sqlite3.Row
-        return conn
+        """Lazily create and cache the fallback connection (L2).
+
+        `check_same_thread=False` is required because callers reach this from
+        whichever `asyncio.to_thread` worker thread happens to run a given
+        call; `self._sqlite_lock` (held by every call site) is what actually
+        makes sharing the connection across threads safe.
+        """
+        if self._sqlite_conn is None:
+            self._sqlite_conn = sqlite3.connect(self.db_path, check_same_thread=False)
+            self._sqlite_conn.row_factory = sqlite3.Row
+        return self._sqlite_conn
 
     def _initialize_sqlite(self):
         if self.redis_client is not None:
             return
 
-        with self._get_sqlite_connection() as conn:
+        with self._sqlite_lock, self._get_sqlite_connection() as conn:
             cursor = conn.cursor()
             cursor.execute("""
                 CREATE TABLE IF NOT EXISTS working_turns (
@@ -134,7 +149,7 @@ class WorkingMemoryStore:
 
         # SQLite Fallback execution
         try:
-            with self._get_sqlite_connection() as conn:
+            with self._sqlite_lock, self._get_sqlite_connection() as conn:
                 cursor = conn.cursor()
                 cursor.execute(
                     "INSERT INTO working_turns (role, content, metadata) VALUES (?, ?, ?)",
@@ -188,7 +203,7 @@ class WorkingMemoryStore:
 
         # SQLite Fallback
         try:
-            with self._get_sqlite_connection() as conn:
+            with self._sqlite_lock, self._get_sqlite_connection() as conn:
                 cursor = conn.cursor()
                 cursor.execute(
                     "SELECT role, content, metadata FROM working_turns ORDER BY id DESC LIMIT ?",
@@ -222,7 +237,7 @@ class WorkingMemoryStore:
                 logger.error(f"Redis clear_turns failed: {e}. Falling back to SQLite.")
 
         try:
-            with self._get_sqlite_connection() as conn:
+            with self._sqlite_lock, self._get_sqlite_connection() as conn:
                 cursor = conn.cursor()
                 cursor.execute("DELETE FROM working_turns")
                 conn.commit()
@@ -247,7 +262,7 @@ class WorkingMemoryStore:
                 )
 
         try:
-            with self._get_sqlite_connection() as conn:
+            with self._sqlite_lock, self._get_sqlite_connection() as conn:
                 cursor = conn.cursor()
                 cursor.execute(
                     "INSERT INTO working_state (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
@@ -274,7 +289,7 @@ class WorkingMemoryStore:
                 )
 
         try:
-            with self._get_sqlite_connection() as conn:
+            with self._sqlite_lock, self._get_sqlite_connection() as conn:
                 cursor = conn.cursor()
                 cursor.execute("SELECT value FROM working_state WHERE key = ?", (key,))
                 row = cursor.fetchone()

--- a/backend/app/vision/agent.py
+++ b/backend/app/vision/agent.py
@@ -210,7 +210,7 @@ class VisionAgent(BaseAgent):
 
             return 1.0
         except Exception as e:
-            logger.debug(f"Failed to calculate user distance: {e}")
+            logger.debug("Failed to calculate user distance: %s", e)
             return 1.0
 
     async def _run_appraisal(self, frame_b64: str):

--- a/backend/app/vision/agent.py
+++ b/backend/app/vision/agent.py
@@ -3,7 +3,7 @@ import base64
 import logging
 import time
 
-from ..agents.base import BaseAgent
+from ..agents.base import BaseAgent, install_shutdown_signal_handlers
 from ..config import Config
 from ..contracts import Topics, VisionDescription
 from ..llm.ollama_client import OllamaClient
@@ -244,11 +244,10 @@ async def main():
 
     agent = VisionAgent()
     await agent.start()
-    try:
-        while True:
-            await asyncio.sleep(1)
-    except asyncio.CancelledError:
-        await agent.stop()
+    shutdown_trigger = asyncio.Event()
+    install_shutdown_signal_handlers(shutdown_trigger)
+    await shutdown_trigger.wait()
+    await agent.stop()
 
 
 if __name__ == "__main__":

--- a/backend/app/vision/links.py
+++ b/backend/app/vision/links.py
@@ -65,8 +65,31 @@ class ScreenLink:
         _, buffer = cv2.imencode(".jpg", frame, [int(cv2.IMWRITE_JPEG_QUALITY), 50])
         return buffer.tobytes()
 
+    def _ensure_sct(self):
+        """Retry display discovery if currently headless (#169).
+
+        Unlike `CameraLink._ensure_cap`, which already retried
+        `cv2.VideoCapture(0)` on every call, `ScreenLink` decided `headless`
+        once at construction and never looked again - a display attached
+        after startup (or a headless container later given one) left the
+        agent blind for the rest of the process's life.
+        """
+        if not self.headless or mss is None or np is None:
+            return
+        try:
+            self.sct = mss.mss()
+            try:
+                self.monitor = self.sct.monitors[1]
+            except IndexError:
+                self.monitor = self.sct.monitors[0]
+            self.headless = False
+            logger.info("[Vision] Screen capture recovered; a display is available.")
+        except Exception:
+            pass  # still headless; capture_frame() below returns None as before
+
     def capture_frame(self) -> bytes | None:
         """Captures and returns a compressed JPEG frame of the screen."""
+        self._ensure_sct()
         if self.headless:
             return None
 

--- a/backend/tests/test_config_validation.py
+++ b/backend/tests/test_config_validation.py
@@ -1,0 +1,82 @@
+"""
+L5: pydantic-settings validates type on load (a non-numeric env value fails
+to parse) but not range - a negative timeout or a zero halflife loaded fine
+and only broke something later, at runtime, far from the misconfiguration.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from app.config import AppSettings
+
+
+def _settings(**overrides):
+    return AppSettings(_env_file=None, **overrides)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "DOPAMINE_PHASIC_HALFLIFE_S",
+        "CORTISOL_PHASIC_HALFLIFE_S",
+        "TOKEN_RATE_LIMIT_WINDOW_SECONDS",
+        "LLM_STREAM_MAX_SECONDS",
+    ],
+)
+def test_zero_or_negative_rejected_for_positive_float_fields(field):
+    """A zero halflife divides by zero in decay math; a zero/negative
+    timeout produces nonsensical (instant or infinite) behavior."""
+    with pytest.raises(ValidationError):
+        _settings(**{field: 0})
+    with pytest.raises(ValidationError):
+        _settings(**{field: -1})
+
+
+def test_negative_decay_rate_rejected():
+    """A negative ACTR_DECAY_RATE would make memories strengthen with time
+    instead of decaying - an inversion of the intended model, not just an
+    edge case."""
+    with pytest.raises(ValidationError):
+        _settings(ACTR_DECAY_RATE=-0.1)
+
+
+def test_zero_decay_rate_is_allowed():
+    """Zero is a legitimate (if unusual) choice - 'never decay' - unlike
+    negative, which inverts the model."""
+    settings = _settings(ACTR_DECAY_RATE=0.0)
+    assert settings.ACTR_DECAY_RATE == 0.0
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "SYSTEM_TICK_INTERVAL",
+        "TOKEN_RATE_LIMIT_MAX_REQUESTS",
+        "MAX_VOICE_QUEUE_SIZE",
+        "VOICE_SYNTH_CONCURRENCY",
+        "TRANSPORT_AUDIO_QUEUE_SIZE",
+        "STT_WHISPER_QUEUE_SIZE",
+        "STT_PERCEPTION_QUEUE_SIZE",
+    ],
+)
+def test_zero_or_negative_rejected_for_positive_int_fields(field):
+    """A zero SYSTEM_TICK_INTERVAL busy-loops; a zero queue/concurrency size
+    is a store nothing can ever pass through."""
+    with pytest.raises(ValidationError):
+        _settings(**{field: 0})
+    with pytest.raises(ValidationError):
+        _settings(**{field: -1})
+
+
+def test_qdrant_port_out_of_range_rejected():
+    with pytest.raises(ValidationError):
+        _settings(QDRANT_PORT=0)
+    with pytest.raises(ValidationError):
+        _settings(QDRANT_PORT=70000)
+
+
+def test_default_settings_load_without_error():
+    """Sanity check that the new validator doesn't reject the shipped
+    defaults themselves."""
+    settings = _settings()
+    assert settings.SYSTEM_TICK_INTERVAL > 0

--- a/backend/tests/test_config_validation.py
+++ b/backend/tests/test_config_validation.py
@@ -80,3 +80,15 @@ def test_default_settings_load_without_error():
     defaults themselves."""
     settings = _settings()
     assert settings.SYSTEM_TICK_INTERVAL > 0
+
+
+def test_log_json_env_var_actually_reaches_the_setting(monkeypatch):
+    """#160: `main.py` reads `getattr(Config, "LOG_JSON", False)` to choose
+    JSON vs plain-text logging, but `LOG_JSON` was never declared as an
+    `AppSettings` field - with `extra="ignore"`, setting `LOG_JSON=true` in
+    the environment had silently zero effect, always falling through to the
+    getattr default. This proves the env var now actually reaches the field.
+    """
+    monkeypatch.setenv("LOG_JSON", "true")
+    settings = AppSettings(_env_file=None)
+    assert settings.LOG_JSON is True

--- a/backend/tests/test_graph_db_initialize.py
+++ b/backend/tests/test_graph_db_initialize.py
@@ -10,6 +10,7 @@ from app.state.graph_db import MAX_BELIEF_CACHE_ENTRIES, GraphDB
 
 def _make_graph_db() -> GraphDB:
     mock_driver = MagicMock()
+    mock_driver.close = AsyncMock()
     mock_session = AsyncMock()
     mock_driver.session.return_value.__aenter__.return_value = mock_session
     with patch("neo4j.AsyncGraphDatabase.driver", return_value=mock_driver):
@@ -121,3 +122,66 @@ async def test_belief_cache_lru_recency_survives_eviction():
     key1 = ("MATCH (n) RETURN n", json.dumps({"i": 1}))
     assert key0 in db._belief_cache  # just re-touched, survives
     assert key1 not in db._belief_cache  # least-recently-used, evicted
+
+
+@pytest.mark.asyncio
+async def test_close_waits_for_an_in_flight_query_before_closing_the_driver():
+    """L7: `close()` used to cancel the bootstrap task and immediately call
+    `driver.close()`, with no regard for a concurrent `execute_query()` call
+    still in flight (e.g. a background reflection/decay task) - that call
+    would then raise an unhandled connection error instead of finishing or
+    failing on its own terms.
+    """
+    db = _make_graph_db()
+    db.bootstrap_constraints = AsyncMock()
+    query_started = asyncio.Event()
+    release_query = asyncio.Event()
+
+    async def slow_session_read(tx_func):
+        query_started.set()
+        await release_query.wait()
+        return []
+
+    mock_session = db.driver.session.return_value.__aenter__.return_value
+    mock_session.execute_read = slow_session_read
+
+    query_task = asyncio.create_task(db.execute_query("MATCH (n) RETURN n"))
+    await query_started.wait()
+
+    close_task = asyncio.create_task(db.close())
+    await asyncio.sleep(0.01)
+    assert not close_task.done()  # must still be waiting on the query
+    assert db.driver.close.await_count == 0
+
+    release_query.set()
+    await query_task
+    await close_task
+
+    assert db.driver.close.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_close_does_not_hang_forever_on_a_stuck_query(monkeypatch):
+    """A query that never finishes must not block shutdown indefinitely -
+    close() should time out and proceed anyway, loudly."""
+    import app.state.graph_db as graph_db_module
+
+    monkeypatch.setattr(graph_db_module, "GRAPHDB_CLOSE_DRAIN_TIMEOUT_SECONDS", 0.05)
+
+    db = _make_graph_db()
+    db.bootstrap_constraints = AsyncMock()
+
+    async def hung_session_read(tx_func):
+        await asyncio.sleep(999)
+        return []
+
+    mock_session = db.driver.session.return_value.__aenter__.return_value
+    mock_session.execute_read = hung_session_read
+
+    query_task = asyncio.create_task(db.execute_query("MATCH (n) RETURN n"))
+    await asyncio.sleep(0.01)
+
+    await db.close()
+
+    assert db.driver.close.await_count == 1
+    query_task.cancel()

--- a/backend/tests/test_phase5_tom.py
+++ b/backend/tests/test_phase5_tom.py
@@ -53,6 +53,25 @@ def test_vocabulary_tracker_evicts_oldest_once_the_cap_is_exceeded():
     assert "brandnewword" in updated  # newest, retained
 
 
+def test_vocabulary_tracker_filters_conversational_filler_words():
+    """L8: high-frequency filler/connector words ('also', 'even', 'still',
+    'well', etc.) used to pass the length filter and get tracked as if they
+    were distinctive user vocabulary, diluting the concept list with noise.
+    """
+    current = []
+    user_input = "well i also think it was still quite good actually"
+
+    updated = update_known_concepts(current, user_input)
+
+    assert "well" not in updated
+    assert "also" not in updated
+    assert "still" not in updated
+    assert "actually" not in updated
+    # A genuine content word in the same sentence must survive the filter.
+    assert "think" in updated
+    assert "good" in updated
+
+
 @pytest.mark.asyncio
 async def test_state_tom_update_and_bounds(mock_graph_db):
     """Validates that update_theory_of_mind parses concepts and enforces bounds."""

--- a/backend/tests/test_phase6_advanced_cognition.py
+++ b/backend/tests/test_phase6_advanced_cognition.py
@@ -239,6 +239,14 @@ async def test_sleep_dreaming_neo4j():
         source="subconscious_dream",
     )
 
+    dream_query = mock_graph_db.execute_query.await_args.args[0]
+    assert "rand()" not in dream_query.lower(), (
+        "Regression for the O(N log N) `ORDER BY rand()` full-graph-scan-and-"
+        "sort fix - the query must use apoc.coll.randomItems (O(N), no sort) "
+        "instead of evaluating and sorting a random value for every node."
+    )
+    assert "apoc.coll.randomitems" in dream_query.lower()
+
 
 @pytest.mark.asyncio
 async def test_mrl_dimension_gating():

--- a/backend/tests/test_shutdown_signal_handling.py
+++ b/backend/tests/test_shutdown_signal_handling.py
@@ -1,0 +1,52 @@
+"""
+#153: worker agent processes run via plain `asyncio.run(main())`, not under
+a framework like uvicorn (which installs its own signal handling for free
+for main.py's FastAPI server). Python's default disposition for SIGTERM is
+to kill the process outright - no exception is raised, so no graceful
+`stop()` (NATS unsubscribe, GraphDB close, task cancellation) ever ran.
+`install_shutdown_signal_handlers` closes that gap by wiring both SIGTERM
+and SIGINT to the same shutdown-event path.
+"""
+
+import asyncio
+import os
+import signal
+
+import pytest
+
+from app.agents.base import install_shutdown_signal_handlers
+
+
+@pytest.mark.asyncio
+async def test_sigterm_sets_the_shutdown_event():
+    """A real SIGTERM sent to this process must reach the event - not just
+    SIGINT, which Python already translates to KeyboardInterrupt by default.
+    """
+    shutdown_event = asyncio.Event()
+    install_shutdown_signal_handlers(shutdown_event)
+
+    os.kill(os.getpid(), signal.SIGTERM)
+    await asyncio.wait_for(shutdown_event.wait(), timeout=2.0)
+
+    assert shutdown_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_sigint_still_sets_the_shutdown_event():
+    """SIGINT must keep working through the same unified path."""
+    shutdown_event = asyncio.Event()
+    install_shutdown_signal_handlers(shutdown_event)
+
+    os.kill(os.getpid(), signal.SIGINT)
+    await asyncio.wait_for(shutdown_event.wait(), timeout=2.0)
+
+    assert shutdown_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_without_a_handler_the_event_never_sets_on_its_own():
+    """Sanity check for the test technique itself: the event must not be
+    set just by existing - only the signal handler should set it."""
+    shutdown_event = asyncio.Event()
+    await asyncio.sleep(0.05)
+    assert not shutdown_event.is_set()

--- a/backend/tests/test_somatic_vision.py
+++ b/backend/tests/test_somatic_vision.py
@@ -8,6 +8,7 @@ probe that makes a blind agent say so instead of failing silently.
 """
 
 import asyncio
+import math
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -101,6 +102,27 @@ def test_non_numeric_confidence_falls_back_rather_than_raising():
     appraiser, _ = _appraiser([{"name": "chai", "confidence": "very"}])
     result = appraiser.appraise("some chai")
     assert result is not None and result["confidence"] == 1.0
+
+
+@pytest.mark.parametrize("nan_value", ["nan", "NaN", float("nan")])
+def test_nan_confidence_from_the_graph_never_reaches_a_spike(nan_value):
+    """L9 was filed as a missing NaN guard, but investigation showed the
+    existing clamp already closes it: `float("nan")` and a literal NaN both
+    parse successfully (the `except (TypeError, ValueError)` never catches
+    either), yet `max(0.0, min(1.0, confidence))` deterministically resolves
+    NaN to 1.0 in CPython - NaN compares False against everything, so
+    `min(1.0, nan)` always keeps the first (non-NaN) argument, and the outer
+    `max` does the same. Verified stable across 1000 runs before trusting it.
+    An explicit `math.isnan()` guard was written and found to be a genuine
+    no-op (mutation-tested: removing it did not make this test fail) - not
+    kept, since dead code claiming to guard something it cannot affect is
+    worse than no comment at all. This test stands as the regression guard
+    should that clamp ever change shape.
+    """
+    appraiser, _ = _appraiser([{"name": "chai", "confidence": nan_value}])
+    result = appraiser.appraise("some chai")
+    assert result is not None
+    assert not math.isnan(result["confidence"])
 
 
 # --------------------------------------------------------------------------

--- a/backend/tests/test_subconscious_consolidation.py
+++ b/backend/tests/test_subconscious_consolidation.py
@@ -265,3 +265,66 @@ async def test_subconscious_consolidation_pipeline(mock_llm_service, mock_graph_
             await mem_store.close()
         await store.close()
         Config.TESTING_CONSOLIDATION_BYPASS_SILENCE = orig_bypass
+
+
+@pytest.mark.asyncio
+async def test_consecutive_user_messages_are_never_attributed_to_the_wrong_speaker(
+    mock_graph_db,
+):
+    """Issue #174 claimed that a burst of consecutive user messages before a
+    single assistant reply makes the consolidation loop "misidentify message
+    roles". Traced the actual pairing logic in `_on_system_tick`: it checks
+    `chrono_episodes[i + 1].get("role") == "assistant"` explicitly before
+    pairing, rather than assuming alternating roles by index parity - so a
+    message's `speaker` field always comes from that message's own recorded
+    role, never from its position. This test proves that directly with a
+    three-user-messages-then-one-reply burst, the exact scenario the issue
+    describes. (The narrower, real observation - that only the last of the
+    three gets the assistant's reply attached, not all three - is a
+    defensible choice: attaching one reply to three separate reflection
+    episodes would triple-count a single exchange's relationship_delta and
+    fact extraction, arguably worse than the current behavior.)
+    """
+    mock_memory_store = MagicMock()
+    # DESC order (most-recent-first), matching get_recent_unconsolidated_episodes's
+    # real ORDER BY timestamp DESC.
+    mock_memory_store.get_recent_unconsolidated_episodes = AsyncMock(
+        return_value=[
+            {"id": "4", "role": "assistant", "content": "Got it, on all three!"},
+            {"id": "3", "role": "user", "content": "and dinner at 8"},
+            {"id": "2", "role": "user", "content": "also pick up the mail"},
+            {"id": "1", "role": "user", "content": "remind me to call mom"},
+        ]
+    )
+    mock_memory_store.mark_episodes_consolidated = AsyncMock()
+
+    mock_reflection_service = MagicMock()
+    mock_reflection_service.trigger_reflection = AsyncMock(return_value=None)
+
+    agent = SubconsciousAgent(
+        memory_store=mock_memory_store,
+        reflection_service=mock_reflection_service,
+        graph_db=mock_graph_db,
+    )
+    agent.state_service.current_state.last_user_interaction = time.time() - 301
+    agent.engine.evaluate_and_think = AsyncMock(return_value=None)
+
+    await agent._on_system_tick({"uptime": 100})
+
+    mock_reflection_service.trigger_reflection.assert_awaited_once()
+    (episodes,), _ = mock_reflection_service.trigger_reflection.call_args
+
+    by_id = {ep["id"]: ep for ep in episodes}
+    # Every episode's speaker must match who actually sent that message - the
+    # bug under test would show up as a "user" id carrying speaker="assistant"
+    # or vice versa.
+    assert by_id["1"]["speaker"] == "user"
+    assert by_id["1"]["event"] == "remind me to call mom"
+    assert by_id["2"]["speaker"] == "user"
+    assert by_id["2"]["event"] == "also pick up the mail"
+    assert by_id["3"]["speaker"] == "user"
+    assert by_id["3"]["event"] == "and dinner at 8"
+    # Only the message immediately preceding the reply gets it attached.
+    assert by_id["1"]["response"] == ""
+    assert by_id["2"]["response"] == ""
+    assert by_id["3"]["response"] == "Got it, on all three!"

--- a/backend/tests/test_transport_agent_inbound_audio.py
+++ b/backend/tests/test_transport_agent_inbound_audio.py
@@ -1,0 +1,125 @@
+"""
+#173: `_process_remote_audio` used to `await self.publish("audio.inbound",
+...)` directly inside LiveKit's `AudioStream` iteration loop. If NATS
+publishing stalls (network delay, JetStream backpressure), that await stalls
+right there, delaying every subsequent frame the WebRTC stack hands over.
+These tests cover the fix: capture is decoupled from publish via a bounded
+queue and a dedicated worker.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.agents.transport_agent import TransportAgent
+
+
+def _make_agent(queue_size: int = 4) -> TransportAgent:
+    with patch("app.agents.transport_agent.Config") as mock_config:
+        mock_config.NATS_URL = "nats://127.0.0.1:4222"
+        mock_config.LIVEKIT_URL = "ws://127.0.0.1:7880"
+        mock_config.LIVEKIT_API_KEY = "k"
+        mock_config.LIVEKIT_API_SECRET = "s"
+        mock_config.SAMPLE_RATE = 16000
+        mock_config.TRANSPORT_AUDIO_QUEUE_SIZE = queue_size
+        agent = TransportAgent()
+    return agent
+
+
+def _fake_frame_event(sample_rate=16000, channels=1, data=b"\x00\x01"):
+    frame = SimpleNamespace(data=data, sample_rate=sample_rate, num_channels=channels)
+    return SimpleNamespace(frame=frame)
+
+
+class _FakeAudioStream:
+    """Minimal async-iterable standing in for `rtc.AudioStream(track)`."""
+
+    def __init__(self, events):
+        self._events = list(events)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._events:
+            raise StopAsyncIteration
+        return self._events.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_capture_does_not_await_publish_directly():
+    """A blocked/slow `publish` must not stall frame capture - only enqueue,
+    never await the network call inline, is what makes this true."""
+    agent = _make_agent()
+    agent.publish = AsyncMock(side_effect=Exception("should never be called here"))
+
+    events = [_fake_frame_event() for _ in range(3)]
+    with patch("app.agents.transport_agent.rtc.AudioStream", return_value=_FakeAudioStream(events)):
+        await agent._process_remote_audio(track=SimpleNamespace(sid="track-1"))
+
+    agent.publish.assert_not_awaited()
+    assert agent.inbound_audio_queue.qsize() == 3
+
+
+@pytest.mark.asyncio
+async def test_queue_overflow_drops_the_oldest_frame_not_the_newest():
+    agent = _make_agent(queue_size=32)  # constructor floors below 32; override after
+    agent.inbound_audio_queue = asyncio.Queue(maxsize=2)
+
+    events = [
+        _fake_frame_event(data=b"first"),
+        _fake_frame_event(data=b"second"),
+        _fake_frame_event(data=b"third"),
+    ]
+    with patch("app.agents.transport_agent.rtc.AudioStream", return_value=_FakeAudioStream(events)):
+        await agent._process_remote_audio(track=SimpleNamespace(sid="track-1"))
+
+    assert agent.inbound_audio_queue.qsize() == 2
+    remaining = []
+    while not agent.inbound_audio_queue.empty():
+        data, _meta = agent.inbound_audio_queue.get_nowait()
+        remaining.append(data)
+    assert remaining == [b"second", b"third"]
+    assert agent.dropped_inbound_audio_frames == 1
+
+
+@pytest.mark.asyncio
+async def test_inbound_worker_drains_the_queue_and_publishes():
+    agent = _make_agent()
+    agent.publish = AsyncMock()
+
+    await agent.inbound_audio_queue.put((b"pcm-bytes", {"sample_rate": 16000}))
+
+    worker = asyncio.create_task(agent._inbound_audio_worker())
+    try:
+        await asyncio.wait_for(agent.inbound_audio_queue.join(), timeout=2.0)
+    finally:
+        worker.cancel()
+        try:
+            await worker
+        except Exception:
+            pass
+
+    agent.publish.assert_awaited_once_with(
+        "audio.inbound", b"pcm-bytes", metadata={"sample_rate": 16000}
+    )
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_the_inbound_worker_task():
+    agent = _make_agent()
+    agent.room = SimpleNamespace(disconnect=AsyncMock())
+    agent.nc = None
+
+    async def never_ending():
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(never_ending())
+    agent.inbound_audio_worker_task = task
+    agent.audio_worker_task = None
+
+    await agent.stop()
+
+    assert task.cancelled()

--- a/backend/tests/test_vision_links.py
+++ b/backend/tests/test_vision_links.py
@@ -48,6 +48,41 @@ def test_screen_link_still_works_normally_with_numpy_present():
     assert links_module.np is not None
 
 
+def test_screen_link_retries_display_discovery_after_going_headless():
+    """#169: once `headless=True`, ScreenLink used to never look for a
+    display again - a display attached after startup (or a headless
+    container later given one) left the agent blind for the process's
+    entire remaining life, unlike CameraLink, which already retried
+    `cv2.VideoCapture(0)` on every call.
+    """
+    with patch.object(links_module, "mss", MagicMock()) as mock_mss:
+        mock_mss.mss.side_effect = Exception("no display yet")
+
+        link = links_module.ScreenLink()
+        assert link.headless is True
+        assert link.capture_frame() is None
+
+        # Display becomes available; the next capture attempt (via the same
+        # public entry point the capture loop calls every tick) should
+        # recover without needing the agent to be restarted.
+        recovered_sct = MagicMock()
+        recovered_sct.monitors = [{}, {"width": 1920, "height": 1080}]
+        recovered_sct.grab.return_value = MagicMock()
+        mock_mss.mss.side_effect = None
+        mock_mss.mss.return_value = recovered_sct
+
+        with patch.object(links_module, "np") as mock_np, patch.object(
+            links_module, "cv2"
+        ) as mock_cv2:
+            mock_np.array.return_value = mock_np.array.return_value
+            mock_cv2.cvtColor.return_value = mock_cv2.cvtColor.return_value
+            mock_cv2.imencode.return_value = (True, MagicMock(tobytes=lambda: b"jpg"))
+            link.capture_frame()
+
+        assert link.headless is False
+        assert link.sct is recovered_sct
+
+
 def test_camera_link_releases_stale_handle_before_reopening():
     """M3: `_ensure_cap` used to reassign `self.cap` to a fresh
     `VideoCapture` whenever the existing one reported `isOpened() is False`,

--- a/backend/tests/test_working_memory_store.py
+++ b/backend/tests/test_working_memory_store.py
@@ -87,3 +87,26 @@ def test_clear_turns_empties_the_store(tmp_path):
 
     turns = asyncio.run(run())
     assert turns == []
+
+
+def test_sqlite_fallback_reuses_one_connection_across_calls(tmp_path):
+    """L2: every fallback method used to call `_get_sqlite_connection()`,
+    which opened a brand new `sqlite3.connect()` handle (and never explicitly
+    closed it - `sqlite3.Connection.__exit__` only commits/rolls back, it
+    doesn't close) on every single call. The store should open one connection
+    for its lifetime and hand back that same object every time.
+    """
+    store = _make_store(str(tmp_path / "working.db"))
+
+    async def run():
+        await store.add_turn(role="user", content="one")
+        conn_after_first_call = store._sqlite_conn
+        await store.add_turn(role="user", content="two")
+        await store.get_recent_turns()
+        await store.set_state_var("k", "v")
+        return conn_after_first_call
+
+    conn_after_first_call = asyncio.run(run())
+
+    assert conn_after_first_call is not None
+    assert store._sqlite_conn is conn_after_first_call

--- a/frontend/app/layout.js
+++ b/frontend/app/layout.js
@@ -3,6 +3,17 @@ import "./globals.css";
 export const metadata = {
   title: "AI Friend",
   description: "Sovereign AI Voice Mesh",
+  openGraph: {
+    title: "AI Friend",
+    description: "Sovereign AI Voice Mesh",
+    siteName: "AI Friend",
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "AI Friend",
+    description: "Sovereign AI Voice Mesh",
+  },
 };
 
 export default function RootLayout({ children }) {


### PR DESCRIPTION
## Summary
Stacked on #178 (still open) — this PR's diff will shrink to just this PR's own changes once #178 merges into `main`; will retarget to `main` at that point.

This PR grew across two triage batches (a branch-management mistake on my part — the second batch's commit landed on this branch instead of a new one; rather than force-push to split them, both are described honestly below).

**Batch 4 (P3 Low, #142-150):**
- Fixes L1/L2/L4/L5/L7/L8 — lazy debug logging, a leaking-not-just-redundant SQLite connection in `WorkingMemoryStore`'s fallback, OpenGraph/Twitter metadata, `Config` range validation, graceful `GraphDB.close()` draining, expanded ToM stop words.
- Closes #144, #150 (L3/L9) as false positives.
- Ran `gitleaks` against full git history for L6 — two false-positive findings, nothing to rotate.

**Batch 5 (Architecture/Production-Readiness, #151-175):**
- Fixes #153/#160/#169/#171/#172/#173 — SIGTERM handling across all six agent processes, a dead `LOG_JSON` config toggle, `ScreenLink` re-detection after going headless, a gitleaks CI job, replacing a full-graph-scan Cypher `rand()` with `apoc.coll.randomItems`, and a non-blocking inbound audio queue in `TransportAgent`.
- Closes #157/#163/#165/#166/#170/#175 as already resolved by prior work.
- Closes #174 as a false positive on its specific claim (traced and disproven by test).
- Twelve issues (#151/#152/#154/#155/#156/#158/#159/#161/#162/#164/#167/#168) deferred — large infra/design decisions or contradict this repo's documented single-family deployment model.

Full per-fix reasoning in the "2026-08-21 GitHub triage batch 4" and "batch 5" entries in `.agents/CONTEXT.md`.

## Test plan
- [x] Full backend suite via junit-xml: 941 passed, 0 failed/errored/skipped
- [x] `ruff check .` clean
- [x] Every new/changed test mutation-tested (fix reverted → test fails, fix restored → test passes)
- [x] `npm run build` and `npm run lint` clean on frontend
- [x] OpenGraph/Twitter tags confirmed present in served HTML via `curl`
- [x] SIGTERM handling verified with a real `os.kill(os.getpid(), signal.SIGTERM)` inside the test process

🤖 Generated with [Claude Code](https://claude.com/claude-code)