### PR TITLE
fix: suspend VLM during turns, reinforce facts, loud SQLite fallback, subject-wiring CI, share subconscious state (P1-7, P2-13, P1-6, P1-8, P1-5)

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -6778,3 +6778,158 @@ for this session; a bare `cargo check` at the workspace root fails with
 - #164 (multi-tenancy - contradicts the documented single-family deployment
   model; would need an explicit product-direction decision first)
 - #162's Vault/Docker-secrets-file integration (already noted in batch 7)
+
+## 2026-08-22 -- audit/ implementation, Stage 1 (P1-7, P2-13, P1-6, P1-8, P1-5) -- five zero-prerequisite roadmap items
+
+Second implementation batch from `audit/`'s roadmap (`audit/ROADMAP.md` §7,
+Stage 1): the five items with no dependencies on each other or on Stage 0,
+done in the sequence's stated order.
+
+**P1-7 -- VLM/LLM contention was measured before touching code, not assumed.**
+`HARDWARE.md` §5 reported two resident 3B models costing each other roughly
+40% decode rate. Reproduced this session against the actually-running
+`ollama serve` (llama3.2:3b-instruct + qwen2.5:3b, 100 tokens each): solo
+57-59 tok/s, concurrent 31-32 tok/s, matching the prior measurement closely
+(-44%/-47% here vs -44%/-41% in HARDWARE.md). Also measured the roadmap's
+named alternative, `OLLAMA_MAX_LOADED_MODELS=1`, by starting a second
+`ollama serve` instance on an alternate loopback port sharing the same model
+store (no re-download needed): it removed the decode penalty entirely
+(-0.4%/+0.0%) but serialized the two calls with a ~2.2s model-swap between
+them, consistent with the 1.94s cold-load figure already in `HARDWARE.md`.
+For this system's actual access pattern -- VLM appraisal firing roughly
+once a second, potentially throughout an active conversation -- that
+trades a steady 40% throughput cost for repeated ~2s swap stalls each time
+appraisal and a turn overlap, which is very likely worse, not better.  Went
+with the code-level fix instead: `vision/agent.py` now tracks whether a
+cognitive turn is in flight (`chat.input` seen, no `chat.output`
+`done=True` yet) and suspends `_run_appraisal` for that duration, with a
+watchdog bounded by `LLM_STREAM_MAX_SECONDS` so a dropped `done` can't
+blind vision permanently. Also added a circuit breaker to the VLM caller
+(`appraisal.py`, finding M3-R3 -- no backoff existed, so a down VLM was
+retried every tick with a full base64 frame), modeled directly on the
+existing Rust `CircuitBreaker` in `voice-agent/src/main.rs` (consecutive-
+failure threshold, then a cooldown, then a half-open trial).
+
+**P2-13 -- the cheapest correctness fix in the audit, and it was exactly
+that cheap.** `cognitive/learning.py`'s fact consolidation ran a `MATCH`
+query to check whether a relationship already existed, and on a hit logged
+"Fact RESOLVED" and `continue`d -- past a comment reading `# Optionally
+nudge the weight instead of creating new`. `GraphDB.consolidate_relationship`
+(called by `create_triplet`, which the skip was bypassing) already has
+`ON MATCH SET r.weight = coalesce(r.weight, 1) + 1` -- the reinforcement
+existed and was unreachable. Deleted the pre-check; `create_triplet` now
+runs unconditionally. One graph round-trip per extracted fact was removed
+as a side effect. The bug was invisible to the existing test suite because
+`mock_graph_db.execute_query` defaults to returning `[]` (falsy) in
+`conftest.py`, so the buggy branch was never exercised by any prior test --
+worth knowing before trusting `execute_query.return_value` defaults
+elsewhere in this file's test suite for similar reasons.
+
+**P1-6 -- the Postgres-to-SQLite downgrade is loud now, and fails closed
+in production by default.** `runtime_bootstrap.py`'s `_ensure_database_schema`
+caught a Postgres connection failure, logged at WARNING, and silently
+continued on SQLite -- losing pgvector with no other signal, into a mode a
+prior session's triage (Q-M2-2, this session) established is emergency-only,
+not supported. New `_enter_sqlite_fallback` helper: logs at ERROR, writes a
+JSON sentinel file (`SQLITE_FALLBACK_HEALTH_FILE`, matching the existing
+`VISION_HEALTH_FILE` cross-process-signal pattern) that `main.py`'s
+`/health` now reads and surfaces as `degraded: true`, and raises
+(caught by the existing bootstrap retry loop, which then fails loudly
+after exhausting retries rather than continuing silently) under
+`ENVIRONMENT=production` unless `ALLOW_SQLITE_FALLBACK=true` is set
+explicitly. Deliberately does *not* touch the separate "DATABASE_URL was
+never configured" branch a few lines above -- that is a chosen SQLite-only
+deployment, not a downgrade, and must not fail closed. `/health`'s
+`require_lan_client` dependency (LAN_ONLY defaults true) blocks
+`TestClient`'s synthetic host by default -- the new tests use
+`app.dependency_overrides`, the standard FastAPI pattern, not a `.env`
+change.
+
+**P1-8 -- the category fix, and it found more than the audit did manually.**
+Eight NATS subjects were found wired at one end only across M1/M2/M3,
+because subjects are plain strings with nothing type-checking a publisher
+against a subscriber. New `backend/scripts/check_subject_wiring.py`:
+Python-side via `ast` (walks every `.py` under `app/` plus `main.py`,
+resolving `Topics.NAME` attributes, string literals, and the
+`"subject": "literal"` dict-key shape `cognitive/pipeline.py`'s mesh-signal
+producers use for otherwise-dynamic subjects), Rust-side via regex over the
+`topics::CONST` constants in `crates/contracts/src/lib.rs` used at
+`.publish`/`.publish_with_headers`/`.subscribe` call sites, cross-referenced
+against `nats_streams.py`'s `CORE_STREAMS` wildcard patterns (own NATS
+`>`/`*` matcher, since nothing existing needed one). Wired into
+`mesh-integrity.yml` as a new job, path-filtered on `backend/app/**`,
+`backend/crates/**`, and the checker itself. Building it surfaced **six**
+previously-undiscovered one-ended subjects beyond the audit's original
+eight: `audio.pre_generate` (published by the mesh-signal path, zero
+subscribers, not even in the `Topics` enum), `telemetry.reflection`
+(published by `cognitive/core.py`, matches no declared stream pattern,
+zero subscribers), `state.subconscious` (the internal-monologue thought is
+published, zero subscribers), `voice.segmentation_feedback` (`brain_agent`
+subscribes, zero publishers anywhere), `control.interrupt`
+(`action.py`'s self-correction path publishes it alongside `audio.stop`,
+which *is* wired -- `control.interrupt` itself has none), and `vision.frames`
+(the only publish call is commented out -- `# TEMPORARILY DISABLED FOR
+DIAGNOSTICS` -- while `brain_agent` still subscribes). All six are
+allowlisted with that exact context rather than silently fixed -- each is
+its own scoped question (is `audio.pre_generate` dead code or a missing
+consumer? was `vision.frames` disabled for a reason still live today?) and
+fixing them as a drive-by inside a "add a CI check" item would hide
+exactly the kind of undecided change this repo's own conventions ask to be
+made explicitly. Two earlier scanner bugs were caught and fixed before
+landing: `CORE_STREAMS` is an `ast.AnnAssign` (annotated), not a plain
+`Assign`, which made every subject falsely read as matching no stream; and
+the initial scan missed `main.py` (outside `app/`), which is where
+`vision.control`'s only publisher lives.
+
+**P1-5 -- subconscious_agent now actually observes the brain's state,
+closing the gap that made dreaming unreachable.** `hydrate_state` was
+verified to already hold `_state_lock` (`agent_state.py:475`) before
+implementing anything further -- the roadmap's stated risk here (that it
+didn't) was already retired by prior work and is corrected in this entry
+rather than carried forward. `agent_state.py` lines ~478-829 were read in
+full per the roadmap's stated precondition (previously PARTIAL coverage in
+`audit/`). New `StateService.apply_external_state(data)`: applies the exact
+field set `persist_state` already publishes on `state.broadcast` (every
+real appraisal/interaction update, plus a rate-limited sensory path) onto
+`current_state`, under `_state_lock` -- the fourth source of this same
+field shape (Redis/SQLite/Neo4j were the other three, in `_hydrate_locked`).
+Deliberately defaults each field to its *current* value when absent from a
+partial broadcast, not to a hardcoded zero the way hydration's cold-start
+branches do -- a missing field there means "never persisted"; here it means
+"unchanged since the last broadcast," a different case, and a test pins
+this distinction. `subconscious_agent._on_state_broadcast` now calls this
+in addition to its existing Neo4j sync (kept -- durable graph persistence
+serves a different purpose than live in-process state); `start()` calls
+`hydrate_state()` once as a startup catch-up so the process isn't running
+on pure persona defaults until the first broadcast happens to arrive.
+
+**A tooling trap worth recording for next time.** During mutation testing
+(deliberately breaking `subconscious_agent.py`, confirming a test fails,
+reverting), a test that should have passed cleanly after reverting kept
+failing -- traced to stale `__pycache__/*.pyc` bytecode surviving a rapid
+mutate-revert-reedit cycle on the same file within the same
+filesystem-timestamp granularity window, so Python's import cache
+invalidation (mtime-keyed) didn't detect the change. `find . -name
+__pycache__ -exec rm -rf {} +` (or `python -B`) resolved it. Not a real
+bug in the P1-5 change -- confirmed by reproducing the same false failure
+against a hand-written fake object with no mocking library involved at
+all, before finding the cache explanation.
+
+**Verified:** full backend suite, 995/995 passed (up from 970 before this
+batch's 25 new tests, net of a few consolidated into existing parametrize
+lists), `ruff check .` clean. Every new test mutation-tested individually:
+broke the specific line(s) it exists to catch, confirmed the test failed,
+reverted, confirmed clean again -- done for the VLM turn-suspension gate,
+the VLM circuit breaker, the reflection reinforcement fix, the SQLite
+fail-closed check, the `/health` sentinel read, the subject-wiring
+checker's own core logic (via its synthetic fixture repo), the
+`_on_state_broadcast` wiring, `apply_external_state`'s lock discipline, and
+the startup `hydrate_state` call.
+
+**NOT done:**
+- The six newly-discovered one-ended subjects from P1-8 -- allowlisted
+  with reasons, not fixed; each needs its own investigation.
+- Stages 2-6 of the roadmap sequence (`audit/ROADMAP.md` §7) -- P1-1 (ack
+  model) and P1-2 (retention tiers) still want Docker running to verify
+  properly; Stage 3's six measurements are still blocked on Docker and
+  `backend/models/`.

--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -6933,3 +6933,62 @@ the startup `hydrate_state` call.
   model) and P1-2 (retention tiers) still want Docker running to verify
   properly; Stage 3's six measurements are still blocked on Docker and
   `backend/models/`.
+
+## 2026-08-22 -- audit/ implementation, Stage 1 review pass -- three defects found in the batch above, all mutation-tested
+
+Self-review of the open PR before merge, on the principle that a batch
+this size shouldn't go in on the strength of its own green suite. Three
+real defects, none of which any test in the batch would have caught.
+
+**VisionAgent's turn-tracking subscriptions used the wrong delivery
+policy.** `BaseAgent.subscribe` defaults `deliver_policy="all"`, and the
+two new subscriptions (`chat.input`, `chat.output`) were the only ones in
+the entire mesh that took that default -- every other call site in
+`app/` names a policy explicitly, overwhelmingly `"new"`, with `"last"` for
+the two snapshot cases. The consequence is specific: durables are named
+`{agent_name}_{subject}`, so vision's are fresh, and under `"all"` a fresh
+durable replays the stream's whole retained history at startup.
+`chat.output` is published once per response *chunk*, so every vision
+restart would re-walk the entire conversation, and would finish in
+whatever state the last replayed message left it -- typically suspended by
+a `chat.input` from hours ago, blind until the `LLM_STREAM_MAX_SECONDS`
+watchdog fired. Both now pass `deliver_policy="new"`. These are liveness
+signals, not work items: a replayed turn boundary carries no information
+about whether the LLM is busy *now*.
+
+**The SQLite-fallback sentinel was write-only.** `_enter_sqlite_fallback`
+wrote it; nothing ever removed it. One transient Postgres outage would
+therefore leave `/health` reporting `degraded: true` for the lifetime of
+the host, long after Postgres came back. That is worse than a subtle bug --
+a degradation signal that never turns off is one an operator learns to
+ignore, which is precisely the silence P1-6 exists to end. Added
+`_clear_sqlite_fallback`, called on the successful-connect path.
+
+**The sentinel's cross-process claim was overstated.** The docstring said
+`/health` (a separate process) reads it, which is true on a single host and
+false under `docker-compose.prod.yml`, where bootstrap runs inside the
+`brain_agent` container and `main.py` is served elsewhere -- `/tmp` is not
+shared between them. Documented as the limitation it is on
+`SQLITE_FALLBACK_HEALTH_FILE`, with the fix (point it at a shared mount)
+stated. Not treated as a blocker: the ERROR log and the production
+fail-closed are the primary signals and neither depends on topology.
+
+**Considered and deliberately not changed:** `apply_external_state` does
+not clamp incoming values to PAD bounds. Checked `_hydrate_locked`, which
+doesn't clamp either -- both are loading a snapshot produced by a
+`StateService` that already enforced bounds on write, so this matches the
+established convention for that shape rather than diverging from it.
+
+**Verified:** full backend suite 998/998 (three new tests: the
+`deliver_policy` assertion, sentinel clearing, and clearing an absent
+sentinel), `ruff check .` clean. Each of the three fixes mutation-tested:
+dropped `deliver_policy="new"` from the `chat.input` subscription, replaced
+the `unlink` with a no-op -- each broke exactly the test written for it and
+nothing else.
+
+**NOT done:**
+- Nothing new attempted beyond the three fixes; the batch's scope is
+  unchanged.
+- The cross-container sentinel path is documented, not solved. Solving it
+  means either a shared volume in `docker-compose.prod.yml` or moving the
+  signal onto the mesh, and neither is in this batch's scope.

--- a/.github/workflows/mesh-integrity.yml
+++ b/.github/workflows/mesh-integrity.yml
@@ -14,6 +14,9 @@ on:
       - 'frontend/prisma/**'
       - '.env.example'
       - 'backend/app/cognitive/identity.py'
+      - 'backend/app/**'
+      - 'backend/crates/**'
+      - 'backend/scripts/check_subject_wiring.py'
   pull_request:
     branches: [main, master]
     paths:
@@ -22,6 +25,9 @@ on:
       - 'frontend/prisma/**'
       - '.env.example'
       - 'backend/app/cognitive/identity.py'
+      - 'backend/app/**'
+      - 'backend/crates/**'
+      - 'backend/scripts/check_subject_wiring.py'
 
 jobs:
   compose-validation:
@@ -116,3 +122,17 @@ jobs:
           else
             echo "✅ All compose variables are documented in .env.example"
           fi
+
+  subject-wiring:
+    name: NATS Subject Wiring (P1-8)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Check every subject is wired at both ends or explicitly allowlisted
+        working-directory: backend
+        run: python scripts/check_subject_wiring.py

--- a/backend/app/agents/subconscious_agent.py
+++ b/backend/app/agents/subconscious_agent.py
@@ -60,6 +60,13 @@ class SubconsciousAgent(BaseAgent):
         await self.connect()
         await self.graph_db.initialize()
 
+        # P1-5: a one-time catch-up so this process's state isn't just the
+        # persona defaults until the brain's next state.broadcast arrives --
+        # mirrors what CognitiveService.initialize() does on the brain side.
+        # Ongoing sync after this is event-driven (_on_state_broadcast,
+        # below), not polled.
+        await self.state_service.hydrate_state()
+
         # Initialize SQLite/Postgres DB pool and MemoryStore if not provided
         if not self.memory_store:
             from app.state.conversation_store import ConversationHistoryStore
@@ -108,7 +115,16 @@ class SubconsciousAgent(BaseAgent):
         logger.info(f"🧠 {self.name} Online | Subconscious Mesh Interface Active.")
 
     async def _on_state_broadcast(self, data: dict[str, Any]):
-        """Asynchronously syncs state changes from NATS state.broadcast into Neo4j."""
+        """Syncs state changes from NATS state.broadcast into Neo4j, and
+        applies them to this process's own live StateService (P1-5).
+
+        Before this, `subconscious_agent`'s AgentState was never hydrated
+        and never updated -- an independent copy holding whatever the
+        persona defaults were at startup, forever. Every silence gate and
+        the dream path (`_run_dream_sequence`) read that same
+        `self.state_service.current_state`, so both were measuring a state
+        that had nothing to do with the brain's actual mood/fatigue/trust.
+        """
         agent_name = data.get("agent_name", "my friend")
 
         # Validate agent_name
@@ -117,6 +133,8 @@ class SubconsciousAgent(BaseAgent):
                 f"[Subconscious] Invalid or missing agent_name in state broadcast. Payload: {data}"
             )
             return
+
+        await self.state_service.apply_external_state(data)
 
         logger.info(
             f"[Subconscious] Received state broadcast for {agent_name}. Syncing to Neo4j..."

--- a/backend/app/cognitive/learning.py
+++ b/backend/app/cognitive/learning.py
@@ -227,24 +227,15 @@ class ReflectionService:
                         )
                         continue
 
-                    # Search if this relationship already exists with high weight
-                    query = f"""
-                    MATCH (s)-[r:{rel_type}]->(t)
-                    WHERE s.name = $s_name AND t.name = $t_name
-                    RETURN r
-                    """
-                    existing = await self.graph.execute_query(
-                        query, {"s_name": subject, "t_name": object_val}
-                    )
-
-                    if existing:
-                        logger.debug(
-                            f"Fact RESOLVED: Relationship already exists between {subject} and {object_val}."
-                        )
-                        # Optionally nudge the weight instead of creating new
-                        continue
-
-                    # Actual Storage
+                    # P2-13: this used to MATCH for an existing relationship
+                    # first and `continue` on a hit, logging "Fact RESOLVED"
+                    # and never writing anything -- so a restated fact never
+                    # reinforced, while decay_relationships still pushed
+                    # every edge toward the prune threshold regardless of
+                    # repetition. create_triplet -> consolidate_relationship
+                    # already does the right thing on a repeat (`ON MATCH SET
+                    # r.weight = coalesce(r.weight, 1) + 1`); the guard above
+                    # was preventing that path from ever being reached.
                     await self.graph.create_triplet(
                         subject,
                         rel_type,

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -150,6 +150,17 @@ class AppSettings(BaseSettings):
     RUNTIME_BOOTSTRAP_RETRIES: int = 12
     OLLAMA_REQUIRED_MODELS_STR: str = Field(default="", alias="OLLAMA_REQUIRED_MODELS")
 
+    # P1-6: Q-M2-2 answered SQLite as emergency-only, not a supported runtime
+    # mode. A Postgres connection failure at bootstrap defaults to refusing
+    # to start under ENVIRONMENT=production rather than silently downgrading
+    # (losing pgvector) into a mode nobody chose to run. Set true only for a
+    # deliberate degraded deployment, not as a standing default.
+    ALLOW_SQLITE_FALLBACK: bool = False
+    # Written by runtime_bootstrap.py (a different process than the backend
+    # API) when the SQLite fallback is entered, so /health can surface it.
+    # Same pattern as VISION_HEALTH_FILE below.
+    SQLITE_FALLBACK_HEALTH_FILE: str = "/tmp/sqlite_fallback_active"
+
     SOVITS_URL: str = "http://127.0.0.1:9871"
     STT_LANGUAGE: str = "en"
     TTS_LANGUAGE: str = "en"
@@ -171,6 +182,23 @@ class AppSettings(BaseSettings):
     # Touched on every successful frame capture so a container healthcheck can
     # probe the real path rather than mere process liveness (see finding E1).
     VISION_HEALTH_FILE: str = "/tmp/vision_agent_healthy"
+
+    # P1-7: measured (this repo's audit/) that two resident 3B models roughly
+    # halve each other's decode rate on one GPU/one Ollama endpoint -- the
+    # VLM and the conversational LLM otherwise contend on every turn. Since
+    # OLLAMA_MAX_LOADED_MODELS=1 was measured to trade that for a ~2s
+    # model-swap on every contention event (worse for VLM_APPRAISAL_INTERVAL-
+    # frequency calls than the throughput hit it removes), the fix is
+    # scheduling, not eviction: suspend VLM appraisal for the duration of a
+    # cognitive turn instead.
+    VISION_SUSPEND_DURING_TURN: bool = True
+    # M3-R3: the VLM caller had no circuit breaker, so a failing Ollama (or
+    # missing VLM model) was retried every capture tick with a full base64
+    # frame. Modeled on the Rust CircuitBreaker in
+    # crates/voice-agent/src/main.rs -- consecutive-failure threshold, then a
+    # cooldown before the next real attempt.
+    VLM_BREAKER_FAILURE_THRESHOLD: int = 3
+    VLM_BREAKER_COOLDOWN_S: float = 30.0
 
     # Half-life of a phasic hormone burst, in seconds. Real phasic bursts last
     # only hundreds of milliseconds; these are the *felt* afterglow at

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -157,8 +157,17 @@ class AppSettings(BaseSettings):
     # deliberate degraded deployment, not as a standing default.
     ALLOW_SQLITE_FALLBACK: bool = False
     # Written by runtime_bootstrap.py (a different process than the backend
-    # API) when the SQLite fallback is entered, so /health can surface it.
-    # Same pattern as VISION_HEALTH_FILE below.
+    # API) when the SQLite fallback is entered, so /health can surface it,
+    # and removed again once Postgres answers. Same pattern as
+    # VISION_HEALTH_FILE below.
+    #
+    # Scope, stated plainly: bootstrap runs inside the brain_agent container
+    # under docker-compose.prod.yml, while /health is served by main.py
+    # elsewhere, so this path only carries the signal between them if it is
+    # on a shared mount. It is not the primary alarm and is not relied on to
+    # be -- the ERROR log and the production fail-closed are, and both work
+    # regardless of topology. Point this at a shared volume to get the
+    # /health flag in a multi-container deployment.
     SQLITE_FALLBACK_HEALTH_FILE: str = "/tmp/sqlite_fallback_active"
 
     SOVITS_URL: str = "http://127.0.0.1:9871"

--- a/backend/app/runtime_bootstrap.py
+++ b/backend/app/runtime_bootstrap.py
@@ -56,6 +56,28 @@ def _enter_sqlite_fallback(reason: str) -> None:
         )
 
 
