### PR TITLE
fix: HSTS security headers + TTS cold-start warmup (#155, #165)

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -6693,3 +6693,88 @@ the wrong list even before removal).
   separate feature (a new loading path for credentials, plus a decision about
   which secret backend this deployment is meant to target) rather than
   something the placeholder check above was blocked on.
+
+## 2026-08-21 GitHub triage: #151/#152 closed as already-resolved, batch 8 (#155, #165) — 2 of 2 fixed
+
+**#151 and #152 closed without new code.** Before starting batch 8, checked
+whether either of batch 6's two 12-Factor architecture issues still applied
+now that #117/#118/#113 were merged. Both had described the exact failure
+modes #180 already fixed: #151 (Factor VI, process statelessness) wanted
+`ReappraisalEngine`/`DecisionService` weights surviving a restart, which
+`AdaptiveWeightsStore` + `hydrate()` now do; #152 (Factor V, build/release
+separation) wanted persona writes off git-tracked seed files, which
+`IdentityManager`'s copy-on-first-boot + `agent_configs`-is-the-authority
+`save()` now does. Closed both with the reasoning on the issue rather than
+leaving them open as duplicates of already-shipped work. One deliberate
+non-match: #151 asked for Postgres/Redis specifically, for share-nothing
+horizontal scaling; `AdaptiveWeightsStore` is SQLite-backed, matching the
+codebase's existing dual-backend convention. That gap is real but moot for
+this deployment target (single instance per family, not horizontally
+scaled - see hardware/deployment notes), so it wasn't worth blocking the
+close on.
+
+**#155 — HSTS.** Scoped down from the issue's full ask (HTTPS/WSS redirect +
+HSTS) to the header half only. TLS termination itself - whether port 443
+exists at all - is a reverse-proxy/load-balancer decision this repo has no
+component for (checked: no nginx/traefik/certbot anywhere in either compose
+file), so an app-level HTTP-to-HTTPS redirect would assume an architecture
+that doesn't exist here; same shape of narrowing as #162's Vault half.
+Added a `Strict-Transport-Security: max-age=31536000; includeSubDomains`
+response header: backend (`main.py`) gates it on `Config.ENVIRONMENT ==
+"production"` (the signal #162 introduced) via `@app.middleware("http")`,
+registered at import time so it either exists for the process's whole
+lifetime or not at all; frontend (`next.config.mjs`) adds it unconditionally
+alongside the existing CSP header, since HSTS is inert until a browser
+receives it over an actual HTTPS response, so serving it in local HTTP dev
+is a no-op rather than a lie.
+
+**#165 — TTS cold-start warmup.** The Rust `voice-agent` already had a
+periodic background `probe_synthesis` call (`TTS_READINESS_PROBE_INTERVAL_
+SECS`, default 45s) that happens to fire immediately on its first tick
+(`tokio::time::interval`'s documented behavior) - but as a fire-and-forget
+spawned task, not awaited, so the main `CHAT_OUTPUT` subscriber loop could
+start consuming (and a real utterance could arrive) before that first probe
+finished loading tensors into VRAM. Added one *awaited* `probe_synthesis`
+call in `main()` right before the subscriber loop starts, gated on the same
+`TTS_READINESS_PROBE_INTERVAL_SECS != 0` signal that disables the periodic
+probe (so local dev against a mock/absent SoVITS server isn't blocked on a
+synthesis call that can never succeed) and non-fatal on failure (logs a
+warning, starts serving anyway - matching the existing probe's own
+failure handling rather than crashing startup on a transient TTS outage).
+NATS messages published to `CHAT_OUTPUT` before the subscriber loop starts
+still queue in the JetStream/core-NATS subscription buffer created earlier
+in `main()`, so this doesn't drop anything - it only delays when the loop
+starts pulling from it.
+
+**Verified:** full backend suite - 970 passed (968 before this batch's 2 new
+tests), 0 failed. `ruff check .` clean. `cargo check --manifest-path
+crates/voice-agent/Cargo.toml` clean; existing `probe_synthesis` unit tests
+(`probe_succeeds_when_real_audio_bytes_come_back`,
+`probe_fails_on_empty_response_body_not_just_bad_status`) still pass
+unchanged - the new call reuses that same function, so its correctness is
+already covered; the `main()`-level sequencing/gating is a few inlined
+lines matching the existing `spawn_readiness_probe` gate's shape and isn't
+independently unit-testable without a live NATS connection, same as that
+existing code. Mutation-tested the new Python test
+(`test_security_headers.py`) by replacing the `if Config.ENVIRONMENT ==
+"production":` guard with `if False:` and confirming
+`test_hsts_header_present_in_production` fails, then restoring. Rust
+toolchain note: `cargo` isn't on `PATH` in this environment even though
+`rustup` reports it installed - resolved by prefixing
+`$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin` onto `PATH`
+for this session; a bare `cargo check` at the workspace root fails with
+"could not execute process `rustc -vV`" until that's done.
+
+**NOT done, deferred (unchanged from prior batches, still legitimate):**
+- #138, #139 (frontend-only, need a browser to verify visually)
+- #154 (accessibility, needs a screen reader to verify)
+- #156, #159, #167, #168 (each a standalone infra/observability/testing
+  project, not a narrow bug)
+- #158 (Alembic migration governance - large, mechanical, but a real
+  multi-file scaffolding project rather than a bounded fix; a candidate for
+  its own dedicated batch rather than folding in here)
+- #161 (LiveKit STUN/TURN - needs a real public IP / TURN credential to
+  configure against, not decidable from code alone)
+- #164 (multi-tenancy - contradicts the documented single-family deployment
+  model; would need an explicit product-direction decision first)
+- #162's Vault/Docker-secrets-file integration (already noted in batch 7)

