### PR TITLE
fix: remove committed LiveKit credential, bind infra ports to loopback (P0-1, P0-2)

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -6778,3 +6778,94 @@ for this session; a bare `cargo check` at the workspace root fails with
 - #164 (multi-tenancy - contradicts the documented single-family deployment
   model; would need an explicit product-direction decision first)
 - #162's Vault/Docker-secrets-file integration (already noted in batch 7)
+
+## 2026-08-22 -- audit/ implementation, Stage 0 (P0-1, P0-2) -- LiveKit credential removed, all infra ports bound to loopback
+
+A forensic audit (`audit/`, untracked -- see AUDIT.md) filed 101 findings and
+ranked them P0-P4. This is the first implementation batch: the two P0 items,
+both security, both with zero prerequisites.
+
+**P0-1 -- the audit's own finding needed correcting before fixing it.** The
+audit assumed `livekit.yaml`'s committed `keys: {devkey: secretsecretsecret}`
+was the live signing credential. It wasn't (or at least, isn't now): compose
+passes `LIVEKIT_KEYS=${LIVEKIT_KEYS}` into the container as an env var, and
+the operator's `.env` holds a distinct real key/secret pair, not the
+committed one. So the fix isn't rotation, it's deletion -- the block can only
+ever have been redundant with or shadowed by the env var. Removed the `keys:`
+block from `livekit.yaml` entirely; a comment in its place explains why.
+Extended `AppSettings._PLACEHOLDER_SECRET_MARKERS` (config.py) with
+`"devkey"` and `"secretsecretsecret"` so the existing production boot guard
+(#162) also refuses to start if either value ever lands in
+`LIVEKIT_API_KEY`/`LIVEKIT_API_SECRET` -- e.g. from an `.env` copied forward
+from before this fix. Added two parametrized cases to the existing
+`test_placeholder_secret_rejected_in_production` in
+`test_config_validation.py` rather than a new test function, since the
+guard's existing test already states exactly the property being extended.
+
+Added a fourth pattern to `security-audit.yml`'s `credential-scan` job:
+fail on any tracked YAML with an inline `keys:` mapping. This is the actual
+gap that let the original value ship undetected -- gitleaks' entropy rules
+don't fire on a low-entropy, placeholder-shaped string like
+`secretsecretsecret`, and the hand-rolled regex-based scan only walks
+`.py`/`.js`/`.ts`/`.tsx` under `backend/`/`frontend/app/`/`frontend/
+components/`, never touching `livekit.yaml` at the repo root. Verified the
+new check against a scratch file reproducing the original block: it fires
+(non-zero exit). Confirmed no other tracked YAML in the repo has a `keys:`
+block, so the new check adds zero false positives today.
+
+**Not done as part of P0-1, deliberately:** whether livekit-server *merges*
+a config-file `keys:` block with `LIVEKIT_KEYS` or the env var fully
+replaces it is still unconfirmed -- LiveKit's public docs don't state the
+precedence, and it wasn't worth guessing rather than checking. The fix
+(remove the block) is correct under either reading, so this doesn't block
+the fix, only the question of whether the committed value was ever
+*live*. Verifying that needs a running LiveKit container (Docker was down
+this session): mint a token signed with `devkey`/`secretsecretsecret`
+against the server post-fix and confirm it's rejected. If it isn't, the
+value was live and both `.env` and `frontend/.env.local` need a fresh
+LiveKit key pair immediately.
+
+**P0-2 -- all nine `docker-compose.infra.yml` services were reachable from
+the LAN.** Every `ports:` mapping (nats, postgres, neo4j, redis, livekit,
+ollama, gpt-sovits, qdrant -- 16 host bindings total) defaulted to `0.0.0.0`,
+including the LiveKit SFU, which has no authentication of its own and
+combined with P0-1's exposure meant any device on the network could join a
+live voice session. Prefixed every one with `127.0.0.1:`. The maintainer's
+answer (this session): single-host personal/family deployment, no reverse
+proxy, so nothing needs LAN reach -- a comment at the top of the compose
+file records the answer and what to do if that ever changes (narrow the
+binding back on the one service that needs it, don't revert the file).
+`docker-compose.prod.yml` (the agent containers) was already un-published --
+confirmed no `ports:` block exists there at all, so nothing to change.
+
+Added a CI lint to `mesh-integrity.yml`'s existing `compose-validation` job:
+fail if either compose file has a port mapping not prefixed `127.0.0.1:`
+and not carrying a `# lan-exposed: <reason>` annotation. Verified it passes
+clean against the fixed files and (by construction, matching the grep by
+hand) would have failed against the pre-fix ones.
+
+Left `backend/app/config.py`'s `BACKEND_BIND_HOST` (defaults `0.0.0.0`)
+untouched -- that's a different, already-deliberate decision (finding C4,
+`test_audit_hygiene.py`), explicitly kept configurable rather than
+hardcoded, with its own test pinning the `0.0.0.0` default for backward
+compatibility. P0-2 is scoped to the *infra* compose file's nine
+containerized services; the backend API isn't one of them in either compose
+file (no `ports:` for it in `docker-compose.prod.yml`), so this batch
+doesn't touch it.
+
+**Verified:** `backend/tests/test_config_validation.py` +
+`test_audit_hygiene.py`, 38 passed / 0 failed (via `--junit-xml`, per this
+file's own documented pytest-summary-swallowing gotcha -- reproduced again
+this session). `ruff check .` clean. `python -c "import yaml;
+yaml.safe_load(...)"` on all four edited YAML/compose files. `docker
+compose -f docker-compose.infra.yml config --quiet` and the combined
+`-f docker-compose.infra.yml -f docker-compose.prod.yml` form both clean.
+Mutation-tested the new CI grep steps by hand against a scratch fixture
+reproducing each original defect (an inline `keys:` block; an unbound port
+mapping) -- both fire.
+
+**NOT done:**
+- The `devkey` live/dead verification above -- needs Docker, which was down
+  this session.
+- Stages 1-6 of the roadmap sequence (`audit/ROADMAP.md` §7) -- this batch
+  is Stage 0 only.

--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -6869,3 +6869,104 @@ mapping) -- both fire.
   this session.
 - Stages 1-6 of the roadmap sequence (`audit/ROADMAP.md` §7) -- this batch
   is Stage 0 only.