+def _clear_sqlite_fallback() -> None:
+    """Remove the sentinel once Postgres answers again.
+
+    Without this the flag is write-only: one transient Postgres outage
+    would leave `/health` reporting `degraded: true` for the lifetime of
+    the host, long after the condition cleared. A degradation signal that
+    never turns off is one operators learn to ignore, which is the same
+    silence P1-6 set out to fix.
+    """
+    health_file = getattr(Config, "SQLITE_FALLBACK_HEALTH_FILE", "")
+    if not health_file:
+        return
+    try:
+        Path(health_file).unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as file_err:
+        logger.debug(
+            "[Bootstrap] Could not clear SQLite fallback sentinel: %s", file_err
+        )
+
+
 async def bootstrap_runtime() -> None:
     """Run idempotent runtime bootstrap so one-command deploy reaches a working mesh."""
     retries = max(1, int(getattr(Config, "RUNTIME_BOOTSTRAP_RETRIES", 12)))
@@ -136,6 +158,8 @@ async def _ensure_database_schema() -> None:
             "[Bootstrap] SQLite database schema and core tables verified via fallback."
         )
         return
+
+    _clear_sqlite_fallback()
 
     schema_path = Path(__file__).resolve().parents[1] / "db" / "schema.sql"
     if not schema_path.exists():

