### PR TITLE
fix: add startup secret validation for placeholder credentials in production (#162)

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -6632,3 +6632,64 @@ exactly the test written for it).
   target entirely, not just relocate it) - see the #113 writeup above. A real,
   independent decision about removing a documented safety net, not something
   #113 was blocked on.
+
+## 2026-08-21 GitHub triage batch 7 (#162, narrowed) — 1 of 1 fixed (narrow scope), Vault/Docker-secrets integration still deferred
+
+**#162 — strict startup secret validation.** Batch 5 deferred this whole:
+"no `ENVIRONMENT`/production signal exists anywhere in `Config`...this needs
+the same missing-signal problem solved first, a design decision." Solving
+that signal turned out to be the entire narrow, decidable half of this issue
+- the other half (Vault/Docker-secrets-file integration) is a genuinely
+separate, larger scope and stays deferred, same split as #113/#152 in batch 6.
+
+Added `Config.ENVIRONMENT: str = "development"` (opt-in, so nothing about
+existing behavior changes until an operator sets it) and a `model_validator`
+that, only when `ENVIRONMENT == "production"`, checks `DATABASE_URL`,
+`NEO4J_PASSWORD`, `NEO4J_AUTH`, `LIVEKIT_API_KEY`, and `LIVEKIT_API_SECRET`
+against the literal placeholder strings this repo's own `.env.example` ships
+(`your_password_here`, `your_graph_password_here`, `your_api_key_here`,
+`your_api_secret_here`) and raises `ValueError` - which crashes the process
+at import time, since `config_instance = AppSettings()` runs at module load,
+satisfying the issue's "crash immediately" ask for free. Deliberately this
+narrow literal-string set rather than a generic weak-password heuristic - a
+heuristic strong enough to catch real weak passwords is also strong enough to
+false-positive on a legitimate secret that contains a common substring, and a
+false positive here means production refuses to boot. Scoped to the five
+fields that gate an actually-reachable service (Postgres/Neo4j auth, LiveKit
+room credentials); optional integrations (Gemini, ElevenLabs, Porcupine) are
+excluded, since a placeholder there disables a feature rather than exposing one.
+
+Wired `ENVIRONMENT=${ENVIRONMENT:-production}` into all six Python-based
+services in `docker-compose.prod.yml` (`brain_agent`, `system_agent`,
+`subconscious_agent`, `surfacing_agent`, `transport_agent`, `vision_agent` -
+the Rust `voice_agent`/`stt_agent` don't read this `Config`), defaulting to
+`production` there specifically because that compose file is only ever used
+for a production-shaped deployment (unlike `.env.example`'s own default,
+which stays `development` so copying it during initial local setup - the
+documented first step - doesn't crash before secrets are even filled in).
+Validated the combined `docker-compose.infra.yml` + `docker-compose.prod.yml`
+config resolves `ENVIRONMENT: production` correctly via `docker compose
+config` before committing. Documented the new var in the root `.env.example`.
+
+**Verified:** full backend suite - 966 passed (958 before this batch's 8 new
+tests), 0 failed. `ruff check .` clean. Mutation-tested by disabling the
+validator body and confirming all 5 parametrized placeholder-rejection tests
+fail, then restoring.
+
+**Also fixed in passing:** `frontend/prisma.config.ts`'s `import 'dotenv/
+config'` broke when batch 3 removed `dotenv` from `package.json` as an
+apparently-unused dependency - the "zero imports" check that justified the
+removal only grepped `.js`/`.jsx` source files and missed this `.ts` config
+file. Next.js's own dev/build process loads `.env` itself, but a bare `npx
+prisma validate`/`generate`/`migrate` doesn't, which is exactly what broke:
+a new "Prisma Schema & Identity Seed" CI check (not present when batch 3's
+PR ran, or path-filtered differently then - CLAUDE.md's own CI-gotchas note)
+surfaced it on this batch's PR. Restored `dotenv` to `devDependencies`
+(dev-tooling only, not part of the shipped app bundle, so `dependencies` was
+the wrong list even before removal).
+
+**NOT done, deferred:**
+- **#162's Vault/Docker-secrets-file (`/run/secrets/`) integration** - a real,
+  separate feature (a new loading path for credentials, plus a decision about
+  which secret backend this deployment is meant to target) rather than
+  something the placeholder check above was blocked on.

--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,14 @@
 # DO NOT COMMIT the real `.env` files.
 # -----------------------------------------------------------------------------
 
+# Set to "production" once every secret below has been changed from its
+# placeholder value (#162). Doing so activates a startup check that refuses to
+# boot if DATABASE_URL, NEO4J_PASSWORD, NEO4J_AUTH, LIVEKIT_API_KEY, or
+# LIVEKIT_API_SECRET still contain the literal placeholder text this file
+# ships with -- the exact failure mode of copying this file and forgetting to
+# edit it. Leave unset ("development") for local/dev use; the check never runs.
+ENVIRONMENT=development
+
 # LiveKit (WebRTC SFU)
 LIVEKIT_API_KEY=your_api_key_here
 LIVEKIT_API_SECRET=your_api_secret_here

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -12,6 +12,15 @@ class AppSettings(BaseSettings):
     )
 
     DEBUG: bool = False
+    # #162: the one signal `validate_no_placeholder_secrets_in_production`
+    # gates on. Deliberately not derived from `DEBUG` (which defaults False in
+    # every CI run and most local dev sessions too, so gating on it would fire
+    # the placeholder check constantly where it shouldn't) or from `DATABASE_
+    # URL`'s shape (which says nothing about whether this deployment is meant
+    # to be reachable by anyone but its operator). Unset -- the default --
+    # means the check never runs, so nothing about existing behavior changes
+    # until an operator explicitly opts in.
+    ENVIRONMENT: str = "development"
     # #160: `main.py` already reads this via `getattr(Config, "LOG_JSON",
     # False)` to pick JSON vs plain-text logging, but the field was never
     # actually declared here - `extra="ignore"` meant setting LOG_JSON=true
@@ -241,6 +250,49 @@ class AppSettings(BaseSettings):
                 raise ValueError(f"{name} must be >= 1 (got {value!r})")
         if not (0 < self.QDRANT_PORT <= 65535):
             raise ValueError(f"QDRANT_PORT must be a valid port (got {self.QDRANT_PORT!r})")
+        return self
+
+    # #162: the literal placeholder strings this repo's own `.env.example`
+    # ships. Deliberately this narrow set, not a generic "looks like a weak
+    # password" heuristic -- a heuristic strong enough to catch real weak
+    # passwords is also strong enough to reject a legitimate one that happens
+    # to contain a common word, and a false positive here means production
+    # refuses to boot. This only catches the exact templates a deployment gets
+    # by copying `.env.example` and forgetting to edit it, which is the
+    # failure mode the issue describes.
+    _PLACEHOLDER_SECRET_MARKERS = (
+        "your_password_here",
+        "your_graph_password_here",
+        "your_api_key_here",
+        "your_api_secret_here",
+    )
+    # Only the fields that gate a real, network-reachable service if left at
+    # the shipped placeholder -- Postgres/Neo4j auth and the LiveKit room
+    # credentials. Optional integrations (Gemini, ElevenLabs, Porcupine) are
+    # deliberately excluded: a placeholder there disables a feature, it
+    # doesn't expose one.
+    _SECRET_BEARING_FIELDS = (
+        "DATABASE_URL",
+        "NEO4J_PASSWORD",
+        "NEO4J_AUTH",
+        "LIVEKIT_API_KEY",
+        "LIVEKIT_API_SECRET",
+    )
+
+    @model_validator(mode="after")
+    def validate_no_placeholder_secrets_in_production(self):
+        if self.ENVIRONMENT != "production":
+            return self
+        for name in self._SECRET_BEARING_FIELDS:
+            value = getattr(self, name, None)
+            if not value:
+                continue
+            if any(marker in value for marker in self._PLACEHOLDER_SECRET_MARKERS):
+                raise ValueError(
+                    f"{name} still contains a placeholder value from .env.example "
+                    "-- refusing to start with ENVIRONMENT=production. Set a real "
+                    "secret before deploying."
+                )
         return self
 
     @model_validator(mode="after")

--- a/backend/tests/test_config_validation.py
+++ b/backend/tests/test_config_validation.py
@@ -92,3 +92,53 @@ def test_log_json_env_var_actually_reaches_the_setting(monkeypatch):
     monkeypatch.setenv("LOG_JSON", "true")
     settings = AppSettings(_env_file=None)
     assert settings.LOG_JSON is True
+
+
+# --- #162: placeholder-secret guard in production --------------------------
+
+
+@pytest.mark.parametrize(
+    "field,placeholder",
+    [
+        ("DATABASE_URL", "postgresql://ai_friend:your_password_here@127.0.0.1:5432/db"),
+        ("NEO4J_PASSWORD", "your_graph_password_here"),
+        ("NEO4J_AUTH", "neo4j/your_graph_password_here"),
+        ("LIVEKIT_API_KEY", "your_api_key_here"),
+        ("LIVEKIT_API_SECRET", "your_api_secret_here"),
+    ],
+)
+def test_placeholder_secret_rejected_in_production(field, placeholder):
+    """The exact failure mode #162 describes: copying .env.example and
+    deploying without editing it. If this stops firing, a deployment can boot
+    with Postgres/Neo4j/LiveKit auth set to a publicly-known default."""
+    with pytest.raises(ValidationError):
+        _settings(ENVIRONMENT="production", **{field: placeholder})
+
+
+def test_placeholder_secret_allowed_outside_production():
+    """The guard must not fire for local/dev use, where copying .env.example
+    verbatim before filling in real secrets is the documented first step."""
+    settings = _settings(
+        ENVIRONMENT="development", NEO4J_PASSWORD="your_graph_password_here"
+    )
+    assert settings.NEO4J_PASSWORD == "your_graph_password_here"
+
+
+def test_real_looking_secret_allowed_in_production():
+    """A genuine secret must never be rejected just for existing - only the
+    literal shipped placeholder strings are checked."""
+    settings = _settings(
+        ENVIRONMENT="production",
+        NEO4J_PASSWORD="a-real-generated-secret-x9k2m",
+        LIVEKIT_API_KEY="APIabc123real",
+        LIVEKIT_API_SECRET="a-real-secret-value",
+        DATABASE_URL="postgresql://ai_friend:a-real-secret-value@postgres_db:5432/db",
+    )
+    assert settings.NEO4J_PASSWORD == "a-real-generated-secret-x9k2m"
+
+
+def test_unset_secret_fields_do_not_crash_production():
+    """A field an operator hasn't configured at all (None) must not be
+    treated as a placeholder - only an actual placeholder string should."""
+    settings = _settings(ENVIRONMENT="production")
+    assert settings.ENVIRONMENT == "production"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,6 +18,7 @@ services:
     container_name: brain_agent
     command: [ "python", "-m", "app.agents.brain_agent" ]
     environment:
+      - ENVIRONMENT=${ENVIRONMENT:-production}  # #162: refuses to boot with placeholder secrets
       - NATS_URL=nats://nats_mesh:4222
       - OLLAMA_URL=${OLLAMA_URL:-http://local_brain:11434}
       - LLM_FAST_MODEL=${LLM_FAST_MODEL:-llama3.2:3b}
@@ -87,6 +88,7 @@ services:
     container_name: system_agent
     command: [ "python", "-m", "app.agents.system_agent" ]
     environment:
+      - ENVIRONMENT=${ENVIRONMENT:-production}  # #162: refuses to boot with placeholder secrets
       - NATS_URL=nats://nats_mesh:4222
       - SYSTEM_TICK_INTERVAL=${SYSTEM_TICK_INTERVAL:-60}
     networks:
@@ -109,6 +111,7 @@ services:
     container_name: subconscious_agent
     command: [ "python", "-m", "app.agents.subconscious_agent" ]
     environment:
+      - ENVIRONMENT=${ENVIRONMENT:-production}  # #162: refuses to boot with placeholder secrets
       - NATS_URL=nats://nats_mesh:4222
       - OLLAMA_URL=${OLLAMA_URL:-http://local_brain:11434}
       - DATABASE_URL=postgresql://ai_friend:${POSTGRES_PASSWORD}@postgres_db:5432/ai_friend_db
@@ -153,6 +156,7 @@ services:
     container_name: surfacing_agent
     command: [ "python", "-m", "app.agents.surfacing_agent" ]
     environment:
+      - ENVIRONMENT=${ENVIRONMENT:-production}  # #162: refuses to boot with placeholder secrets
       - NATS_URL=nats://nats_mesh:4222
       - OLLAMA_URL=${OLLAMA_URL:-http://local_brain:11434}
       - DATABASE_URL=postgresql://ai_friend:${POSTGRES_PASSWORD}@postgres_db:5432/ai_friend_db
@@ -224,6 +228,7 @@ services:
     container_name: transport_agent
     command: [ "python", "-m", "app.agents.transport_agent" ]
     environment:
+      - ENVIRONMENT=${ENVIRONMENT:-production}  # #162: refuses to boot with placeholder secrets
       - NATS_URL=nats://nats_mesh:4222
       - LIVEKIT_URL=ws://local_sfu:7880
       - LIVEKIT_API_KEY=${LIVEKIT_API_KEY}
@@ -344,6 +349,7 @@ services:
     command: [ "python", "-m", "app.vision.agent" ]
     env_file: .env
     environment:
+      - ENVIRONMENT=${ENVIRONMENT:-production}  # #162: refuses to boot with placeholder secrets
       - AGENT_NAME=vision_agent
       - NATS_URL=nats://nats_mesh:4222
       - OLLAMA_URL=${OLLAMA_URL}


### PR DESCRIPTION
## Summary

Stacked on #180 (not yet merged) — same triage session, next batch. Narrows issue #162 down to its actually-decidable half, following the same split pattern #113/#152 used in #180.

Batch 5 deferred #162 entirely: *"no `ENVIRONMENT`/production signal exists anywhere in `Config`... this needs the same missing-signal problem solved first, a design decision."* Adding that signal turned out to be the whole narrow, safely-implementable part of this issue.

- New `Config.ENVIRONMENT: str = "development"` — opt-in, so nothing about existing behavior changes until an operator sets it.
- New validator: with `ENVIRONMENT=production`, refuses to start if `DATABASE_URL`, `NEO4J_PASSWORD`, `NEO4J_AUTH`, `LIVEKIT_API_KEY`, or `LIVEKIT_API_SECRET` still contain the literal placeholder strings `.env.example` ships (`your_password_here`, etc.) — the exact failure mode of copying that file and deploying without editing it.
- Deliberately a narrow literal-string check, not a generic weak-password heuristic — a heuristic strong enough to catch real weak passwords is also strong enough to false-positive on a legitimate secret, and a false positive here means production refuses to boot.
- Wired `ENVIRONMENT=${ENVIRONMENT:-production}` into all six Python-based services in `docker-compose.prod.yml` (the two Rust services don't read this `Config`). Validated the combined `docker-compose.infra.yml` + `docker-compose.prod.yml` resolves correctly via `docker compose config`.
- Documented the new var in `.env.example`.

**Still deferred:** Vault/Docker-secrets-file (`/run/secrets/`) integration — a real, separate feature needing its own backend-target decision, not something the validator above was blocked on.

**Also fixed in passing:** unrelated regression found via this branch's CI — `dotenv` was dropped from `frontend/package.json` in an earlier batch's "unused dependency" cleanup, but `prisma.config.ts` still imports it for standalone `npx prisma` CLI commands (Next.js's own dev/build process loads `.env` itself; bare prisma commands don't). That fix landed as its own commit on #180 directly, since it broke that PR's own CI.

## Test plan
- [x] Full backend suite: 966 passed, 0 failed/errored/skipped
- [x] `ruff check .` clean
- [x] New validator mutation-tested: disabled it, confirmed all 5 parametrized placeholder-rejection tests fail, restored
- [x] `docker compose -f docker-compose.infra.yml -f docker-compose.prod.yml config` resolves `ENVIRONMENT: production` correctly for all six services

🤖 Generated with [Claude Code](https://claude.com/claude-code)