+
+## 2026-08-22 -- audit/ implementation, Stage 0 review pass -- both new CI checks were inverted; placeholder guard narrowed
+
+Both CI steps added in the batch above failed on their own PR, and the
+failure was more interesting than a typo.
+
+**Both new checks passed only when the repository was broken.** GitHub
+Actions runs `run:` blocks under `bash -e`. A simple assignment
+`var=$(cmd)` takes the command's exit status as its own, and `grep` exits
+1 when it matches nothing -- so `exposed=$(grep ... | grep -v ...)` aborted
+the step the moment every port was correctly loopback-bound. Same for the
+`keys:` scan. The steps were exactly inverted: green required a violation,
+which they would then never get far enough to report. Both now end the
+substitution with `|| true`. Worth recording as a class, not an incident:
+any `set -e` shell check that greps for the *absence* of something has
+this failure mode, and it is invisible in local testing unless `-e` is
+reproduced, because an interactive shell doesn't abort.
+
+Mutation-tested in both directions, which is what distinguishes a working
+check from a check that merely exits 0: re-added a `keys:` block to
+`livekit.yaml` and un-prefixed one port mapping in
+`docker-compose.infra.yml`, confirmed each is caught and named, reverted,
+confirmed clean.
+
+**The placeholder-secret guard was widened by accident.**
+`_PLACEHOLDER_SECRET_MARKERS` is matched as a substring, which the
+surrounding comment justifies at length: the set is deliberately the exact
+`.env.example` template strings, not a weak-password heuristic, because "a
+heuristic strong enough to catch real weak passwords is also strong enough
+to reject a legitimate one," and a false positive here means production
+refuses to boot. Adding `"devkey"` to that tuple quietly broke the
+premise -- it is six characters, so a randomly generated credential
+containing those letters would block a deployment with a misleading
+"placeholder" error. Split into `_PLACEHOLDER_SECRET_EXACT`, matched
+whole. The `.env.example` templates keep substring matching, which they
+genuinely need since `DATABASE_URL` embeds one mid-string. Test added for
+the false-positive direction and mutation-tested against a reverted-to-
+substring implementation.
+
+**Verified:** `test_config_validation.py` 27/27; full backend suite and
+`ruff check .` clean on this branch.
+
+**Addendum, found while opening the PR: a test fixture can trip gitleaks
+even with no real secret involved.** The first version of the false-
+positive test above used two short alphanumeric strings mixing case and
+digits (chosen to prove a credential merely *containing* "devkey" isn't
+rejected) as the LIVEKIT_API_KEY/SECRET values. Gitleaks' `generic-api-key`
+rule scores on Shannon entropy, not on whether the string is real, and
+flagged both as leaks -- CI red on a PR with no actual secret in it.
+(Deliberately not quoting the actual values here: gitleaks scans this
+ledger file too, and the first draft of this very paragraph tripped the
+same rule by quoting one.)
+Worse: because gitleaks scans the full pushed history, not just the
+current tree, a *second* commit correcting the fixture to a low-entropy,
+obviously-fake string (`"livekit-api-key-with-devkey-inside"`) did not
+clear the finding -- the original high-entropy version was still reachable
+in the earlier commit's diff. Fixing it required folding the correction
+into the original commit (`git reset --soft` to before it, recommit) rather
+than adding a commit on top -- a commit-on-top does not remove a finding
+that lives in an earlier commit's diff, only in the tree's current state.
+**The rule to carry forward: a test needing a
+credential-shaped value must pick one that is unmistakably a fixture in
+both name and shape** -- CLAUDE.md already documents the name half
+(don't call a variable `secret`); entropy is the other half, and it applies
+even to values that never leave the repository.
+
+**NOT done:**
+- Still no Docker-based verification that livekit-server rejects
+  `devkey`/`secretsecretsecret` -- the one open question from Stage 0, and
+  the only thing that would turn "remove the block" into "rotate the
+  pair." Unchanged by this review pass.
+
+## 2026-08-22 -- process note: `git add -A` swept the untracked `audit/` deliverables into a public commit
+
+Not a code change; recorded because it is exactly the kind of mistake that
+repeats without a written trace. Committing a review fix on this branch
+used `git add -A`, which staged not just the intended files but the
+untracked `AUDIT.md` and all 12 `audit/*.md` deliverables the earlier
+implementation-phase decision had deliberately left untracked (kept
+visible in `git status` as a standing reminder, no `.gitignore` entry).
+That commit was pushed to the public repo and appeared in the open PR's
+file list before being caught in the next review pass.
+
+No credentials were in the exposed files -- the content was the audit
+findings themselves plus a local filesystem path, not a secret -- but
+publishing an internal engineering audit of a public repo's own security
+posture is a real exposure regardless. Remediated the same way as the
+gitleaks-entropy issue in the entry above: a forward removal commit does
+not clear a finding that lives in an earlier commit's diff, so the fix was
+`git reset --soft` to the commit before the accidental one, followed by a
+force-push of the corrected history. The rewritten commit is fetchable by
+its old SHA via GitHub's API indefinitely (standard GitHub behavior for
+force-pushed commits, not specific to this incident) but is unreachable
+from any branch, PR, or normal browsing path.
+
+**The rule to carry forward:** never use `git add -A` in a repo with
+deliberately-untracked working files. Stage paths explicitly, always, on
+every branch of this repo -- this is a project-wide habit change, not a
+one-branch fix, since the same untracked `audit/` directory persists in
+every future working tree until it is either finished with or the
+maintainer decides otherwise.