--- a/backend/crates/voice-agent/src/main.rs
+++ b/backend/crates/voice-agent/src/main.rs
@@ -650,6 +650,22 @@ async fn main() -> Result<()> {
     });
 
 
+    // #165: block audio ingress until one full synthesis pass has completed, so
+    // the model's weights are already resident in VRAM before the first real
+    // utterance arrives — otherwise that utterance pays the 2-4s cold-start
+    // tensor-load cost itself, before the periodic background probe above (which
+    // only starts amortizing it on some later tick) ever gets a chance to.
+    // Skipped under the same signal that disables the periodic probe
+    // (TTS_READINESS_PROBE_INTERVAL_SECS=0) — local dev against a mock or
+    // absent SoVITS server should not have startup blocked on a synthesis call
+    // that can never succeed.
+    if env_or("TTS_READINESS_PROBE_INTERVAL_SECS", "45").parse().unwrap_or(45u64) > 0 {
+        match probe_synthesis(&config, &http).await {
+            Ok(()) => info!("TTS warmup pass complete"),
+            Err(e) => warn!("TTS warmup pass failed, continuing startup anyway: {e:#}"),
+        }
+    }
+
     info!("rust voice-agent subscribed to {}", topics::CHAT_OUTPUT);
 
     let mut ola_filter = OlaCrossfadeFilter::new(config.sample_rate);

--- a/backend/main.py
+++ b/backend/main.py
@@ -206,6 +206,24 @@ app.add_middleware(
 )
 
 
+# #155: HSTS tells a browser to upgrade this origin to HTTPS on every future
+# visit, but is only safe to promise once TLS is actually terminated in front
+# of this process — gated on ENVIRONMENT=production (the same signal #162
+# added) rather than always-on, so local/LAN HTTP development is untouched.
+# TLS termination itself (the reverse proxy / load balancer that decides
+# whether port 443 exists at all) is deployment-specific infra, not something
+# this process can configure for itself, and stays out of scope here.
+if Config.ENVIRONMENT == "production":
+
+    @app.middleware("http")
+    async def add_hsts_header(request: Request, call_next):
+        response = await call_next(request)
+        response.headers["Strict-Transport-Security"] = (
+            "max-age=31536000; includeSubDomains"
+        )
+        return response
+
+
 @app.get("/")
 async def root():
     return {

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -1,0 +1,45 @@
+"""
+#155: the backend must promise HSTS to browsers once it is actually running
+behind TLS (ENVIRONMENT=production), but never in local/LAN HTTP development,
+where advertising HSTS would be a lie the browser then remembers for a year.
+
+The middleware is registered at module import time (`if Config.ENVIRONMENT ==
+"production":` at the top level of main.py), so flipping the setting after
+import has no effect on an already-built FastAPI app -- these tests reload
+`main` under each setting to observe the registration decision itself.
+"""
+
+import importlib
+
+from fastapi.testclient import TestClient
+
+from app import config as config_module
+
+
+def _import_main_with_environment(monkeypatch, environment: str):
+    monkeypatch.setattr(config_module.config_instance, "ENVIRONMENT", environment)
+    import main
+
+    importlib.reload(main)
+    return main
+
+
+def test_hsts_header_present_in_production(monkeypatch):
+    main = _import_main_with_environment(monkeypatch, "production")
+    client = TestClient(main.app)
+
+    response = client.get("/")
+
+    assert (
+        response.headers.get("strict-transport-security")
+        == "max-age=31536000; includeSubDomains"
+    )
+
+
+def test_hsts_header_absent_outside_production(monkeypatch):
+    main = _import_main_with_environment(monkeypatch, "development")
+    client = TestClient(main.app)
+
+    response = client.get("/")
+
+    assert "strict-transport-security" not in response.headers

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -28,10 +28,20 @@ const nextConfig = {
   reactCompiler: true,
   output: 'standalone',
   async headers() {
+    // #155: HSTS is safe to ship unconditionally from Next's own headers()
+    // (unlike the backend's, this isn't gated on an environment flag) because
+    // a browser only honors it after receiving it over an HTTPS response in
+    // the first place — serving it over plain HTTP in local dev is a no-op.
     return [
       {
         source: '/(.*)',
-        headers: [{ key: 'Content-Security-Policy', value: CSP }],
+        headers: [
+          { key: 'Content-Security-Policy', value: CSP },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=31536000; includeSubDomains',
+          },
+        ],
       },
     ];
   },


### PR DESCRIPTION
## Summary
- **#155** (narrowed): backend emits `Strict-Transport-Security` when `ENVIRONMENT=production`; frontend emits it unconditionally (inert until served over real HTTPS). TLS termination / HTTP→HTTPS redirect is out of scope — no reverse proxy component exists in this repo to own that, same shape of narrowing as #162's Vault half.
- **#165**: `voice-agent` now awaits one synthesis warmup pass before its `CHAT_OUTPUT` subscriber loop starts consuming, so the first real utterance doesn't pay the cold VRAM-load cost. Gated on the same `TTS_READINESS_PROBE_INTERVAL_SECS != 0` signal that disables the existing periodic probe; non-fatal on failure.
- Closes **#151** and **#152** as already resolved by #180 (verified against current code before closing, not just recalled from an old triage).

## Test plan
- [x] `pytest` — 970 passed, 0 failed
- [x] `ruff check .` — clean
- [x] `cargo check --manifest-path crates/voice-agent/Cargo.toml` — clean
- [x] New `test_security_headers.py` mutation-tested (guard replaced with `if False:`, confirmed failure, restored)
- [x] Existing `probe_synthesis` unit tests unaffected

Full writeup in `.agents/CONTEXT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)