--- a/backend/app/runtime_bootstrap.py
+++ b/backend/app/runtime_bootstrap.py
@@ -1,5 +1,7 @@
 import asyncio
+import json
 import logging
+import time
 from pathlib import Path
 
 import asyncpg
@@ -9,6 +11,49 @@ from .config import Config
 from .nats_streams import setup_streams
 
 logger = logging.getLogger("runtime_bootstrap")
+
+
+def _enter_sqlite_fallback(reason: str) -> None:
+    """P1-6: a Postgres connection failure used to log at WARNING and fall
+    back to SQLite with no other signal. Q-M2-2 answered SQLite as
+    emergency-only, not a supported runtime mode, which makes silence here
+    worse than the degradation itself -- M2-P3's synchronous SQLite I/O then
+    blocks the whole mesh's event loop in a mode nobody knows it entered.
+
+    Logs at ERROR, writes a sentinel file `/health` (main.py, a separate
+    process) can read, and fails closed under ENVIRONMENT=production unless
+    explicitly overridden -- silently losing pgvector in production is worse
+    than refusing to start. Deliberately does NOT apply to a deployment that
+    never configured DATABASE_URL at all (see `_ensure_database_schema`'s
+    first branch): that is a chosen SQLite-only configuration, not a
+    downgrade, and must not be made to fail closed.
+    """
+    logger.error(
+        "[Bootstrap] %s. Falling back to SQLite -- this is an EMERGENCY-ONLY "
+        "degraded mode (pgvector is unavailable), not a supported runtime "
+        "configuration.",
+        reason,
+    )
+
+    if Config.ENVIRONMENT == "production" and not getattr(
+        Config, "ALLOW_SQLITE_FALLBACK", False
+    ):
+        raise RuntimeError(
+            f"{reason}. Refusing to silently downgrade to SQLite in production "
+            "(ENVIRONMENT=production). Set ALLOW_SQLITE_FALLBACK=true to permit "
+            "this degraded mode explicitly."
+        )
+
+    health_file = getattr(Config, "SQLITE_FALLBACK_HEALTH_FILE", "")
+    if not health_file:
+        return
+    try:
+        with open(health_file, "w") as fh:
+            fh.write(json.dumps({"reason": reason, "timestamp": time.time()}))
+    except OSError as file_err:
+        logger.debug(
+            "[Bootstrap] Could not write SQLite fallback sentinel: %s", file_err
+        )
 
 
 async def bootstrap_runtime() -> None:
@@ -82,9 +127,8 @@ async def _ensure_database_schema() -> None:
     try:
         conn = await asyncpg.connect(dsn)
     except Exception as e:
-        logger.warning(
-            f"[Bootstrap] PostgreSQL connection failed: {e}. Falling back to SQLite."
-        )
+        _enter_sqlite_fallback(reason=f"PostgreSQL connection failed: {e}")
+
         from .state.sqlite_fallback import SQLiteConnection
 
         SQLiteConnection("app.db")

--- a/backend/app/state/agent_state.py
+++ b/backend/app/state/agent_state.py
@@ -649,6 +649,90 @@ class StateService:
             except Exception as e:
                 logger.warning(f"Failed fallback hydration from Neo4j: {e}")
 
+    async def apply_external_state(self, data: dict[str, Any]) -> None:
+        """P1-5: apply a `state.broadcast` snapshot from another process's
+        `StateService` onto this one's `current_state`.
+
+        `subconscious_agent` and `brain_agent` run as separate OS processes
+        (`ARCHITECTURE.md`), so they can never share one `AgentState` object
+        -- the only channel between them is the mesh. `persist_state` already
+        broadcasts the full snapshot on `state.broadcast` after every real
+        appraisal/interaction update (rate-limited to
+        `STATE_SENSORY_PERSIST_INTERVAL` on the sensory path, uncapped on
+        appraisal/event/tick/ToM updates), so it is close to real-time,
+        unlike polling `hydrate_state` on a timer -- and it needed no new
+        publisher, since the brain already broadcasts this to no listener
+        that applied it. `_on_state_broadcast` (subconscious_agent.py)
+        called this method's Neo4j-only predecessor and now also calls this.
+
+        Takes `_state_lock` like every other mutation path, same reasoning
+        as `hydrate_state`: applied under the lock, a receiver processing a
+        broadcast mid fire-and-forget System-2 appraisal cannot leave
+        `current_state` half-overwritten and half-appraised.
+
+        Same field set as `_hydrate_locked`'s Redis/SQLite/Neo4j branches,
+        applied from the broadcast dict instead -- this is the fourth
+        source of the same shape, not a new one.
+        """
+        async with self._state_lock:
+            self.current_state.mood = float(data.get("mood", self.current_state.mood))
+            self.current_state.energy = float(
+                data.get("energy", self.current_state.energy)
+            )
+            self.current_state.dominance = float(
+                data.get("dominance", self.current_state.dominance)
+            )
+            self.current_state.trust_benevolence = float(
+                data.get("trust_benevolence", self.current_state.trust_benevolence)
+            )
+            self.current_state.trust_competence = float(
+                data.get("trust_competence", self.current_state.trust_competence)
+            )
+            self.current_state.trust_integrity = float(
+                data.get("trust_integrity", self.current_state.trust_integrity)
+            )
+            self.current_state.attachment = float(
+                data.get("attachment", self.current_state.attachment)
+            )
+            self.current_state.fatigue = float(
+                data.get("fatigue", self.current_state.fatigue)
+            )
+            self.current_state.last_user_interaction = float(
+                data.get(
+                    "last_user_interaction", self.current_state.last_user_interaction
+                )
+            )
+            self.current_state.interaction_count = int(
+                data.get("interaction_count", self.current_state.interaction_count)
+            )
+            self.current_state.user_mental_model.inferred_valence = float(
+                data.get(
+                    "inferred_valence",
+                    self.current_state.user_mental_model.inferred_valence,
+                )
+            )
+            self.current_state.user_mental_model.inferred_arousal = float(
+                data.get(
+                    "inferred_arousal",
+                    self.current_state.user_mental_model.inferred_arousal,
+                )
+            )
+            implied_goals = data.get("implied_goals")
+            if isinstance(implied_goals, list):
+                self.current_state.user_mental_model.implied_goals = implied_goals
+            known_concepts = data.get("known_concepts")
+            if isinstance(known_concepts, list):
+                self.current_state.user_mental_model.known_concepts = known_concepts
+            self.current_state.baseline_valence = float(
+                data.get("baseline_valence", self.current_state.baseline_valence)
+            )
+            self.current_state.baseline_arousal = float(
+                data.get("baseline_arousal", self.current_state.baseline_arousal)
+            )
+            self.current_state.baseline_dominance = float(
+                data.get("baseline_dominance", self.current_state.baseline_dominance)
+            )
+
     async def persist_state(self, agent_name: str = "my friend"):
         """Save state to Redis and the local SQLite cache, then broadcast.
 

--- a/backend/app/vision/agent.py
+++ b/backend/app/vision/agent.py
@@ -61,7 +61,18 @@ class VisionAgent(BaseAgent):
                 model=Config.VLM_MODEL,
                 interval=Config.VLM_APPRAISAL_INTERVAL,
                 prompt=Config.VLM_PROMPT,
+                breaker_failure_threshold=Config.VLM_BREAKER_FAILURE_THRESHOLD,
+                breaker_cooldown_s=Config.VLM_BREAKER_COOLDOWN_S,
             )
+
+        # P1-7: true while a cognitive turn is in flight (chat.input seen,
+        # no chat.output done=True yet), so _capture_loop can suspend VLM
+        # appraisal for its duration rather than contend with the
+        # conversational LLM on the same Ollama endpoint. Bounded by
+        # LLM_STREAM_MAX_SECONDS so a dropped/never-arriving `done` cannot
+        # blind vision permanently.
+        self._turn_in_flight = False
+        self._turn_started_at = 0.0
 
     def preflight(self) -> bool:
         """Probe whether this process can actually see anything.
@@ -119,6 +130,11 @@ class VisionAgent(BaseAgent):
         # Subscribe to control signals from main.py
         await self.subscribe(Topics.VISION_CONTROL, self._handle_control)
 
+        # P1-7: track turn boundaries so appraisal can suspend during one.
+        if Config.VISION_SUSPEND_DURING_TURN:
+            await self.subscribe(Topics.CHAT_INPUT, self._on_chat_input)
+            await self.subscribe(Topics.CHAT_OUTPUT, self._on_chat_output)
+
         self.running = True
         vlm_status = f"VLM={Config.VLM_MODEL}" if self.vlm_enabled else "VLM=disabled"
         self.can_capture = self.preflight()
@@ -135,6 +151,32 @@ class VisionAgent(BaseAgent):
         if new_source in ["screen", "camera"]:
             self.source = new_source
             logger.info(f"Vision source switched to: {new_source}")
+
+    async def _on_chat_input(self, data: dict):
+        """A turn is starting: suspend VLM appraisal until it ends."""
+        self._turn_in_flight = True
+        self._turn_started_at = time.time()
+
+    async def _on_chat_output(self, data: dict):
+        """`done=True` closes the turn; any other chunk leaves it open."""
+        if data.get("done"):
+            self._turn_in_flight = False
+
+    def _is_turn_in_flight(self) -> bool:
+        """Watchdog: a `done` that never arrives (crash, dropped message)
+        must not blind vision forever. Bounded by the same
+        LLM_STREAM_MAX_SECONDS a turn is itself allowed to run for."""
+        if not self._turn_in_flight:
+            return False
+        if time.time() - self._turn_started_at > Config.LLM_STREAM_MAX_SECONDS:
+            logger.warning(
+                "[Vision] Turn-in-flight watchdog fired after %.0fs with no "
+                "chat.output done=True; resuming appraisal.",
+                Config.LLM_STREAM_MAX_SECONDS,
+            )
+            self._turn_in_flight = False
+            return False
+        return True
 
     async def _capture_loop(self):
         while self.running:
@@ -215,6 +257,8 @@ class VisionAgent(BaseAgent):
 
     async def _run_appraisal(self, frame_b64: str):
         """Run VLM appraisal if the interval has elapsed and publish the description."""
+        if Config.VISION_SUSPEND_DURING_TURN and self._is_turn_in_flight():
+            return
         if not self.appraisal.should_appraise():
             return
 

--- a/backend/app/vision/agent.py
+++ b/backend/app/vision/agent.py
@@ -131,9 +131,21 @@ class VisionAgent(BaseAgent):
         await self.subscribe(Topics.VISION_CONTROL, self._handle_control)
 
         # P1-7: track turn boundaries so appraisal can suspend during one.
+        # deliver_policy="new", as every other subscription in the mesh
+        # does, because these are liveness signals rather than work items:
+        # a replayed turn boundary from an hour ago says nothing about
+        # whether the LLM is busy *now*. Under the "all" default a fresh
+        # durable would redeliver the entire retained chat history -- and
+        # chat.output is published once per response chunk -- on every
+        # vision restart, leaving vision suspended by a historical
+        # chat.input until the watchdog cleared it.
         if Config.VISION_SUSPEND_DURING_TURN:
-            await self.subscribe(Topics.CHAT_INPUT, self._on_chat_input)
-            await self.subscribe(Topics.CHAT_OUTPUT, self._on_chat_output)
+            await self.subscribe(
+                Topics.CHAT_INPUT, self._on_chat_input, deliver_policy="new"
+            )
+            await self.subscribe(
+                Topics.CHAT_OUTPUT, self._on_chat_output, deliver_policy="new"
+            )
 
         self.running = True
         vlm_status = f"VLM={Config.VLM_MODEL}" if self.vlm_enabled else "VLM=disabled"

--- a/backend/app/vision/appraisal.py
+++ b/backend/app/vision/appraisal.py
@@ -28,6 +28,8 @@ class VisualAppraisalService:
         model: str = "moondream",
         interval: float = 5.0,
         prompt: str = "Describe what you see in this image briefly. Focus on what the user is doing.",
+        breaker_failure_threshold: int = 3,
+        breaker_cooldown_s: float = 30.0,
     ):
         self.llm = ollama_client
         self.model = model
@@ -37,6 +39,35 @@ class VisualAppraisalService:
         self._last_description: str = ""
         self._last_appraisal_time: float = 0.0
         self._last_visual_vector = None
+
+        # M3-R3: without this, a down VLM (or Ollama, or a model that was
+        # never pulled) got retried every capture tick with a full base64
+        # frame -- no backoff. Modeled on the Rust CircuitBreaker
+        # (crates/voice-agent/src/main.rs): consecutive_failures crosses
+        # breaker_failure_threshold -> opened_at is set; allow_request()
+        # stays False until breaker_cooldown_s has elapsed, then the next
+        # call is a half-open trial whose own result decides close-vs-reopen.
+        # Single-consumer (only `appraise`, called sequentially from
+        # VisionAgent's one capture loop), so no lock is needed -- same
+        # reasoning the Rust breaker documents for its atomics.
+        self._breaker_failure_threshold = max(1, breaker_failure_threshold)
+        self._breaker_cooldown_s = breaker_cooldown_s
+        self._consecutive_failures = 0
+        self._breaker_opened_at: float = 0.0
+
+    def _breaker_allow_request(self) -> bool:
+        if self._breaker_opened_at == 0.0:
+            return True
+        return (time.time() - self._breaker_opened_at) >= self._breaker_cooldown_s
+
+    def _breaker_record_success(self) -> None:
+        self._consecutive_failures = 0
+        self._breaker_opened_at = 0.0
+
+    def _breaker_record_failure(self) -> None:
+        self._consecutive_failures += 1
+        if self._consecutive_failures >= self._breaker_failure_threshold:
+            self._breaker_opened_at = time.time()
 
     def should_appraise(self) -> bool:
         """Check if enough time has elapsed since the last VLM call."""
@@ -117,6 +148,14 @@ class VisualAppraisalService:
                 self._last_appraisal_time = time.time()
                 return self._last_description
 
+        if not self._breaker_allow_request():
+            logger.debug(
+                "[VisualAppraisal] Circuit breaker open (%d consecutive failures); "
+                "skipping VLM call, using cache.",
+                self._consecutive_failures,
+            )
+            return self._last_description
+
         try:
             description = await self.llm.describe_image(
                 image_b64=frame_b64,
@@ -125,6 +164,7 @@ class VisualAppraisalService:
             )
 
             if description:
+                self._breaker_record_success()
                 self._last_description = description
                 self._last_visual_vector = current_vector
                 self._last_appraisal_time = time.time()
@@ -139,6 +179,7 @@ class VisualAppraisalService:
                 # vector/timestamp so a persistently quiet scene doesn't keep
                 # re-triggering VLM calls every tick the way a genuine
                 # pipeline failure should (below).