--- a/.github/workflows/mesh-integrity.yml
+++ b/.github/workflows/mesh-integrity.yml
@@ -55,6 +55,21 @@ jobs:
       - name: Validate Unified Phased Startup (Infra + Agents)
         run: docker compose -f docker-compose.infra.yml -f docker-compose.prod.yml config --quiet
 
+      - name: Check no service publishes off loopback (P0-2)
+        # audit/ (M4-S3, M4-S8) found every infra service bound to 0.0.0.0 by
+        # default, including the unauthenticated LiveKit SFU -- reachable by
+        # anything on the LAN. Every host port mapping must be prefixed
+        # 127.0.0.1: unless the line carries a "# lan-exposed: <reason>"
+        # annotation explaining why that one service needs LAN reach.
+        run: |
+          exposed=$(grep -nE '^[[:space:]]*-[[:space:]]*"[0-9]' docker-compose.infra.yml docker-compose.prod.yml 2>/dev/null | grep -vE '"127\.0\.0\.1:' | grep -v '# lan-exposed:')
+          if [ -n "$exposed" ]; then
+            echo "❌ Port mapping(s) not bound to 127.0.0.1 and not annotated with '# lan-exposed: <reason>':"
+            echo "$exposed"
+            exit 1
+          fi
+          echo "✅ Every published port is loopback-bound (or explicitly annotated as LAN-exposed)"
+
   prisma-validation:
     name: Prisma Schema & Identity Seed
     runs-on: ubuntu-latest

--- a/.github/workflows/mesh-integrity.yml
+++ b/.github/workflows/mesh-integrity.yml
@@ -62,7 +62,10 @@ jobs:
         # 127.0.0.1: unless the line carries a "# lan-exposed: <reason>"
         # annotation explaining why that one service needs LAN reach.
         run: |
-          exposed=$(grep -nE '^[[:space:]]*-[[:space:]]*"[0-9]' docker-compose.infra.yml docker-compose.prod.yml 2>/dev/null | grep -vE '"127\.0\.0\.1:' | grep -v '# lan-exposed:')
+          # `|| true`: the job runs under `bash -e`, where a pipeline finding
+          # nothing exits 1 and would abort the step -- i.e. fail precisely
+          # when every port is correctly loopback-bound.
+          exposed=$(grep -nE '^[[:space:]]*-[[:space:]]*"[0-9]' docker-compose.infra.yml docker-compose.prod.yml 2>/dev/null | grep -vE '"127\.0\.0\.1:' | grep -v '# lan-exposed:' || true)
           if [ -n "$exposed" ]; then
             echo "❌ Port mapping(s) not bound to 127.0.0.1 and not annotated with '# lan-exposed: <reason>':"
             echo "$exposed"

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -75,7 +75,10 @@ jobs:
           # `keys:` mapping is a LiveKit-specific credential block; nothing
           # in this repo's tracked YAML legitimately needs one (keys belong
           # in .env / LIVEKIT_KEYS instead), so any match is a finding.
-          yaml_keys_hits=$(grep -rlE "^[[:space:]]*keys:[[:space:]]*$" --include="*.yml" --include="*.yaml" --exclude-dir=node_modules --exclude-dir=.next . 2>/dev/null | grep -v "^\./\.github/workflows/security-audit\.yml$")
+          # `|| true`: the job runs under `bash -e`, where a pipeline finding
+          # nothing exits 1 and would abort the step -- i.e. fail precisely
+          # when the check passes.
+          yaml_keys_hits=$(grep -rlE "^[[:space:]]*keys:[[:space:]]*$" --include="*.yml" --include="*.yaml" --exclude-dir=node_modules --exclude-dir=.next . 2>/dev/null | grep -v "^\./\.github/workflows/security-audit\.yml$" || true)
           if [ -n "$yaml_keys_hits" ]; then
             echo "❌ Inline 'keys:' block found in tracked YAML — LiveKit (or similar) credentials belong in .env, not committed config"
             echo "$yaml_keys_hits"

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -67,6 +67,21 @@ jobs:
             errors=$((errors + 1))
           fi
 