+                self._breaker_record_success()
                 self._last_visual_vector = current_vector
                 self._last_appraisal_time = time.time()
                 logger.debug(
@@ -148,12 +189,14 @@ class VisualAppraisalService:
                 # description is None: the call itself failed. Deliberately
                 # does NOT update the habituation vector/timestamp, so the
                 # next tick retries the VLM rather than treating this frame
-                # as an observed (quiet) baseline.
+                # as an observed (quiet) baseline -- until the breaker opens.
+                self._breaker_record_failure()
                 logger.warning(
                     "[VisualAppraisal] VLM pipeline failure, using cache."
                 )
 
         except Exception as e:
+            self._breaker_record_failure()
             logger.error(
                 "[VisualAppraisal] VLM appraisal failed: %s. Using cached description.",
                 e,

--- a/backend/main.py
+++ b/backend/main.py
@@ -288,9 +288,28 @@ async def toggle_vision(source: str):
     return await backend.toggle_vision_source(source)
 
 
+def _read_sqlite_fallback_sentinel() -> dict | None:
+    """P1-6: runtime_bootstrap.py runs in a different process (brain_agent
+    or the standalone bootstrap script), so a sentinel file is how it tells
+    this process's /health that the emergency-only SQLite mode is active."""
+    path = getattr(Config, "SQLITE_FALLBACK_HEALTH_FILE", "")
+    if not path:
+        return None
+    try:
+        with open(path) as fh:
+            return json.loads(fh.read())
+    except (OSError, ValueError):
+        return None
+
+
 @app.get("/health")
 async def health():
-    return {"status": "healthy", "nats": backend.is_ready}
+    payload = {"status": "healthy", "nats": backend.is_ready}
+    sqlite_fallback = _read_sqlite_fallback_sentinel()
+    if sqlite_fallback:
+        payload["degraded"] = True
+        payload["degraded_reason"] = sqlite_fallback.get("reason")
+    return payload
 
 
 if __name__ == "__main__":

--- a/backend/scripts/check_subject_wiring.py
+++ b/backend/scripts/check_subject_wiring.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""
+P1-8: assert NATS subject wiring statically, in CI.
+
+`ARCHITECTURE.md` (audit/, this repo's forensic audit) found eight subjects
+wired at one end only across three separate milestones -- each failing half
+compiled, passed its own tests, and logged as though it were working,
+because NATS subjects are plain strings: nothing type-checks a publisher
+against its subscriber, or a subject against the stream that is supposed to
+carry it. This script is the fix for the *category*, not any one instance
+of it: it statically enumerates every subject this codebase publishes or
+subscribes to (Python via `Topics.*` / string literals / the
+`"subject": "..."` mesh-signal dict pattern in `cognitive/pipeline.py`, Rust
+via the `topics::*` constants), cross-references them against the `Topics`
+enum, the Rust `topics` module, and the stream patterns in
+`nats_streams.py`, and fails on:
+
+  - a subject published but never subscribed, or subscribed but never
+    published (one end wired, the other missing)
+  - a subject that matches no declared JetStream stream pattern at all
+
+A curated ALLOWLIST below covers issues already known and tracked in
+`audit/ROADMAP.md` (or judged not to need a subscriber -- e.g. a
+frontend/browser consumer this repo's static scan cannot see). Anything not
+allowlisted is a new finding and fails the build; extending the allowlist
+requires a reason, by construction of the data structure below.
+
+Usage: python scripts/check_subject_wiring.py
+Exit 0 = every subject is either fully wired or explicitly allowlisted.
+Exit 1 = an unallowlisted issue exists (printed with locations).
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = BACKEND_ROOT / "app"
+CRATES_ROOT = BACKEND_ROOT / "crates"
+CONTRACTS_PY = APP_ROOT / "contracts.py"
+NATS_STREAMS_PY = APP_ROOT / "nats_streams.py"
+CONTRACTS_RS = CRATES_ROOT / "contracts" / "src" / "lib.rs"
+
+# subject -> reason. Each entry is a defect already tracked in
+# audit/ROADMAP.md (or a deliberate cross-boundary design, annotated as
+# such), not something this check should keep discovering as new.
+ALLOWLIST: dict[str, str] = {
+    # M1-D1 / M0-D11: wired for cache invalidation, never published anywhere.
+    "cache.sync": "ROADMAP P4-1: wire or delete IdentityCoreStore/cache.sync",
+    # M2-A2 / M2-A4: AGENT_VOICE_MODULATION and AUDIO_PLAYBACK_VISEMES are
+    # published to NATS but consumed by the frontend voice UI directly
+    # (LiveKit data track / browser client), not by another backend agent --
+    # this scan only sees backend Python/Rust, so a real consumer existing
+    # outside the repo's static reach is expected here, not a defect.
+    "agent.voice.modulation": "consumed by the frontend voice UI, not a backend agent",
+    "audio.playback.visemes": "consumed by the frontend voice UI, not a backend agent",
+    # M3-A1 / P4-2: Q-M3-1 resolved -- the intended publisher was always the
+    # browser-side PCM player (docs/API_SPEC.md), never built. Subscriber
+    # exists (brain_agent.py) and is a real, tracked gap, not new.
+    "audio.playback.progress": "ROADMAP P4-2: intended publisher (browser player) never built",
+    # M3-A5: matches no CORE_STREAMS pattern at all -- not `chat.>`,
+    # `audio.>`, or any other declared wildcard.
+    "ambient.noise.telemetry": "ROADMAP P3-12 / M3-A5: matches no declared stream pattern",
+    # M4-11a / Q-M1-1: Rust subscribes over core NATS (not JetStream), so it
+    # is invisible to a scan keyed on `topics::` constants passed to a
+    # jetstream `.publish`/`.subscribe` call -- confirmed present by manual
+    # read at M1/M3, tracked as a reliability trade-off, not missing wiring.
+    "audio.stream": "ROADMAP P4-11a: Rust-side core-NATS subscriber, not JetStream-visible to this scan",
+    # Discovered while building this check (not one of the audit's original
+    # eight) -- genuinely new findings, allowlisted so this check can land
+    # enforcing rather than warn-only, per ROADMAP P1-8. Each needs its own
+    # look, tracked here rather than silently fixed as a drive-by.
+    "audio.pre_generate": "NEW (found building this check): published by cognitive/pipeline.py mesh_signal, zero subscribers anywhere -- needs investigation, not yet in ROADMAP",
+    "telemetry.reflection": "NEW (found building this check): published by cognitive/core.py, matches no declared stream pattern and has zero subscribers -- needs investigation, not yet in ROADMAP",
+    "state.subconscious": "NEW (found building this check): subconscious_agent's internal-monologue thought is published, zero subscribers anywhere -- needs investigation, not yet in ROADMAP",
+    "voice.segmentation_feedback": "NEW (found building this check): brain_agent subscribes, zero publishers anywhere in Python or Rust -- needs investigation, not yet in ROADMAP",
+    "control.interrupt": "NEW (found building this check): cognitive/action.py's self-correction path publishes this alongside audio.stop (which IS subscribed); control.interrupt itself has zero subscribers -- needs investigation, not yet in ROADMAP",
+    "vision.frames": "NEW (found building this check): the only publish call is commented out in vision/agent.py ('TEMPORARILY DISABLED FOR DIAGNOSTICS'), brain_agent still subscribes -- deliberately not silently re-enabled by this batch, needs its own investigation",
+}
+
+PUBLISH_METHODS = {"publish", "publish_cb", "publish_with_headers", "publish_pcm"}
+SUBSCRIBE_METHODS = {"subscribe"}
+
+# Python files whose publish/subscribe calls are the generic transport
+# implementation (forwarding whatever subject the caller passed), not a
+# declaration of a specific subject -- would only ever contribute noise to
+# the UNRESOLVED bucket.
+TRANSPORT_IMPL_FILES = {APP_ROOT / "agents" / "base.py"}
+
+
+@dataclass
+class Site:
+    file: str
+    line: int
+
+
+@dataclass
+class SubjectUsage:
+    publish_sites: list[Site] = field(default_factory=list)
+    subscribe_sites: list[Site] = field(default_factory=list)
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(BACKEND_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def parse_python_topics() -> dict[str, str]:
+    """Topics.NAME -> "subject.value", from the `class Topics(str, Enum)` in
+    contracts.py."""
+    tree = ast.parse(CONTRACTS_PY.read_text(), filename=str(CONTRACTS_PY))
+    topics: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "Topics":
+            for stmt in node.body:
+                if (
+                    isinstance(stmt, ast.Assign)
+                    and len(stmt.targets) == 1
+                    and isinstance(stmt.targets[0], ast.Name)
+                    and isinstance(stmt.value, ast.Constant)
+                    and isinstance(stmt.value.value, str)
+                ):
+                    topics[stmt.targets[0].id] = stmt.value.value
+    return topics
+
+
+def parse_rust_topics() -> dict[str, str]:
+    """topics::NAME -> "subject.value", from the Rust `pub mod topics` block."""
+    text = CONTRACTS_RS.read_text()
+    module_match = re.search(r"pub mod topics\s*\{(.*?)\n\}", text, re.DOTALL)
+    if not module_match:
+        return {}
+    body = module_match.group(1)
+    return dict(re.findall(r'pub const ([A-Z_]+):\s*&str\s*=\s*"([^"]+)";', body))
+
+
+def parse_core_streams() -> dict[str, list[str]]:
+    tree = ast.parse(NATS_STREAMS_PY.read_text(), filename=str(NATS_STREAMS_PY))
+    for node in ast.walk(tree):
+        # CORE_STREAMS: dict[str, Sequence[str]] = {...} is an AnnAssign
+        # (annotated assignment), not a plain Assign.
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "CORE_STREAMS"
+            and node.value is not None
+        ):
+            return ast.literal_eval(node.value)
+    return {}
+
+
+def subject_matches_pattern(subject: str, pattern: str) -> bool:
+    """NATS wildcard match: `>` matches one or more trailing tokens, `*`
+    matches exactly one token. Only `>` is actually used in this repo's
+    CORE_STREAMS, but both are handled since they're both valid NATS syntax.
+    """
+    subj_tokens = subject.split(".")
+    pat_tokens = pattern.split(".")
+
+    for i, pat_tok in enumerate(pat_tokens):
+        if pat_tok == ">":
+            return len(subj_tokens) > i
+        if i >= len(subj_tokens):
+            return False
+        if pat_tok == "*":
+            continue
+        if pat_tok != subj_tokens[i]:
+            return False
+    return len(subj_tokens) == len(pat_tokens)
+
+
+def matches_any_stream(subject: str, streams: dict[str, list[str]]) -> bool:
+    return any(
+        subject_matches_pattern(subject, pattern)
+        for patterns in streams.values()
+        for pattern in patterns
+    )
+
+
+def _resolve_topics_attribute(node: ast.expr, py_topics: dict[str, str]) -> str | None:
+    """Resolve `Topics.NAME` or `Topics.NAME.value` to its subject string."""
+    target = node
+    if (
+        isinstance(target, ast.Attribute)
+        and target.attr == "value"
+        and isinstance(target.value, ast.Attribute)
+    ):
+        target = target.value
+    if (
+        isinstance(target, ast.Attribute)
+        and isinstance(target.value, ast.Name)
+        and target.value.id == "Topics"
+    ):
+        return py_topics.get(target.attr)
+    return None
+
+
+def scan_python(
+    py_topics: dict[str, str], usage: dict[str, SubjectUsage], unresolved: list[Site]
+) -> None:
+    py_files = list(APP_ROOT.rglob("*.py"))
+    main_py = BACKEND_ROOT / "main.py"
+    if main_py.exists():
+        py_files.append(main_py)
+
+    for path in sorted(py_files):
+        if "tests" in path.parts or path in TRANSPORT_IMPL_FILES:
+            continue
+        try:
+            tree = ast.parse(path.read_text(), filename=str(path))
+        except SyntaxError:
+            continue
+
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+            ):
+                continue
+            method = node.func.attr
+            if method not in PUBLISH_METHODS and method not in SUBSCRIBE_METHODS:
+                continue
+            if not node.args:
+                continue
+
+            arg = node.args[0]
+            subject: str | None = None
+            if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                subject = arg.value
+            else:
+                subject = _resolve_topics_attribute(arg, py_topics)
+
+            site = Site(_rel(path), node.lineno)
+            if subject is None:
+                unresolved.append(site)
+                continue
+
+            entry = usage.setdefault(subject, SubjectUsage())
+            if method in PUBLISH_METHODS:
+                entry.publish_sites.append(site)
+            else:
+                entry.subscribe_sites.append(site)
+
+        # Auxiliary pattern: `"subject": "literal"` dict entries, the shape
+        # cognitive/pipeline.py's mesh_signal producers use -- the actual
+        # publish call (cognitive/core.py's generic `self.agent.publish
+        # (subject, data)`) takes a runtime variable, unresolvable by the
+        # AST scan above, so this catches the subject at its true origin.
+        text = path.read_text()
+        for match in re.finditer(r'"subject":\s*"([a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+)+)"', text):
+            line = text[: match.start()].count("\n") + 1
+            entry = usage.setdefault(match.group(1), SubjectUsage())
+            entry.publish_sites.append(Site(_rel(path), line))
+
+
+def scan_rust(rust_topics: dict[str, str], usage: dict[str, SubjectUsage]) -> None:
+    for path in sorted(CRATES_ROOT.rglob("src/*.rs")):
+        text = path.read_text()
+        for match in re.finditer(
+            r"\.(publish|publish_with_headers|subscribe)\(\s*(?:\n\s*)?topics::([A-Z_]+)",
+            text,
+        ):
+            method, const_name = match.group(1), match.group(2)
+            subject = rust_topics.get(const_name)
+            if subject is None:
+                continue
+            line = text[: match.start()].count("\n") + 1
+            entry = usage.setdefault(subject, SubjectUsage())
+            site = Site(_rel(path), line)
+            if method == "subscribe":
+                entry.subscribe_sites.append(site)
+            else:
+                entry.publish_sites.append(site)
+
+
+def main() -> int:
+    py_topics = parse_python_topics()
+    rust_topics = parse_rust_topics()
+    streams = parse_core_streams()
+
+    usage: dict[str, SubjectUsage] = {}
+    unresolved: list[Site] = []
+    scan_python(py_topics, usage, unresolved)
+    scan_rust(rust_topics, usage)
+
+    known_subjects = set(py_topics.values()) | set(rust_topics.values())
+    all_subjects = known_subjects | set(usage.keys())
+
+    failures: list[str] = []
+    allowlisted: list[str] = []
+
+    for subject in sorted(all_subjects):
+        entry = usage.get(subject, SubjectUsage())
+        problems: list[str] = []
+
+        if entry.publish_sites and not entry.subscribe_sites:
+            problems.append("published but never subscribed")
+        elif entry.subscribe_sites and not entry.publish_sites:
+            problems.append("subscribed but never published")
+        elif not entry.publish_sites and not entry.subscribe_sites:
+            # Declared (in Topics/topics::) but used nowhere this scan can
+            # see -- not this check's concern (that's dead-code territory,
+            # a different finding class), so it's neither a failure nor
+            # printed as one.
+            continue
+
+        if not matches_any_stream(subject, streams):
+            problems.append("matches no declared stream pattern")
+
+        if not problems:
+            continue
+
+        reason = ALLOWLIST.get(subject)
+        detail = f"{subject}: {'; '.join(problems)}"
+        if entry.publish_sites:
+            detail += "\n    published at: " + ", ".join(
+                f"{s.file}:{s.line}" for s in entry.publish_sites
+            )
+        if entry.subscribe_sites:
+            detail += "\n    subscribed at: " + ", ".join(
+                f"{s.file}:{s.line}" for s in entry.subscribe_sites
+            )
+
+        if reason is not None:
+            allowlisted.append(f"{detail}\n    allowlisted: {reason}")
+        else:
+            failures.append(detail)
+
+    print(f"Subjects declared (Topics/topics::): {len(known_subjects)}")
+    print(f"Subjects observed in publish/subscribe call sites: {len(usage)}")
+    if unresolved:
+        print(
+            f"Unresolved (dynamic) subject arguments -- informational, not "
+            f"enforced: {len(unresolved)}"
+        )
+        for site in unresolved:
+            print(f"    {site.file}:{site.line}")
+    print()
+
+    if allowlisted:
+        print(f"=== {len(allowlisted)} known issue(s), allowlisted ===")
+        for item in allowlisted:
+            print(item)
+        print()
+
+    if failures:
+        print(f"=== {len(failures)} UNALLOWLISTED issue(s) ===")
+        for item in failures:
+            print(item)
+        print()
+        print(
+            "A subject above is wired at only one end, or matches no "
+            "declared stream. If this is a real defect, fix it. If it is a "
+            "deliberate design (e.g. a frontend-only consumer this scan "
+            "cannot see), add it to ALLOWLIST in this script with a reason."
+        )
+        return 1
+
+    print("OK: every observed subject is fully wired or explicitly allowlisted.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_check_subject_wiring.py
+++ b/backend/tests/test_check_subject_wiring.py
@@ -1,0 +1,116 @@
+"""
+P1-8: the subject-wiring checker (scripts/check_subject_wiring.py) is CI
+enforcement, so it needs to prove it actually catches the defect class it
+exists for - a fixture with a one-ended subject must fail it, per
+`ROADMAP.md`'s own requirement for this item ("the check tests itself").
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import check_subject_wiring as wiring
+
+
+def test_the_real_repository_passes_clean():
+    """Regression guard: if this starts failing, either a real wiring
+    defect was introduced, or something the checker doesn't yet know about
+    needs an ALLOWLIST entry - not the check silently going warn-only."""
+    assert wiring.main() == 0
+
+
+@pytest.fixture
+def fixture_repo(tmp_path, monkeypatch):
+    """A minimal synthetic repo tree with a known one-ended subject, so the
+    checker's logic can be exercised in isolation from the real codebase."""
+    backend_root = tmp_path
+    app_root = backend_root / "app"
+    crates_root = backend_root / "crates"
+    app_root.mkdir()
+    crates_root.mkdir()
+
+    (app_root / "contracts.py").write_text(
+        "from enum import Enum\n\n\n"
+        "class Topics(str, Enum):\n"
+        '    ONE_ENDED = "test.one_ended"\n'
+        '    WELL_WIRED = "test.well_wired"\n'
+    )
+    (app_root / "nats_streams.py").write_text(
+        "CORE_STREAMS: dict = {\n"
+        '    "TEST_STREAM": ["test.>"],\n'
+        "}\n"
+    )
+    (crates_root / "contracts").mkdir()
+    (crates_root / "contracts" / "src").mkdir(parents=True)
+    (crates_root / "contracts" / "src" / "lib.rs").write_text("pub mod topics {}\n")
+
+    agent_file = app_root / "some_agent.py"
+    agent_file.write_text(
+        "from .contracts import Topics\n\n\n"
+        "async def run(agent):\n"
+        "    # ONE_ENDED is published but nothing ever subscribes to it.\n"
+        "    await agent.publish(Topics.ONE_ENDED, {})\n"
+        "    await agent.subscribe(Topics.WELL_WIRED, handler)\n"
+    )
+    another_file = app_root / "another_agent.py"
+    another_file.write_text(
+        "from .contracts import Topics\n\n\n"
+        "async def run(agent):\n"
+        "    await agent.publish(Topics.WELL_WIRED, {})\n"
+    )
+
+    monkeypatch.setattr(wiring, "BACKEND_ROOT", backend_root)
+    monkeypatch.setattr(wiring, "APP_ROOT", app_root)
+    monkeypatch.setattr(wiring, "CRATES_ROOT", crates_root)
+    monkeypatch.setattr(wiring, "CONTRACTS_PY", app_root / "contracts.py")
+    monkeypatch.setattr(wiring, "NATS_STREAMS_PY", app_root / "nats_streams.py")
+    monkeypatch.setattr(
+        wiring, "CONTRACTS_RS", crates_root / "contracts" / "src" / "lib.rs"
+    )
+    monkeypatch.setattr(wiring, "TRANSPORT_IMPL_FILES", set())
+    monkeypatch.setattr(wiring, "ALLOWLIST", {})
+
+    return backend_root
+
+
+def test_fixture_with_one_ended_subject_fails(fixture_repo, capsys):
+    """The check's core purpose: a subject published but never subscribed
+    (or vice versa) must fail the build, not just get logged."""
+    exit_code = wiring.main()
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "test.one_ended" in captured.out
+    assert "published but never subscribed" in captured.out
+
+
+def test_fixture_well_wired_subject_does_not_fail(fixture_repo, capsys):
+    """The inverse guard: a subject with both ends wired must NOT appear in
+    the failure output - otherwise the check would be trivially useless
+    (failing on everything, including correct wiring)."""
+    wiring.main()
+
+    captured = capsys.readouterr()
+    unallowlisted_section = captured.out.split("UNALLOWLISTED")[-1]
+    assert "test.well_wired" not in unallowlisted_section
+
+
+def test_allowlisted_issue_does_not_fail_the_build(fixture_repo, monkeypatch, capsys):
+    """An allowlisted subject still gets reported (for visibility) but must
+    not fail the build - that is the whole point of the allowlist letting
+    this check land enforcing rather than warn-only."""
+    monkeypatch.setattr(
+        wiring, "ALLOWLIST", {"test.one_ended": "deliberately allowlisted for this test"}
+    )
+
+    exit_code = wiring.main()
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "test.one_ended" in captured.out
+    assert "allowlisted: deliberately allowlisted for this test" in captured.out

--- a/backend/tests/test_health_sqlite_fallback.py
+++ b/backend/tests/test_health_sqlite_fallback.py
@@ -1,0 +1,72 @@
+"""
+P1-6: /health must surface the emergency-only SQLite fallback so it stops
+being invisible - runtime_bootstrap.py writes a sentinel file from a
+different process (brain_agent), and /health (main.py's own process) reads
+it back.
+"""
+
+import importlib
+import json
+
+from fastapi.testclient import TestClient
+
+from app import config as config_module
+
+
+def _import_main(monkeypatch, sentinel_path):
+    monkeypatch.setattr(
+        config_module.config_instance, "SQLITE_FALLBACK_HEALTH_FILE", str(sentinel_path)
+    )
+    import main
+
+    importlib.reload(main)
+    # /health carries the app-wide require_lan_client dependency (LAN_ONLY
+    # defaults True); TestClient's synthetic host isn't a real IP, so it
+    # fails that check with 403 unless overridden - unrelated to what this
+    # test is actually checking.
+    main.app.dependency_overrides[main.require_lan_client] = lambda: None
+    return main
+
+
+def test_health_reports_degraded_when_sentinel_present(tmp_path, monkeypatch):
+    sentinel = tmp_path / "sqlite_fallback_active"
+    sentinel.write_text(
+        json.dumps({"reason": "PostgreSQL connection failed: timeout", "timestamp": 0.0})
+    )
+
+    main = _import_main(monkeypatch, sentinel)
+    client = TestClient(main.app)
+
+    response = client.get("/health")
+
+    body = response.json()
+    assert body["degraded"] is True
+    assert body["degraded_reason"] == "PostgreSQL connection failed: timeout"
+
+
+def test_health_does_not_report_degraded_when_sentinel_absent(tmp_path, monkeypatch):
+    sentinel = tmp_path / "does_not_exist"
+
+    main = _import_main(monkeypatch, sentinel)
+    client = TestClient(main.app)
+
+    response = client.get("/health")
+
+    body = response.json()
+    assert "degraded" not in body
+    assert body["status"] == "healthy"
+
+
+def test_health_tolerates_a_corrupt_sentinel_file(tmp_path, monkeypatch):
+    """A malformed sentinel (partial write, disk full mid-write) must not
+    take /health itself down."""
+    sentinel = tmp_path / "sqlite_fallback_active"
+    sentinel.write_text("not valid json{{{")
+
+    main = _import_main(monkeypatch, sentinel)
+    client = TestClient(main.app)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert "degraded" not in response.json()

--- a/backend/tests/test_reflection.py
+++ b/backend/tests/test_reflection.py
@@ -76,6 +76,50 @@ async def test_fact_rejection_low_confidence(
 
 
 @pytest.mark.asyncio
+async def test_repeated_fact_is_reinforced_not_skipped(
+    reflection_service, mock_llm_service, mock_graph_db
+):
+    """P2-13: `_consolidate` used to MATCH for an existing relationship and
+    `continue` on a hit, logging "Fact RESOLVED" and never writing anything -
+    so a restated fact never reinforced its edge weight, while
+    `decay_relationships` still pushed every edge toward the prune threshold
+    regardless of repetition. `create_triplet` must be called every time the
+    same fact is extracted, so `consolidate_relationship`'s own `ON MATCH SET
+    r.weight = coalesce(r.weight, 1) + 1` actually runs on a repeat instead
+    of being unreachable.
+    """
+    # _consolidate makes three sequential self.llm.generate calls per
+    # invocation (facts, identity suggestion, episodic summary) - all six
+    # must be supplied since the mock's side_effect iterator is shared
+    # across both calls below.
+    mock_llm_service.generate.side_effect = [
+        '[{"subject": "User", "relation": "LIKES", "object": "Tea", "confidence": 0.9}]',
+        "{}",
+        "We talked about tea.",
+        '[{"subject": "User", "relation": "LIKES", "object": "Tea", "confidence": 0.9}]',
+        "{}",
+        "We talked about tea again.",
+    ]
+
+    await reflection_service._consolidate(
+        [{"content": "I like tea", "response": "Noted."}]
+    )
+    await reflection_service._consolidate(
+        [{"content": "I still like tea", "response": "Noted again."}]
+    )
+
+    assert mock_graph_db.create_triplet.call_count == 2
+    mock_graph_db.create_triplet.assert_called_with(
+        "User",
+        "LIKES",
+        "Tea",
+        properties=ANY,
+        subject_label="Entity",
+        target_label="Entity",
+    )
+
+
+@pytest.mark.asyncio
 async def test_synonym_relations_are_canonicalized_before_storage(
     reflection_service, mock_llm_service, mock_graph_db
 ):

--- a/backend/tests/test_runtime_bootstrap.py
+++ b/backend/tests/test_runtime_bootstrap.py
@@ -12,7 +12,7 @@ import logging
 import pytest
 
 from app import config as config_module
-from app.runtime_bootstrap import _enter_sqlite_fallback
+from app.runtime_bootstrap import _clear_sqlite_fallback, _enter_sqlite_fallback
 
 
 @pytest.fixture(autouse=True)
@@ -74,3 +74,34 @@ def test_fallback_writes_health_sentinel(tmp_path, monkeypatch):
     payload = json.loads(sentinel.read_text())
     assert payload["reason"] == "PostgreSQL connection failed: timeout"
     assert "timestamp" in payload
+
+
+def test_recovery_clears_the_health_sentinel(tmp_path, monkeypatch):
+    """The signal has to turn off again. Without this, one transient
+    Postgres outage leaves /health reporting `degraded: true` for the
+    lifetime of the host, long after Postgres came back - and a warning
+    that never clears is one operators stop reading, which is the same
+    silence this item set out to fix."""
+    sentinel = tmp_path / "sqlite_fallback_active"
+    monkeypatch.setattr(
+        config_module.config_instance, "SQLITE_FALLBACK_HEALTH_FILE", str(sentinel)
+    )
+
+    _enter_sqlite_fallback(reason="PostgreSQL connection failed: timeout")
+    assert sentinel.exists()
+
+    _clear_sqlite_fallback()
+
+    assert not sentinel.exists()
+
+
+def test_clearing_an_absent_sentinel_is_not_an_error(tmp_path, monkeypatch):
+    """The healthy path runs this on every boot, and on almost all of them
+    there is no sentinel to remove. It must not raise into bootstrap."""
+    monkeypatch.setattr(
+        config_module.config_instance,
+        "SQLITE_FALLBACK_HEALTH_FILE",
+        str(tmp_path / "never_written"),
+    )
+
+    _clear_sqlite_fallback()

--- a/backend/tests/test_runtime_bootstrap.py
+++ b/backend/tests/test_runtime_bootstrap.py
@@ -1,0 +1,76 @@
+"""
+P1-6: a Postgres connection failure at bootstrap used to log at WARNING and
+silently fall back to SQLite, losing pgvector with no other signal. Q-M2-2
+answered SQLite as emergency-only, not a supported runtime mode, so entering
+it unnoticed is the actual defect -- M2-P3's synchronous SQLite I/O then
+blocks the whole mesh's event loop in a mode nobody knows it entered.
+"""
+
+import json
+import logging
+
+import pytest
+
+from app import config as config_module
+from app.runtime_bootstrap import _enter_sqlite_fallback
+
+
+@pytest.fixture(autouse=True)
+def _reset_environment(monkeypatch):
+    """Every test starts from a known ENVIRONMENT/ALLOW_SQLITE_FALLBACK
+    baseline regardless of what an earlier test (or the real .env) set."""
+    monkeypatch.setattr(config_module.config_instance, "ENVIRONMENT", "development")
+    monkeypatch.setattr(config_module.config_instance, "ALLOW_SQLITE_FALLBACK", False)
+
+
+def test_fallback_logs_at_error_not_warning(monkeypatch, caplog):
+    """The original bug was specifically that this was invisible at default
+    log levels - WARNING is easy to filter out; ERROR is not."""
+    with caplog.at_level(logging.ERROR, logger="runtime_bootstrap"):
+        _enter_sqlite_fallback(reason="PostgreSQL connection failed: timeout")
+
+    assert any(
+        record.levelno == logging.ERROR and "PostgreSQL connection failed" in record.message
+        for record in caplog.records
+    )
+
+
+def test_fallback_fails_closed_in_production_by_default(monkeypatch):
+    """Q-M2-2: SQLite is emergency-only. A production deployment silently
+    losing pgvector is worse than refusing to start."""
+    monkeypatch.setattr(config_module.config_instance, "ENVIRONMENT", "production")
+
+    with pytest.raises(RuntimeError, match="Refusing to silently downgrade"):
+        _enter_sqlite_fallback(reason="PostgreSQL connection failed: timeout")
+
+
+def test_fallback_allowed_in_production_with_explicit_override(monkeypatch):
+    """ALLOW_SQLITE_FALLBACK is the documented escape hatch for a deliberate
+    degraded production deployment - it must not fail closed."""
+    monkeypatch.setattr(config_module.config_instance, "ENVIRONMENT", "production")
+    monkeypatch.setattr(config_module.config_instance, "ALLOW_SQLITE_FALLBACK", True)
+
+    _enter_sqlite_fallback(reason="PostgreSQL connection failed: timeout")
+
+
+def test_fallback_does_not_fail_closed_outside_production(monkeypatch):
+    monkeypatch.setattr(config_module.config_instance, "ENVIRONMENT", "development")
+
+    _enter_sqlite_fallback(reason="PostgreSQL connection failed: timeout")
+
+
+def test_fallback_writes_health_sentinel(tmp_path, monkeypatch):
+    """A different process (main.py's /health) reads this file, so its
+    shape - a JSON object with `reason` - is a real contract, not just a
+    debugging aid."""
+    sentinel = tmp_path / "sqlite_fallback_active"
+    monkeypatch.setattr(
+        config_module.config_instance, "SQLITE_FALLBACK_HEALTH_FILE", str(sentinel)
+    )
+
+    _enter_sqlite_fallback(reason="PostgreSQL connection failed: timeout")
+
+    assert sentinel.exists()
+    payload = json.loads(sentinel.read_text())
+    assert payload["reason"] == "PostgreSQL connection failed: timeout"
+    assert "timestamp" in payload

--- a/backend/tests/test_state.py
+++ b/backend/tests/test_state.py
@@ -1,8 +1,9 @@
+import asyncio
 from datetime import datetime, timedelta
 
 import pytest
 
-from app.state.agent_state import StateService
+from app.state.agent_state import AgentState, StateService
 
 
 @pytest.fixture
@@ -197,3 +198,95 @@ async def test_events_still_apply_without_emotional_bias(state_service):
     assert state_service.current_state.energy > 0.5
     # ...but the absent emotion estimate still must not move mood.
     assert state_service.current_state.mood == baseline_mood
+
+
+# --------------------------------------------------------------------------
+# P1-5: apply_external_state -- subconscious_agent observing the brain's
+# state.broadcast, instead of holding an independent, never-updated copy.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_external_state_updates_fields_from_broadcast(state_service):
+    """The exact payload shape persist_state() publishes on state.broadcast
+    must actually change current_state - this is the behavior that was
+    entirely missing before (M1-A6/M1-A8): a broadcast arrived and nothing
+    read it into the receiving process's own state."""
+    broadcast = {
+        "agent_name": "my friend",
+        "mood": 0.42,
+        "energy": 0.77,
+        "dominance": 0.61,
+        "trust_benevolence": 0.3,
+        "trust_competence": 0.35,
+        "trust_integrity": 0.4,
+        "attachment": 0.55,
+        "fatigue": 0.2,
+        "last_user_interaction": 1234.5,
+        "interaction_count": 7,
+        "inferred_valence": 0.15,
+        "inferred_arousal": 0.6,
+        "implied_goals": ["finish the report"],
+        "known_concepts": ["deadlines"],
+        "baseline_valence": 0.1,
+        "baseline_arousal": 0.5,
+        "baseline_dominance": 0.5,
+    }
+
+    await state_service.apply_external_state(broadcast)
+
+    assert state_service.current_state.mood == 0.42
+    assert state_service.current_state.energy == 0.77
+    assert state_service.current_state.dominance == 0.61
+    assert state_service.current_state.trust_benevolence == 0.3
+    assert state_service.current_state.attachment == 0.55
+    assert state_service.current_state.fatigue == 0.2
+    assert state_service.current_state.interaction_count == 7
+    assert state_service.current_state.user_mental_model.inferred_valence == 0.15
+    assert state_service.current_state.user_mental_model.implied_goals == [
+        "finish the report"
+    ]
+    assert state_service.current_state.baseline_valence == 0.1
+
+
+@pytest.mark.asyncio
+async def test_apply_external_state_holds_the_state_lock():
+    """Same discipline as hydrate_state (test_hydration_holds_the_same_lock_
+    as_every_other_mutation in test_audit_hygiene.py): applying a broadcast
+    that arrives mid fire-and-forget System-2 appraisal must not interleave
+    with it and leave current_state half-overwritten, half-appraised."""
+    service = object.__new__(StateService)
+    service._state_lock = asyncio.Lock()
+    service.current_state = AgentState()
+
+    observed_locked_during_call = []
+
+    original_lock_acquire = service._state_lock.acquire
+
+    async def spying_acquire():
+        result = await original_lock_acquire()
+        observed_locked_during_call.append(service._state_lock.locked())
+        return result
+
+    service._state_lock.acquire = spying_acquire
+
+    await service.apply_external_state({"mood": 0.9})
+
+    assert observed_locked_during_call == [True]
+
+
+@pytest.mark.asyncio
+async def test_apply_external_state_preserves_fields_missing_from_broadcast(
+    state_service,
+):
+    """A partial broadcast must not reset unlisted fields to a hardcoded
+    default the way hydrate_state's Redis/SQLite branches do (there, a
+    missing field means 'never persisted, use a sane zero'; here, a missing
+    field means 'unchanged since the last broadcast', a different case)."""
+    state_service.current_state.dominance = 0.73
+    state_service.current_state.attachment = 0.44
+
+    await state_service.apply_external_state({"mood": 0.1})
+
+    assert state_service.current_state.dominance == 0.73
+    assert state_service.current_state.attachment == 0.44

--- a/backend/tests/test_subconscious.py
+++ b/backend/tests/test_subconscious.py
@@ -118,3 +118,69 @@ class TestBrainAgentSubconsciousRouting:
         # 3. Ensure stream_to_speech was called with is_proactive=True
         agent._stream_to_speech.assert_awaited_once()
         assert agent._stream_to_speech.await_args.kwargs["is_proactive"] is True
+
+
+class TestSubconsciousAgentStateSharing:
+    """P1-5: subconscious_agent's AgentState was never hydrated and never
+    updated - an independent copy diverging from the brain's real state
+    from the moment each process started. Every silence gate and the dream
+    path read that same never-synced state."""
+
+    @pytest.mark.asyncio
+    async def test_state_broadcast_is_applied_to_this_process_own_state(self):
+        from app.agents.subconscious_agent import SubconsciousAgent
+
+        mock_state_service = MagicMock()
+        mock_state_service.apply_external_state = AsyncMock()
+        mock_graph_db = MagicMock()
+        mock_graph_db.execute_query = AsyncMock(return_value=[{"name": "my friend"}])
+        mock_graph_db.invalidate_cache = AsyncMock()
+
+        agent = SubconsciousAgent(state_service=mock_state_service, graph_db=mock_graph_db)
+
+        broadcast = {"agent_name": "my friend", "mood": 0.42, "energy": 0.8}
+        await agent._on_state_broadcast(broadcast)
+
+        mock_state_service.apply_external_state.assert_awaited_once_with(broadcast)
+
+    @pytest.mark.asyncio
+    async def test_state_broadcast_with_invalid_agent_name_does_not_touch_state(self):
+        """The existing agent_name validation must still short-circuit
+        before either sync path runs - applying a malformed broadcast is
+        worse than dropping it."""
+        from app.agents.subconscious_agent import SubconsciousAgent
+
+        mock_state_service = MagicMock()
+        mock_state_service.apply_external_state = AsyncMock()
+
+        agent = SubconsciousAgent(state_service=mock_state_service, graph_db=MagicMock())
+
+        await agent._on_state_broadcast({"agent_name": None, "mood": 0.9})
+
+        mock_state_service.apply_external_state.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_start_hydrates_state_before_serving(self, monkeypatch):
+        """A one-time catch-up on startup, so this process isn't running on
+        persona defaults until the first broadcast happens to arrive -
+        mirrors what CognitiveService.initialize() does on the brain side."""
+        from app.agents.subconscious_agent import SubconsciousAgent
+
+        mock_state_service = MagicMock()
+        mock_state_service.hydrate_state = AsyncMock()
+        mock_graph_db = MagicMock()
+        mock_graph_db.initialize = AsyncMock()
+
+        agent = SubconsciousAgent(state_service=mock_state_service, graph_db=mock_graph_db)
+        agent.connect = AsyncMock()
+        agent.subscribe = AsyncMock()
+        agent.memory_store = MagicMock()  # pre-set: skip the init-on-start block
+        agent.reflection_service = MagicMock()  # pre-set: skip the init-on-start block
+        agent._continuous_monologue_loop = AsyncMock()
+
+        await agent.start()
+
+        mock_state_service.hydrate_state.assert_awaited_once()
+        # Hydration must happen before the mesh is serving traffic, not
+        # racing the first tick/broadcast to decide which wins.
+        assert agent.connect.await_count >= 1

--- a/backend/tests/test_vision.py
+++ b/backend/tests/test_vision.py
@@ -144,6 +144,76 @@ class TestVisualAppraisalService:
         # Should bypass describe_image call completely due to habituation
         mock_ollama_client.describe_image.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_breaker_opens_after_consecutive_failures_and_stops_calling_vlm(
+        self, mock_appraisal_service, mock_ollama_client
+    ):
+        """M3-R3: a down VLM used to be retried every tick with a full
+        frame, with no backoff. After breaker_failure_threshold consecutive
+        pipeline failures, the VLM must not be called again until the
+        cooldown elapses."""
+        mock_appraisal_service._breaker_failure_threshold = 2
+        mock_ollama_client.describe_image = AsyncMock(return_value=None)
+
+        mock_appraisal_service._last_appraisal_time = time.time() - 2.0
+        await mock_appraisal_service.appraise("f1")
+        mock_appraisal_service._last_appraisal_time = time.time() - 2.0
+        await mock_appraisal_service.appraise("f2")
+        assert mock_appraisal_service._consecutive_failures == 2
+        assert mock_appraisal_service._breaker_opened_at > 0.0
+
+        mock_ollama_client.describe_image.reset_mock()
+        mock_appraisal_service._last_appraisal_time = time.time() - 2.0
+        desc = await mock_appraisal_service.appraise("f3")
+
+        mock_ollama_client.describe_image.assert_not_awaited()
+        assert desc == ""
+
+    @pytest.mark.asyncio
+    async def test_breaker_half_open_trial_after_cooldown_recovers_on_success(
+        self, mock_appraisal_service, mock_ollama_client
+    ):
+        """Once the cooldown has elapsed, the next call is a real attempt
+        (a half-open trial) - a success must close the breaker rather than
+        leaving it permanently open."""
+        mock_appraisal_service._breaker_failure_threshold = 1
+        mock_ollama_client.describe_image = AsyncMock(return_value=None)
+        mock_appraisal_service._last_appraisal_time = time.time() - 2.0
+        await mock_appraisal_service.appraise("f1")
+        assert mock_appraisal_service._breaker_opened_at > 0.0
+
+        # Simulate the cooldown window having elapsed.
+        mock_appraisal_service._breaker_cooldown_s = 0.01
+        mock_appraisal_service._breaker_opened_at = time.time() - 1.0
+        mock_ollama_client.describe_image = AsyncMock(return_value="Recovered scene.")
+        mock_appraisal_service._last_appraisal_time = time.time() - 2.0
+
+        desc = await mock_appraisal_service.appraise("f2")
+
+        mock_ollama_client.describe_image.assert_awaited_once()
+        assert desc == "Recovered scene."
+        assert mock_appraisal_service._consecutive_failures == 0
+        assert mock_appraisal_service._breaker_opened_at == 0.0
+
+    @pytest.mark.asyncio
+    async def test_breaker_success_resets_failure_count_below_threshold(
+        self, mock_appraisal_service, mock_ollama_client
+    ):
+        """A transient failure followed by a success must not accumulate
+        toward the threshold across unrelated errors."""
+        mock_appraisal_service._breaker_failure_threshold = 3
+        mock_ollama_client.describe_image = AsyncMock(return_value=None)
+        mock_appraisal_service._last_appraisal_time = time.time() - 2.0
+        await mock_appraisal_service.appraise("f1")
+        assert mock_appraisal_service._consecutive_failures == 1
+
+        mock_ollama_client.describe_image = AsyncMock(return_value="Back to normal.")
+        mock_appraisal_service._last_appraisal_time = time.time() - 2.0
+        await mock_appraisal_service.appraise("f2")
+
+        assert mock_appraisal_service._consecutive_failures == 0
+        assert mock_appraisal_service._breaker_opened_at == 0.0
+
 
 class TestVisionAgent:
     @pytest.mark.asyncio
@@ -214,3 +284,110 @@ class TestVisionAgent:
         assert msg.source == "screen"
         assert msg.user_distance is not None
         assert msg.user_distance == 1.0  # Fallback since frame is invalid/blank
+
+    @pytest.mark.asyncio
+    @patch("app.vision.agent.ScreenLink")
+    @patch("app.vision.agent.CameraLink")
+    async def test_appraisal_suspended_while_turn_in_flight(
+        self, mock_camera_cls, mock_screen_cls
+    ):
+        """P1-7: the VLM and the conversational LLM contend on one Ollama
+        endpoint (MEASURED -44%/-47% decode rate in audit/HARDWARE.md).
+        While a cognitive turn is in flight, appraisal must not call the
+        VLM at all - not even a rate-limited one."""
+        import base64
+
+        agent = VisionAgent()
+        agent.publish = AsyncMock()
+        mock_appraisal = MagicMock()
+        mock_appraisal.should_appraise.return_value = True
+        mock_appraisal.appraise = AsyncMock(return_value="Should not run.")
+        agent.appraisal = mock_appraisal
+
+        await agent._on_chat_input({})
+        assert agent._turn_in_flight is True
+
+        blank_frame_b64 = base64.b64encode(b"\x00" * 100).decode("utf-8")
+        await agent._run_appraisal(blank_frame_b64)
+
+        mock_appraisal.appraise.assert_not_awaited()
+        agent.publish.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @patch("app.vision.agent.ScreenLink")
+    @patch("app.vision.agent.CameraLink")
+    async def test_appraisal_resumes_once_turn_output_is_done(
+        self, mock_camera_cls, mock_screen_cls
+    ):
+        agent = VisionAgent()
+
+        await agent._on_chat_input({})
+        assert agent._turn_in_flight is True
+
+        # A non-final chunk must not close the turn.
+        await agent._on_chat_output({"done": False, "content": "partial"})
+        assert agent._turn_in_flight is True
+
+        await agent._on_chat_output({"done": True})
+        assert agent._turn_in_flight is False
+
+    @pytest.mark.asyncio
+    @patch("app.vision.agent.ScreenLink")
+    @patch("app.vision.agent.CameraLink")
+    async def test_turn_watchdog_resumes_appraisal_if_done_never_arrives(
+        self, mock_camera_cls, mock_screen_cls
+    ):
+        """A crashed brain_agent or a dropped chat.output must not blind
+        vision forever - bounded by LLM_STREAM_MAX_SECONDS, the same
+        deadline a turn itself is allowed to run for."""
+        from app.config import Config
+
+        agent = VisionAgent()
+        agent._turn_in_flight = True
+        agent._turn_started_at = time.time() - (Config.LLM_STREAM_MAX_SECONDS + 1)
+
+        assert agent._is_turn_in_flight() is False
+        assert agent._turn_in_flight is False
+
+    @pytest.mark.asyncio
+    @patch("app.vision.agent.ScreenLink")
+    @patch("app.vision.agent.CameraLink")
+    async def test_turn_watchdog_does_not_fire_before_deadline(
+        self, mock_camera_cls, mock_screen_cls
+    ):
+        agent = VisionAgent()
+        agent._turn_in_flight = True
+        agent._turn_started_at = time.time()
+
+        assert agent._is_turn_in_flight() is True
+
+    @pytest.mark.asyncio
+    @patch("app.vision.agent.ScreenLink")
+    @patch("app.vision.agent.CameraLink")
+    async def test_appraisal_not_suspended_when_flag_disabled(
+        self, mock_camera_cls, mock_screen_cls, monkeypatch
+    ):
+        """VISION_SUSPEND_DURING_TURN=False must fully restore the
+        pre-P1-7 behavior - a stuck or unwanted turn-in-flight flag must
+        not silently gate appraisal when the feature is off."""
+        import base64
+
+        from app import config as config_module
+
+        monkeypatch.setattr(
+            config_module.config_instance, "VISION_SUSPEND_DURING_TURN", False
+        )
+
+        agent = VisionAgent()
+        agent.publish = AsyncMock()
+        agent._turn_in_flight = True  # simulate a stuck flag
+        mock_appraisal = MagicMock()
+        mock_appraisal.should_appraise.return_value = True
+        mock_appraisal.appraise = AsyncMock(return_value="Seen anyway.")
+        agent.appraisal = mock_appraisal
+
+        blank_frame_b64 = base64.b64encode(b"\x00" * 100).decode("utf-8")
+        await agent._run_appraisal(blank_frame_b64)
+
+        mock_appraisal.appraise.assert_awaited_once()
+        agent.publish.assert_awaited_once()

--- a/backend/tests/test_vision.py
+++ b/backend/tests/test_vision.py
@@ -391,3 +391,31 @@ class TestVisionAgent:
 
         mock_appraisal.appraise.assert_awaited_once()
         agent.publish.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    @patch("app.vision.agent.ScreenLink")
+    @patch("app.vision.agent.CameraLink")
+    async def test_turn_tracking_subscribes_for_new_messages_only(
+        self, mock_camera_cls, mock_screen_cls
+    ):
+        """These two subscriptions are liveness signals, not work items. On
+        JetStream's "all" default a fresh durable replays the whole retained
+        chat history at startup - and chat.output carries one message per
+        response chunk - so every vision restart would re-walk the entire
+        conversation and end up suspended by a turn that finished hours ago,
+        blind until the watchdog fired. Every other subscription in the mesh
+        names a policy explicitly; these must too."""
+        agent = VisionAgent()
+        agent.connect = AsyncMock()
+        agent.subscribe = AsyncMock()
+        agent.preflight = MagicMock(return_value=False)
+        agent._capture_loop = AsyncMock()
+
+        await agent.start()
+
+        policies = {
+            call.args[0]: call.kwargs.get("deliver_policy")
+            for call in agent.subscribe.await_args_list
+        }
+        assert policies[Topics.CHAT_INPUT] == "new"
+        assert policies[Topics.CHAT_OUTPUT] == "new"


### PR DESCRIPTION
## Summary

Stage 1 of `audit/`'s roadmap (untracked forensic audit) — the five items with no prerequisites, in dependency order.

- **P1-7**: measured the VLM/LLM contention `audit/HARDWARE.md` reported (−44%/−47% decode rate reproduced this session against a live Ollama instance) and the roadmap's named alternative, `OLLAMA_MAX_LOADED_MODELS=1` (removes the decode penalty but trades it for a ~2s model-swap per contention event — likely worse for this system's ~1/s VLM polling). Went with the code-level fix: `vision/agent.py` suspends VLM appraisal while a cognitive turn is in flight (watchdog-bounded), plus a circuit breaker on the VLM caller modeled on the existing Rust one in `voice-agent`.
- **P2-13**: `cognitive/learning.py` skipped reinforcing a restated fact's edge weight via a dead pre-check; `consolidate_relationship`'s `ON MATCH SET r.weight = coalesce(r.weight, 1) + 1` was already correct and just unreachable. Removed the pre-check.
- **P1-6**: a Postgres connection failure at bootstrap now logs at ERROR (was WARNING), surfaces via a `/health` sentinel (cross-process), and fails closed under `ENVIRONMENT=production` unless `ALLOW_SQLITE_FALLBACK=true`.
- **P1-8**: new `scripts/check_subject_wiring.py` statically enumerates every NATS subject this codebase publishes/subscribes to (Python AST + Rust `topics::` constants) and fails CI on one-ended wiring or an undeclared stream. Building it surfaced **six** previously-undiscovered wiring gaps beyond the audit's original eight — all allowlisted with reasons, not silently fixed.
- **P1-5**: `subconscious_agent`'s state was never hydrated or updated, making the documented dreaming capability unreachable. New `StateService.apply_external_state` applies the brain's existing `state.broadcast` snapshot under `_state_lock`; the subconscious now hydrates at startup and applies every subsequent broadcast.

## Test plan

- [x] Full backend suite: 995/995 passed
- [x] `ruff check .`: clean
- [x] Every new test mutation-tested (broke the code it covers, confirmed the test failed, reverted, confirmed clean)
- [x] Subject-wiring checker's own logic tested against a synthetic fixture repo (isolated from the real codebase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)