+          # Pattern 4 (P0-1): inline `keys:` block in tracked YAML. This is
+          # how livekit.yaml previously shipped a live-looking credential
+          # (`devkey: secretsecretsecret`) undetected by Pattern 1, which
+          # only scans .py/.js/.ts/.tsx — gitleaks' entropy rules also missed
+          # it because the value is low-entropy and placeholder-shaped. A
+          # `keys:` mapping is a LiveKit-specific credential block; nothing
+          # in this repo's tracked YAML legitimately needs one (keys belong
+          # in .env / LIVEKIT_KEYS instead), so any match is a finding.
+          yaml_keys_hits=$(grep -rlE "^[[:space:]]*keys:[[:space:]]*$" --include="*.yml" --include="*.yaml" --exclude-dir=node_modules --exclude-dir=.next . 2>/dev/null | grep -v "^\./\.github/workflows/security-audit\.yml$")
+          if [ -n "$yaml_keys_hits" ]; then
+            echo "❌ Inline 'keys:' block found in tracked YAML — LiveKit (or similar) credentials belong in .env, not committed config"
+            echo "$yaml_keys_hits"
+            errors=$((errors + 1))
+          fi
+
           if [ $errors -gt 0 ]; then
             echo ""
             echo "🚫 $errors security issue(s) found. Fix before merging."

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -265,10 +265,18 @@ class AppSettings(BaseSettings):
         "your_graph_password_here",
         "your_api_key_here",
         "your_api_secret_here",
-        # P0-1: the LiveKit dev credential that was committed in
-        # livekit.yaml's `keys:` block (now removed). Catching it here too
-        # means a deployment that still has it in LIVEKIT_API_KEY/SECRET --
-        # e.g. via an old .env copied forward -- also refuses to boot.
+    )
+    # P0-1: the LiveKit dev credential that was committed in livekit.yaml's
+    # `keys:` block (now removed). Catching it here too means a deployment
+    # still carrying it in LIVEKIT_API_KEY/SECRET -- e.g. via an old .env
+    # copied forward -- also refuses to boot.
+    #
+    # These are matched WHOLE, not as substrings, unlike the markers above.
+    # "devkey" is only six characters; substring-matching it would reinstate
+    # exactly the heuristic the comment above rejects, and a false positive
+    # here means production refuses to start. A real credential is never
+    # equal to one of these, so equality is both sufficient and safe.
+    _PLACEHOLDER_SECRET_EXACT = (
         "devkey",
         "secretsecretsecret",
     )
@@ -293,7 +301,9 @@ class AppSettings(BaseSettings):
             value = getattr(self, name, None)
             if not value:
                 continue
-            if any(marker in value for marker in self._PLACEHOLDER_SECRET_MARKERS):
+            if any(
+                marker in value for marker in self._PLACEHOLDER_SECRET_MARKERS
+            ) or value.strip() in self._PLACEHOLDER_SECRET_EXACT:
                 raise ValueError(
                     f"{name} still contains a placeholder value from .env.example "
                     "-- refusing to start with ENVIRONMENT=production. Set a real "

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -265,6 +265,12 @@ class AppSettings(BaseSettings):
         "your_graph_password_here",
         "your_api_key_here",
         "your_api_secret_here",
+        # P0-1: the LiveKit dev credential that was committed in
+        # livekit.yaml's `keys:` block (now removed). Catching it here too
+        # means a deployment that still has it in LIVEKIT_API_KEY/SECRET --
+        # e.g. via an old .env copied forward -- also refuses to boot.
+        "devkey",
+        "secretsecretsecret",
     )
     # Only the fields that gate a real, network-reachable service if left at
     # the shipped placeholder -- Postgres/Neo4j auth and the LiveKit room

--- a/backend/tests/test_config_validation.py
+++ b/backend/tests/test_config_validation.py
@@ -143,6 +143,24 @@ def test_real_looking_secret_allowed_in_production():
     assert settings.NEO4J_PASSWORD == "a-real-generated-secret-x9k2m"
 
 
+def test_real_credential_containing_devkey_is_not_rejected():
+    """P0-1 follow-up: "devkey" is only six characters, so substring-matching
+    it would let a randomly-generated credential that happens to contain
+    those letters stop production from booting. The two LiveKit markers are
+    matched whole for exactly this reason; if that regresses, a valid
+    deployment fails to start with a misleading "placeholder" error."""
+    # Low-entropy, unmistakably-a-fixture values on purpose: a random-looking
+    # string here (even a fake one) trips the repo's own gitleaks scan, which
+    # scores on entropy rather than provenance -- the same trap CLAUDE.md
+    # documents for the credential-scan grep, one layer over.
+    settings = _settings(
+        ENVIRONMENT="production",
+        LIVEKIT_API_KEY="livekit-api-key-with-devkey-inside",
+        LIVEKIT_API_SECRET="livekit-api-secret-with-secretsecretsecret-inside",
+    )
+    assert settings.LIVEKIT_API_KEY == "livekit-api-key-with-devkey-inside"
+
+
 def test_unset_secret_fields_do_not_crash_production():
     """A field an operator hasn't configured at all (None) must not be
     treated as a placeholder - only an actual placeholder string should."""

--- a/backend/tests/test_config_validation.py
+++ b/backend/tests/test_config_validation.py
@@ -105,6 +105,12 @@ def test_log_json_env_var_actually_reaches_the_setting(monkeypatch):
         ("NEO4J_AUTH", "neo4j/your_graph_password_here"),
         ("LIVEKIT_API_KEY", "your_api_key_here"),
         ("LIVEKIT_API_SECRET", "your_api_secret_here"),
+        # P0-1: the committed livekit.yaml `keys:` block (now removed) held
+        # `devkey: secretsecretsecret`. If either half ever reaches these
+        # fields -- e.g. an .env carried forward from before the fix -- the
+        # guard must still catch it.
+        ("LIVEKIT_API_KEY", "devkey"),
+        ("LIVEKIT_API_SECRET", "secretsecretsecret"),
     ],
 )
 def test_placeholder_secret_rejected_in_production(field, placeholder):

--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -1,4 +1,14 @@
 
+# P0-2: every host port binding below is prefixed 127.0.0.1: (loopback-only).
+# audit/ (M4-S3, M4-S8) found all nine infra services published on 0.0.0.0,
+# reachable by anything on the LAN -- including the *unauthenticated* LiveKit
+# SFU, which meant any LAN device could join a live voice session or run
+# inference for free on the local Ollama instance. The maintainer's answer
+# (2026-08-22) is that this is a single-host personal/family deployment, not
+# a multi-tenant or multi-machine one, so nothing needs LAN reach. If a
+# service ever needs to be reached from another machine (e.g. the frontend
+# served elsewhere), narrow the binding back on that one service and record
+# why, rather than reverting this file wholesale.
 services:
   # 1. Event Bus (NATS JetStream)
   nats:
@@ -7,8 +17,8 @@ services:
     entrypoint: [ "nats-server" ]
     command: [ "-js", "-m", "8222" ]
     ports:
-      - "4222:4222" # Client connections
-      - "8222:8222" # HTTP monitoring
+      - "127.0.0.1:4222:4222" # Client connections
+      - "127.0.0.1:8222:8222" # HTTP monitoring
     working_dir: /
     networks:
       - ai_mesh_network
@@ -29,7 +39,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ai_friend_db
     ports:
-      - "5433:5432"
+      - "127.0.0.1:5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     networks:
@@ -56,8 +66,8 @@ services:
       timeout: 5s
       retries: 5
     ports:
-      - "7474:7474" # HTTP
-      - "7687:7687" # Bolt
+      - "127.0.0.1:7474:7474" # HTTP
+      - "127.0.0.1:7687:7687" # Bolt
     volumes:
       - neo4j_data:/data
       - neo4j_logs:/logs
@@ -73,7 +83,7 @@ services:
     entrypoint: [ "docker-entrypoint.sh" ]
     command: [ "redis-server", "--appendonly", "yes" ]
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     volumes:
       - redis_data:/data
     working_dir: /data
@@ -93,11 +103,11 @@ services:
     entrypoint: [ "/livekit-server" ]
     command: [ "--config", "/etc/livekit.yaml" ]
     ports:
-      - "7880:7880" # HTTP API
-      - "7881:7881" # TURN/STUN TCP
-      - "7882:7882" # Additional TCP
-      - "3478:3478/udp" # STUN/TURN UDP
-      - "50100-50120:50100-50120/udp" # WebRTC media ports
+      - "127.0.0.1:7880:7880" # HTTP API
+      - "127.0.0.1:7881:7881" # TURN/STUN TCP
+      - "127.0.0.1:7882:7882" # Additional TCP
+      - "127.0.0.1:3478:3478/udp" # STUN/TURN UDP
+      - "127.0.0.1:50100-50120:50100-50120/udp" # WebRTC media ports
     volumes:
       - ./livekit.yaml:/etc/livekit.yaml
     environment:
@@ -124,7 +134,7 @@ services:
     command: [ "serve" ]
 
     ports:
-      - "11434:11434"
+      - "127.0.0.1:11434:11434"
     volumes:
       - ollama_models:/root/.ollama
     environment:
@@ -158,8 +168,8 @@ services:
       - CUSTOM_GPT_PATH=${CUSTOM_GPT_PATH:-GPT_weights/ai_friend_voice.ckpt}
       - CUSTOM_SOVITS_PATH=${CUSTOM_SOVITS_PATH:-SoVITS_weights/ai_friend_voice.pth}
     ports:
-      - "9880:9880" # WebUI
-      - "9871:9871" # API
+      - "127.0.0.1:9880:9880" # WebUI
+      - "127.0.0.1:9871:9871" # API
     volumes:
       - voice_models:/workspace/models/pretrained_models
       - ./backend/voice_samples:/workspace/GPT-SoVITS/output
@@ -186,8 +196,8 @@ services:
     image: qdrant/qdrant:v1.9.0
     container_name: brain_vectors
     ports:
-      - "6333:6333"
-      - "6334:6334"
+      - "127.0.0.1:6333:6333"
+      - "127.0.0.1:6334:6334"
     volumes:
       - qdrant_data:/qdrant/storage
     networks:

--- a/livekit.yaml
+++ b/livekit.yaml
@@ -10,8 +10,14 @@ rtc:
 redis:
   address: redis:6379
 
-keys:
-  devkey: secretsecretsecret
+# P0-1: no `keys:` block here. Signing keys come solely from the
+# LIVEKIT_KEYS env var (see docker-compose.infra.yml), which livekit-server
+# reads at startup. A `keys:` block was previously committed here holding
+# the value `devkey: secretsecretsecret` -- audit/ found it published in a
+# public repo. It was likely never the operating credential (.env carries a
+# distinct real key/secret pair), but removing it here is correct either
+# way and closes the question for good: this file cannot grant access to
+# anything, regardless of what LIVEKIT_KEYS is set to.
 
 logging:
   level: info


### PR DESCRIPTION
## Summary

Stage 0 of `audit/`'s roadmap (untracked forensic audit, see `AUDIT.md`) — the two items with zero prerequisites and the audit's highest severity.

- **P0-1**: `livekit.yaml`'s tracked `keys:` block is removed. `LIVEKIT_KEYS` (env, already wired by compose) is the sole source of signing keys now. Planning this found the committed `devkey`/`secretsecretsecret` pair doesn't match `.env`'s actual key — whether it was ever live is unconfirmed (LiveKit's docs don't state config-file-vs-env-var precedence), so rotation is deferred to a runtime test (mint a token with the old value, confirm it's rejected) rather than assumed. The placeholder-secret boot guard now also rejects `devkey`/`secretsecretsecret`, and a new CI check fails on any tracked YAML with an inline `keys:` block — the actual gap that let this ship undetected (gitleaks' entropy rules don't fire on a low-entropy, placeholder-shaped value).
- **P0-2**: all 16 host port mappings across the 9 `docker-compose.infra.yml` services now bind `127.0.0.1:` only, per this repo's single-host personal/family deployment model. A CI lint requires loopback binding or an explicit `# lan-exposed:` annotation.

## Test plan

- [x] Full backend suite: 970/970 passed
- [x] `ruff check .`: clean
- [x] All edited YAML/compose files parse (`docker compose config --quiet`, both individually and combined)
- [x] New CI checks verified against reproduced fixtures of both original defects (fire correctly)
- [ ] Runtime verification once Docker is available: mint a LiveKit token with `devkey`/`secretsecretsecret`, confirm rejection (tracked, not blocking this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)