### PR TITLE
fix: control-tier ack model, stream retention policy (P1-1, P1-2)

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -7183,3 +7183,144 @@ nothing else.
 - The cross-container sentinel path is documented, not solved. Solving it
   means either a shared volume in `docker-compose.prod.yml` or moving the
   signal onto the mesh, and neither is in this batch's scope.
+
+## 2026-08-22 -- audit/ implementation, Stage 2 (P1-1, P1-2) -- ack model and retention policy, in the roadmap's one mandatory order
+
+`ROADMAP.md` §7 requires P1-1 before P1-2: sizing a control-tier `ack_wait`
+while consolidation still ran inside the tick callback would mean choosing a
+number sized around a ~28s defect. Both landed on `fix/p1-stage2-ack-and-retention`,
+in that order, off `main` after Stages 0 and 1 merged (#183, #184).
+
+**P1-1.** `SubconsciousAgent._on_system_tick` awaited reflection, graph writes
+and ACT-R decay inline -- MEASURED ~16s idle, ~28s under the two-model
+contention `HARDWARE.md` §5 measured -- against `BaseAgent.subscribe`'s
+default 30s AckWait with UNLIMITED MaxDeliver. A slow pass outran the
+deadline, was redelivered mid-flight, and ran again: duplicate graph writes
+and duplicate proactive utterances to the user, the symptom that surfaced it
+originally (issue #175, closed once already as "already resolved" -- a prior
+fix scoped `_ack_heartbeat` to `chat.*` and never considered `system.tick`,
+the longest callback in the mesh).
+
+Consolidation now dispatches to a retained `asyncio.Task` (closing M1-A13
+here too) and the callback returns immediately. `_is_consolidating` is set
+*synchronously in the callback*, before `create_task` schedules anything --
+setting it inside the dispatched coroutine would race, since `create_task`
+does not run the body until the loop yields, so two ticks arriving
+back-to-back could both pass the guard before either body ran. The
+proactive-thought LLM call stays inline deliberately: it is gated on
+eligibility so it does not fire every tick, it is one short generation, and
+inlining preserves the ordering between generating the thought, publishing
+it, and marking the attempt -- dispatching it would race that ordering. The
+new `MESH_CONTROL_ACK_WAIT_S` (30s) is sized to cover it.
+
+**The part that would have made this a no-op, found while implementing.**
+`JetStreamContext.subscribe`, when a durable already exists, does
+`config = consumer_info.config` -- it *discards* the `ConsumerConfig` the
+caller passed and adopts whatever the server already has stored. nats-py
+marks the spot itself: `# TODO: Detect configuration drift with any present
+durable consumer.` So the new `ack_wait` would apply on a fresh mesh and in
+every test, and silently not apply on any deployment that had run before --
+while still logging a successful subscribe. Exactly the failure shape this
+audit keeps finding: the half that fails still compiles and still logs as
+though it worked. `BaseAgent._reconcile_consumer_config` now detects the
+drift explicitly (compares `ack_wait`/`max_deliver` against the stored
+config) and deletes the consumer so it is recreated with the requested
+settings, logging loudly either way. Deleting a durable discards its
+delivery cursor -- acceptable here because ticks are periodic and a missed
+one is picked up by the next, and it only fires when an explicit config was
+requested, never on the default path.
+
+**P1-2.** Both `AI_MESSAGES` and `AI_AUDIO` were declared with `name` and
+`subjects` only, inheriting limits retention, FILE storage, and unlimited
+count/bytes/age. `AI_AUDIO` binds `audio.>` and carries raw PCM (ESTIMATED
+~130 KB/s; actual growth NOT TESTED). `STREAM_POLICIES` in `nats_streams.py`
+now declares two tiers per `ARCHITECTURE.md` §28: conversational
+(`AI_MESSAGES`) file-backed, 7-day `max_age`, 1 GiB cap; sensor (`AI_AUDIO`)
+MEMORY-backed, 5-minute `max_age`, 256 MiB cap -- audio has no value once the
+utterance it belongs to is transcribed, and memory storage also removes a
+durable disk write from the hot path. Both bounds and both `max_age` values
+are overridable by env var; `DiscardPolicy.OLD` on both, since rejecting a
+publish at the limit would stall a live conversation or the audio path,
+which is worse than losing the oldest history.
+
+Deliberately **not** done here: splitting `system.>`/`control.*` into their
+own control-tier stream. `system.>` currently lives inside `AI_MESSAGES`,
+and NATS forbids two streams overlapping on a subject -- moving it out is a
+destructive migration (any retained `system.*` data in `AI_MESSAGES` is
+dropped) for a tier whose only distinguishing settings, `ack_wait` and a
+bounded `max_deliver`, are *consumer* settings, not stream settings, and
+already landed with P1-1 at the subscription site. `STREAM_POLICIES` is
+kept as a structure separate from `CORE_STREAMS` specifically so this stream
+split remains a later, isolated decision rather than something this change
+had to also decide.
+
+**The two-path problem, found while planning and confirmed while
+implementing.** There are two stream-creation call sites --
+`nats_streams.setup_streams()` (the bootstrap script) and
+`BaseAgent._bootstrap_mesh()` (`base.py`, which runs on **every agent
+start**). If only one carried the policy, whichever reaches a fresh mesh
+first silently decides it -- usually the agent, not the script. Both now
+build from one function, `build_stream_config()`, and a stream whose name
+has no `STREAM_POLICIES` entry falls back to `subjects`-only exactly as
+before, so an unrecognized stream degrades to old behavior rather than
+inheriting a policy meant for something else. A structural test
+(`test_both_creation_paths_declare_the_same_config`) drives `_bootstrap_mesh`
+against `build_stream_config` directly and asserts the two never diverge --
+mutation-tested by reverting `base.py`'s call site to bare `name=`/`subjects=`
+and confirming exactly that test catches it.
+
+Existing streams from any prior deployment are brought up to policy too, not
+only newly-created ones -- `_apply_policy_to_existing()`, called from both
+paths' "stream already exists" branch. `storage` is deliberately **not**
+changed there: NATS rejects a storage-type change on a live stream, so
+`AI_AUDIO` moving file-to-memory needs the stream deleted and recreated by
+hand. Attempting it in code would turn every bootstrap into a failed update;
+instead it logs a loud warning naming the mismatch, so the migration is a
+decision an operator makes rather than an error they hit.
+
+**A real gap in the test harness, found and fixed while writing P1-2's
+tests, worth its own note.** `tests/conftest.py` globally replaces
+`sys.modules["nats"]` and its submodules with a hand-built stub for the
+whole suite -- deliberately, so no test ever touches a real NATS connection.
+The stub's `nats.js.api` only ever defined `DeliverPolicy`. Two things had
+apparently never been exercised by any test since P1-1 either: `base.py`'s
+real (non-mocked) `subscribe()` body constructs `ConsumerConfig`, which the
+stub didn't provide, and `_bootstrap_mesh`'s exception handler does
+attribute-chain access (`nats.js.errors.BadRequestError`) which raised
+`AttributeError` regardless of what was actually thrown, because the stub
+registers submodules in `sys.modules` without setting them as attributes of
+their parent module object -- real Python's import machinery does that
+automatically; a hand-built stub does not get it for free. Fixed by adding
+`StorageType`, `RetentionPolicy`, `DiscardPolicy`, `ConsumerConfig` and
+`StreamConfig` to the fake `nats.js.api`, and by wiring `nats.js`,
+`nats.js.errors` and `nats.js.api` as real attributes on their parents. Also
+found and fixed in the same pass: `MockJSM.add_stream` only accepted the
+old `name=`/`subjects=` call shape, not the `config=StreamConfig(...)` shape
+real `nats-py` also supports and this change now uses -- confirmed against
+`nats.js.manager.JetStreamManager.add_stream`'s real signature before fixing.
+
+None of this changes application behavior; it only makes the test double
+match the real library closely enough to exercise code paths it was
+silently skipping before.
+
+**Verified:** full backend suite 1019/1019 (18 new tests: 8 in
+`test_mesh_ack_model.py` for P1-1 including the drift reconciliation, 10 in
+`test_stream_retention.py` for P1-2), `ruff check .` clean. Eight
+mutations tested across both items, each caught by exactly the test written
+for it: inline-await, guard-set-after-dispatch, drift-delete removed,
+tick's ack config removed, guard leaked on exception (P1-1); the two
+creation paths diverging, `AI_AUDIO` storage flipped to file, and
+`_apply_policy_to_existing` never reporting a change (P1-2).
+
+**NOT done:**
+- All Docker-based verification: applying the stream config against a real
+  NATS, confirming `AI_AUDIO` actually lands MEMORY-backed and `AI_MESSAGES`
+  FILE-backed, watching `_reconcile_consumer_config` delete and recreate a
+  real durable. Docker Desktop was not running this session.
+- The control-tier stream split (`system.>`/`control.*` out of
+  `AI_MESSAGES`) -- deferred deliberately, reasoning above.
+- Measurement 1.3 (`AI_AUDIO` growth over a real session), which would
+  validate the sizing rather than the estimate it is built on.
+- Stage 3's remaining five measurements, P1-3/P1-4 (gated on measurement
+  1.1), P1-9 (wants an `evals/` baseline), and the six newly-discovered
+  one-ended subjects from P1-8 -- all still out of scope for this batch.

--- a/backend/app/agents/base.py
+++ b/backend/app/agents/base.py
@@ -324,6 +324,79 @@ class BaseAgent:
         except asyncio.CancelledError:
             return
 
+    async def _reconcile_consumer_config(
+        self,
+        subject: str,
+        durable: str,
+        ack_wait: float | None,
+        max_deliver: int | None,
+    ) -> None:
+        """Delete a durable consumer whose stored config no longer matches
+        what the caller is asking for, so it gets recreated with the new one.
+
+        P1-1: without this, sizing `ack_wait` is a no-op on every deployment
+        that has run before. `JetStreamContext.subscribe` looks up an
+        existing durable and, on a hit, does `config = consumer_info.config`
+        -- it *discards* the ConsumerConfig passed in and adopts whatever the
+        server already stored. nats-py marks the spot itself with
+        `# TODO: Detect configuration drift with any present durable
+        consumer.` So the new ack deadline would apply on a fresh mesh (and
+        in every test), and silently not apply anywhere that matters, while
+        still logging a successful subscribe.
+
+        That is precisely the failure shape this audit keeps finding: the
+        half that fails still compiles, still passes its own tests, and still
+        logs as though it worked. Detect the drift explicitly rather than
+        trusting the client to.
+
+        Deleting a durable consumer discards its delivery cursor, so the
+        recreated one starts from `deliver_policy` rather than resuming.
+        That is acceptable for the control tier this is used on -- ticks are
+        periodic and a missed one is picked up by the next -- but it is the
+        reason this only runs when an explicit config was requested, never
+        by default.
+        """
+        try:
+            stream = await self.js.find_stream_name_by_subject(subject)
+            info = await self.js._jsm.consumer_info(stream, durable)
+        except Exception:
+            # No such consumer (the normal first-run case), or JetStream is
+            # not answering yet -- either way there is nothing to reconcile
+            # and the subscribe below will create or retry as appropriate.
+            return
+
+        current = info.config
+        drifted = (
+            ack_wait is not None and current.ack_wait != ack_wait
+        ) or (max_deliver is not None and current.max_deliver != max_deliver)
+        if not drifted:
+            return
+
+        logger.warning(
+            "Agent '%s': durable '%s' on %s has drifted config "
+            "(ack_wait=%s->%s, max_deliver=%s->%s). Deleting so it is "
+            "recreated with the requested settings.",
+            self.name,
+            durable,
+            subject,
+            current.ack_wait,
+            ack_wait,
+            current.max_deliver,
+            max_deliver,
+        )
+        try:
+            await self.js._jsm.delete_consumer(stream, durable)
+        except Exception as e:
+            # Not fatal: the subscribe still succeeds, just with the old
+            # config. Loud, because the requested deadline is not in force.
+            logger.error(
+                "Agent '%s': could not delete drifted durable '%s': %s. "
+                "Subscription will use the STALE stored config.",
+                self.name,
+                durable,
+                e,
+            )
+
     async def subscribe(
         self,
         subject: str,
@@ -332,9 +405,23 @@ class BaseAgent:
         deliver_policy: str = "all",
         pending_msgs_limit: int | None = None,
         pending_bytes_limit: int | None = None,
+        ack_wait: float | None = None,
+        max_deliver: int | None = None,
     ):
         """
         Subscribe to events on the mesh with header validation and fallback.
+
+        P1-1: `ack_wait`/`max_deliver` let a caller size the JetStream
+        consumer explicitly instead of inheriting server defaults (an
+        unbounded 30s ack_wait with unlimited max_deliver, mesh-wide). Passed
+        straight through as a `ConsumerConfig`. Note `MESH_MAX_DELIVER`
+        (below, in `_handler`'s except branch) is a *different*, client-side
+        mechanism -- it counts deliveries after the fact to drop a poison
+        message, it does not configure the server's own redelivery limit.
+        The two are complementary, not redundant: this one bounds how many
+        times JetStream will attempt redelivery at all; that one decides what
+        happens once redelivery has already happened `MESH_MAX_DELIVER`
+        times.
         """
         if not self.js:
             await self.connect()
@@ -429,7 +516,7 @@ class BaseAgent:
             durable = f"{self.name}_{subject_suffix}"
 
         # Mapping string policy to nats.js.api.DeliverPolicy
-        from nats.js.api import DeliverPolicy
+        from nats.js.api import ConsumerConfig, DeliverPolicy
 
         policy_map = {
             "all": DeliverPolicy.ALL,
@@ -447,6 +534,19 @@ class BaseAgent:
             subscribe_kwargs["pending_msgs_limit"] = pending_msgs_limit
         if pending_bytes_limit is not None:
             subscribe_kwargs["pending_bytes_limit"] = pending_bytes_limit
+        if ack_wait is not None or max_deliver is not None:
+            # `deliver_policy` above still wins: the client library applies
+            # the top-level `deliver_policy` kwarg on top of this `config`
+            # unconditionally, so the two do not fight over that field.
+            subscribe_kwargs["config"] = ConsumerConfig(
+                ack_wait=ack_wait, max_deliver=max_deliver
+            )
+            await self._reconcile_consumer_config(
+                subject=subject,
+                durable=durable,
+                ack_wait=ack_wait,
+                max_deliver=max_deliver,
+            )
 
         # 4. Reliable Subscription (Retry for JetStream availability)
         max_retries = 10

--- a/backend/app/agents/base.py
+++ b/backend/app/agents/base.py
@@ -147,7 +147,11 @@ class BaseAgent:
 
     async def _bootstrap_mesh(self):
         """Ensure core streams exist on the mesh (CVS-3.5 Hardened)."""
-        from ..nats_streams import CORE_STREAMS
+        from ..nats_streams import (
+            CORE_STREAMS,
+            _apply_policy_to_existing,
+            build_stream_config,
+        )
 
         core_streams = {name: list(subjects) for name, subjects in CORE_STREAMS.items()}
 
@@ -162,7 +166,13 @@ class BaseAgent:
 
         for stream_name, subjects in core_streams.items():
             try:
-                await jsm.add_stream(name=stream_name, subjects=subjects)
+                # P1-2: the same config the bootstrap script uses. This path
+                # runs on every agent start and usually reaches a fresh mesh
+                # first, so if it declared streams with name+subjects only
+                # the retention policy would never be applied in practice.
+                await jsm.add_stream(
+                    config=build_stream_config(stream_name, subjects)
+                )
                 logger.info(f"Created NATS Stream: {stream_name} {subjects}")
             except nats.js.errors.BadRequestError:
                 # Stream likely already exists, verify subjects
@@ -171,14 +181,22 @@ class BaseAgent:
                     current_subjects = set(info.config.subjects or [])
                     required_subjects = set(subjects)
 
+                    config = info.config
+                    changed = False
                     if not required_subjects.issubset(current_subjects):
                         logger.info(
                             f"Updating NATS Stream '{stream_name}' with additional subjects..."
                         )
-                        config = info.config
                         config.subjects = list(
                             current_subjects.union(required_subjects)
                         )
+                        changed = True
+
+                    # P1-2: bring a pre-existing stream's limits up to the
+                    # policy too, not just its subjects.
+                    changed |= _apply_policy_to_existing(config, stream_name)
+
+                    if changed:
                         await jsm.update_stream(config)
                         logger.info(
                             f"✅ Stream '{stream_name}' synchronized successfully."

--- a/backend/app/agents/subconscious_agent.py
+++ b/backend/app/agents/subconscious_agent.py
@@ -40,6 +40,11 @@ class SubconsciousAgent(BaseAgent):
         self.reflection_service = reflection_service
         self.db_store = None
         self._is_consolidating = False
+        # P1-1: retained so the dispatched consolidation coroutine isn't
+        # only weakly referenced by the event loop and eligible for GC
+        # mid-flight (closes M1-A13 here); also lets a test or caller await
+        # completion explicitly instead of racing the background task.
+        self._consolidation_task = None
         self._current_monologue_task = None
         self._current_dream_task = None
         self._last_monologue_time = 0.0
@@ -92,6 +97,12 @@ class SubconsciousAgent(BaseAgent):
             self._on_system_tick,
             durable=f"{self.name}_system_tick",
             deliver_policy="new",
+            # P1-1: state the control tier's ack deadline instead of
+            # inheriting a 30s default alongside UNLIMITED redelivery. Only
+            # meaningful now that consolidation is dispatched rather than
+            # awaited here -- see _on_system_tick's docstring.
+            ack_wait=Config.MESH_CONTROL_ACK_WAIT_S,
+            max_deliver=Config.MESH_CONTROL_MAX_DELIVER,
         )
         await self.subscribe(
             Topics.CHAT_INPUT,
@@ -204,7 +215,56 @@ class SubconsciousAgent(BaseAgent):
             logger.error(f"[Subconscious] Failed to sync state to Neo4j: {e}")
 
     async def _on_system_tick(self, data: dict[str, Any]):
-        """Delegates thought generation to the engine and routes to the Mesh."""
+        """Delegates thought generation to the engine, routes it to the mesh,
+        then DISPATCHES memory consolidation rather than awaiting it.
+
+        P1-1: consolidation runs reflection (multiple sequential LLM calls),
+        graph writes and ACT-R decay - MEASURED ~16s idle, ~28s under the
+        two-model VLM/LLM contention `HARDWARE.md` §5 measured. This
+        callback used to await all of that inline, before `BaseAgent.
+        subscribe`'s handler acks the message (base.py:383) - against a 30s
+        default AckWait with unlimited MaxDeliver. A slow pass could exceed
+        AckWait, get redelivered mid-flight, and run the same consolidation
+        twice: duplicate graph writes and - the symptom that actually
+        surfaced this - duplicate proactive utterances to the user.
+
+        `_ack_heartbeat` (base.py) already exists for exactly this shape of
+        problem but is gated on `chat.*` subjects; a prior audit weighed it
+        against `audio.*` and never considered `system.tick`, the longest
+        callback in the mesh - issue #175 was then closed as "already
+        resolved" on that basis. Widening `_ack_heartbeat` to every subject
+        was considered and rejected: an ack held in-progress for 28s is a
+        liveness lie regardless of which subject carries it, and doing that
+        everywhere repeats the original scoping mistake rather than fixing
+        it. Dispatching the actual work removes the problem instead of
+        extending the workaround.
+
+        The guard-and-dispatch below is intentionally split from the work
+        itself (`_run_consolidation_pass`): `_is_consolidating` is checked
+        and set HERE, synchronously, before `asyncio.create_task` schedules
+        anything - `create_task` does not run the coroutine body until the
+        event loop yields, so if the guard lived inside the dispatched
+        coroutine instead, two ticks arriving back-to-back could each pass
+        the check before either task actually started and set the flag.
+
+        Scope, deliberately: the proactive-thought LLM call above
+        (`evaluate_and_think`) stays inline. It is gated on
+        `check_proactive_eligibility`, so it is rate-limited rather than
+        per-tick, and it is a single short generation -- seconds, not the
+        ~28s consolidation was. Keeping it inline preserves the ordering
+        between generating a thought, publishing it and calling
+        `mark_proactive_attempt`, which dispatching would race. The ack
+        deadline is sized to cover it (`MESH_CONTROL_ACK_WAIT_S`), so it is
+        bounded work under a stated bound rather than unbounded work under
+        an implicit one.
+
+        Acking before consolidation completes is a genuine semantics change,
+        not just an implementation detail: a crash between dispatch and
+        completion loses that pass. Accepted - consolidation is periodic and
+        runs over *unconsolidated* episodes, so a missed pass is picked up
+        by the next tick, not lost - and recorded here and in the ledger as
+        a decision.
+        """
         last_bench = getattr(self, "_last_benchmark_time", 0.0)
         if time.time() - last_bench < 300:
             logger.info(
@@ -247,7 +307,15 @@ class SubconsciousAgent(BaseAgent):
             )
             return
 
+        # Set synchronously, before dispatch - see the docstring above for
+        # why this cannot move inside _run_consolidation_pass.
         self._is_consolidating = True
+        self._consolidation_task = asyncio.create_task(self._run_consolidation_pass())
+
+    async def _run_consolidation_pass(self) -> None:
+        """The actual consolidation work (P1-1), dispatched by
+        `_on_system_tick` rather than awaited inline so the tick's ack is
+        not held on it. See `_on_system_tick`'s docstring for why."""
         try:
             logger.info("[Subconscious] Initiating subconscious consolidation pass...")
             episodes = await self.memory_store.get_recent_unconsolidated_episodes(

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -114,6 +114,23 @@ class AppSettings(BaseSettings):
 
     LLM_STREAM_MAX_SECONDS: int = 120
     LLM_INTENT_CLASSIFICATION_ENABLED: bool = True
+
+    # P1-1: the control tier's JetStream consumer settings (system.tick).
+    # Both were previously implicit -- a 30s server-default ack_wait and
+    # UNLIMITED max_deliver -- while the tick callback ran a ~28s
+    # consolidation inline before ack. That combination is what produced
+    # duplicate consolidations and duplicate proactive utterances: the
+    # callback outran the deadline and JetStream redelivered, forever.
+    #
+    # With consolidation dispatched to a worker, the callback's remaining
+    # worst case is one short proactive-thought LLM call, so this deadline
+    # is now a genuine liveness bound rather than a number chosen to
+    # accommodate a defect -- which is exactly why the roadmap requires
+    # P1-1 to land before P1-2 sizes the control tier.
+    MESH_CONTROL_ACK_WAIT_S: float = 30.0
+    # Bounded, unlike the JetStream default. A tick that fails repeatedly is
+    # a bug to surface, not a message to retry forever.
+    MESH_CONTROL_MAX_DELIVER: int = 3
     MOCK_LLM_TEXT: bool = False
 
     REFLECTION_ENABLED: bool = True

--- a/backend/app/nats_streams.py
+++ b/backend/app/nats_streams.py
@@ -10,6 +10,50 @@ from nats.js.errors import BadRequestError, ServiceUnavailableError
 logger = logging.getLogger("nats_streams")
 
 
+# P1-2: the retention policy each stream is created with. Kept SEPARATE
+# from CORE_STREAMS deliberately -- scripts/check_subject_wiring.py parses
+# CORE_STREAMS as an annotated dict-of-lists to cross-reference every
+# publish/subscribe subject against a declared stream pattern (P1-8), so
+# changing that literal's shape would silently break the CI wiring check.
+#
+# Both streams previously inherited JetStream's defaults: limits retention,
+# FILE storage, and unlimited count/bytes/age. NATS' own docs warn that "an
+# unbounded stream will eventually fill the disk", and AI_AUDIO carries raw
+# PCM (ESTIMATED ~130 KB/s; actual growth NOT TESTED). Nobody chose these
+# values -- NATS simply permits a two-field declaration, so the policy
+# decision was never made.
+#
+# The tiers follow ARCHITECTURE.md §28. Note the *control* tier's
+# distinguishing settings -- ack_wait and a bounded max_deliver -- are
+# CONSUMER settings, not stream settings, and landed with P1-1 at the
+# subscription site (subconscious_agent's system.tick). Splitting system.>
+# into its own stream would buy only a different max_age for very small
+# messages, and would cost a destructive subject migration out of
+# AI_MESSAGES. Deferred deliberately; see the ledger.
+_MINUTE = 60.0
+_DAY = 24 * 60 * _MINUTE
+
+STREAM_POLICIES: dict[str, dict[str, object]] = {
+    # Conversational tier: durable, bounded. Long enough that a restart
+    # replays real context, short enough to stay bounded.
+    "AI_MESSAGES": {
+        "storage": "file",
+        "max_age": float(os.getenv("NATS_MESSAGES_MAX_AGE_S") or 7 * _DAY),
+        "max_bytes": int(os.getenv("NATS_MESSAGES_MAX_BYTES") or 1 * 1024**3),
+    },
+    # Sensor tier: raw PCM. MEMORY-backed, which also takes a durable disk
+    # write off the audio hot path, and aged out in minutes -- audio frames
+    # have no value once the utterance they belong to is transcribed.
+    # Losing audio.> durability is correct for this data class but is a
+    # stated decision, not an accident.
+    "AI_AUDIO": {
+        "storage": "memory",
+        "max_age": float(os.getenv("NATS_AUDIO_MAX_AGE_S") or 5 * _MINUTE),
+        "max_bytes": int(os.getenv("NATS_AUDIO_MAX_BYTES") or 256 * 1024**2),
+    },
+}
+
+
 CORE_STREAMS: dict[str, Sequence[str]] = {
     "AI_MESSAGES": [
         "chat.>",
@@ -81,6 +125,86 @@ async def _wait_for_jetstream_ready(jsm, retries: int, delay_seconds: float) -> 
     )
 
 
+def _apply_policy_to_existing(config, stream_name: str) -> bool:
+    """Update an existing stream's limits in place. Returns True if anything
+    changed.
+
+    `storage` is deliberately NOT updated: NATS rejects a storage change on
+    a live stream, so AI_AUDIO moving file->memory needs the stream deleted
+    and recreated. Attempting it here would turn every bootstrap into a
+    failed update. Logged loudly instead, so the migration is a decision
+    someone makes rather than an error they hit.
+    """
+    policy = STREAM_POLICIES.get(stream_name)
+    if policy is None:
+        return False
+
+    from nats.js.api import StorageType
+
+    changed = False
+    if config.max_age != policy["max_age"]:
+        config.max_age = policy["max_age"]
+        changed = True
+    if config.max_bytes != policy["max_bytes"]:
+        config.max_bytes = policy["max_bytes"]
+        changed = True
+
+    desired_storage = (
+        StorageType.MEMORY if policy["storage"] == "memory" else StorageType.FILE
+    )
+    if config.storage != desired_storage:
+        logger.warning(
+            "Stream %s storage is %s but policy wants %s. NATS cannot change "
+            "storage on a live stream -- delete and recreate it to apply "
+            "this. Limits below are still being applied.",
+            stream_name,
+            config.storage,
+            desired_storage,
+        )
+
+    return changed
+
+
+def build_stream_config(stream_name: str, subjects: list[str]):
+    """The single source of truth for how a core stream is declared.
+
+    P1-2: there are TWO stream-creation paths in this codebase, and only one
+    is obvious. `setup_streams()` below is the bootstrap script's path;
+    `BaseAgent._bootstrap_mesh()` (agents/base.py) is the other, and it runs
+    on EVERY agent start. Whichever reaches a fresh mesh first decides the
+    policy -- and in practice that is the agent, not the script. If only one
+    path carried the retention config, the streams would be created
+    unbounded and the fix would look applied while doing nothing. Both call
+    this.
+
+    A stream whose name has no policy entry gets subjects only, exactly as
+    before -- so an unknown stream degrades to today's behaviour instead of
+    inheriting limits meant for something else.
+    """
+    from nats.js.api import DiscardPolicy, RetentionPolicy, StorageType, StreamConfig
+
+    policy = STREAM_POLICIES.get(stream_name)
+    if policy is None:
+        return StreamConfig(name=stream_name, subjects=list(subjects))
+
+    storage = (
+        StorageType.MEMORY if policy["storage"] == "memory" else StorageType.FILE
+    )
+    return StreamConfig(
+        name=stream_name,
+        subjects=list(subjects),
+        retention=RetentionPolicy.LIMITS,
+        storage=storage,
+        max_age=policy["max_age"],
+        max_bytes=policy["max_bytes"],
+        # Drop the oldest messages at the limit rather than refusing new
+        # ones: for both tiers, rejecting a publish would stall a live
+        # conversation or the audio path, which is worse than losing the
+        # oldest history.
+        discard=DiscardPolicy.OLD,
+    )
+
+
 async def _ensure_stream(
     jsm, stream_name: str, subjects: list[str], retries: int, delay_seconds: float
 ) -> None:
@@ -88,21 +212,33 @@ async def _ensure_stream(
 
     for attempt in range(1, retries + 1):
         try:
-            await jsm.add_stream(name=stream_name, subjects=subjects)
+            await jsm.add_stream(config=build_stream_config(stream_name, subjects))
             logger.info("Created %s stream", stream_name)
             return
         except BadRequestError:
             info = await jsm.stream_info(stream_name)
             current_subjects = set(info.config.subjects or [])
             desired_subjects = set(subjects)
-            if desired_subjects.issubset(current_subjects):
+            config = info.config
+            changed = False
+
+            if not desired_subjects.issubset(current_subjects):
+                config.subjects = list(current_subjects.union(desired_subjects))
+                changed = True
+
+            # P1-2: an existing stream predates the retention policy, so
+            # bring its limits up to it too. Without this, every deployment
+            # that has ever run keeps the unbounded defaults and the fix
+            # applies only to brand-new meshes -- the same silent no-op
+            # shape P1-1 hit with durable consumers.
+            changed |= _apply_policy_to_existing(config, stream_name)
+
+            if not changed:
                 logger.info("%s already synchronized", stream_name)
                 return
 
-            config = info.config
-            config.subjects = list(current_subjects.union(desired_subjects))
             await jsm.update_stream(config)
-            logger.info("Updated %s subjects", stream_name)
+            logger.info("Updated %s configuration", stream_name)
             return
         except Exception as error:
             if not _is_retryable_error(error) or attempt >= retries:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -55,6 +55,8 @@ import asyncio
 import re
 import sqlite3
 import types
+from dataclasses import dataclass
+from enum import Enum
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -71,7 +73,11 @@ if backend_dir not in sys.path:
 
 
 class MockJSM:
-    async def add_stream(self, name, subjects):
+    async def add_stream(self, config=None, **params):
+        # Real JetStreamManager.add_stream takes `config: StreamConfig` OR
+        # `**params` (e.g. name=, subjects=) -- app code uses both call
+        # shapes (see nats_streams.py and BaseAgent._bootstrap_mesh), so
+        # the mock has to accept both rather than only the older one.
         return None
 
     async def stream_info(self, name):
@@ -218,7 +224,58 @@ class DeliverPolicy:
     NEW = "new"
 
 
+# P1-1/P1-2: real nats-py's ConsumerConfig/StreamConfig are dataclasses and
+# StorageType/RetentionPolicy/DiscardPolicy are str Enums (nats/js/api.py).
+# Mirrored here, not imported for real -- this whole module exists so the
+# suite never touches a real NATS connection, which means it must also
+# never touch the real `nats` package, since importing the real
+# `nats.js.api` alongside this file's fake `sys.modules["nats"]` would bind
+# `ConsumerConfig`'s dataclass machinery to a parent module that isn't
+# actually there. Field names and defaults match the real classes for the
+# fields this codebase constructs; anything unused by app code is omitted
+# rather than chased for completeness.
+class StorageType(str, Enum):
+    FILE = "file"
+    MEMORY = "memory"
+
+
+class RetentionPolicy(str, Enum):
+    LIMITS = "limits"
+    INTEREST = "interest"
+    WORK_QUEUE = "workqueue"
+
+
+class DiscardPolicy(str, Enum):
+    OLD = "old"
+    NEW = "new"
+
+
+@dataclass
+class ConsumerConfig:
+    name: str | None = None
+    durable_name: str | None = None
+    deliver_policy: str | None = DeliverPolicy.ALL
+    ack_wait: float | None = None
+    max_deliver: int | None = None
+
+
+@dataclass
+class StreamConfig:
+    name: str | None = None
+    subjects: list | None = None
+    retention: RetentionPolicy | None = None
+    max_bytes: int | None = None
+    discard: DiscardPolicy | None = DiscardPolicy.OLD
+    max_age: float | None = None
+    storage: StorageType | None = None
+
+
 nats_js_api_module.DeliverPolicy = DeliverPolicy
+nats_js_api_module.StorageType = StorageType
+nats_js_api_module.RetentionPolicy = RetentionPolicy
+nats_js_api_module.DiscardPolicy = DiscardPolicy
+nats_js_api_module.ConsumerConfig = ConsumerConfig
+nats_js_api_module.StreamConfig = StreamConfig
 
 # Register them in sys.modules to satisfy python's package import system
 sys.modules["nats"] = nats_module
@@ -226,6 +283,19 @@ sys.modules["nats.errors"] = nats_errors_module
 sys.modules["nats.js"] = nats_js_module
 sys.modules["nats.js.errors"] = nats_js_errors_module
 sys.modules["nats.js.api"] = nats_js_api_module
+
+# Real `import nats` followed by dotted attribute access (`nats.js.errors.X`,
+# as base.py's _bootstrap_mesh does) works because CPython's import
+# machinery sets each submodule as an attribute of its parent when it is
+# first imported. Registering only in sys.modules above does not do that --
+# it satisfies `from nats.js.api import X` (which looks the dotted name up
+# in sys.modules directly) but not attribute chains, which would raise
+# AttributeError instead of whatever real exception the code is trying to
+# catch. Wire the same parent/child attributes real import does.
+nats_module.errors = nats_errors_module
+nats_module.js = nats_js_module
+nats_js_module.errors = nats_js_errors_module
+nats_js_module.api = nats_js_api_module
 
 
 # =====================================================================

--- a/backend/tests/test_mesh_ack_model.py
+++ b/backend/tests/test_mesh_ack_model.py
@@ -1,0 +1,246 @@
+"""
+P1-1: long work must not run inside a NATS callback.
+
+`BaseAgent.subscribe` acks only after the callback returns (base.py), and
+`SubconsciousAgent._on_system_tick` used to await an LLM call, reflection,
+graph writes and ACT-R decay inline -- MEASURED ~16s idle and ~28s under
+the two-model contention HARDWARE.md §5 measured -- against a 30s default
+AckWait with UNLIMITED MaxDeliver. A pass that outran the deadline was
+redelivered mid-flight and ran again: duplicate graph writes, and the
+symptom that actually surfaced it, duplicate proactive utterances.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.config import Config
+
+
+def _make_agent(monkeypatch, consolidation_gate=None):
+    """A SubconsciousAgent wired far enough to reach the consolidation
+    dispatch, with every external dependency mocked."""
+    from app.agents.subconscious_agent import SubconsciousAgent
+
+    state_service = MagicMock()
+    state_service.check_proactive_eligibility.return_value = False
+    state_service.get_context_snapshot.return_value = {"emotion": "calm", "energy": 0.5}
+    # Long silence, so the 300s consolidation gate opens.
+    state_service.current_state.last_user_interaction = 0.0
+
+    agent = SubconsciousAgent(state_service=state_service, graph_db=MagicMock())
+    agent.publish = AsyncMock()
+    agent.engine = MagicMock()
+    agent.engine.evaluate_and_think = AsyncMock(return_value=None)
+
+    async def _episodes(*args, **kwargs):
+        if consolidation_gate is not None:
+            await consolidation_gate.wait()
+        return []
+
+    agent.memory_store = MagicMock()
+    agent.memory_store.get_recent_unconsolidated_episodes = AsyncMock(
+        side_effect=_episodes
+    )
+    agent.reflection_service = MagicMock()
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_tick_callback_returns_before_consolidation_completes(monkeypatch):
+    """The whole point of the change: the callback must hand control back --
+    so BaseAgent.subscribe can ack -- while consolidation is still running.
+    If this regresses, the ack is held for the length of the consolidation
+    again and JetStream redelivers the tick mid-pass."""
+    gate = asyncio.Event()
+    agent = _make_agent(monkeypatch, consolidation_gate=gate)
+
+    # Bounded on purpose: if consolidation were awaited inline again this
+    # would block on the gate forever, and a hang is a worse test failure
+    # than an assertion -- it tells you nothing and stalls the suite.
+    await asyncio.wait_for(agent._on_system_tick({"timestamp": 1.0}), timeout=5)
+
+    # Returned already, but the work has not finished.
+    assert agent._consolidation_task is not None
+    assert not agent._consolidation_task.done()
+
+    gate.set()
+    await agent._consolidation_task
+    assert agent._consolidation_task.done()
+
+
+@pytest.mark.asyncio
+async def test_two_overlapping_ticks_run_one_consolidation(monkeypatch):
+    """`_is_consolidating` is set synchronously in the callback, before
+    create_task schedules anything. If it were set inside the dispatched
+    coroutine instead, two ticks arriving back-to-back would both pass the
+    guard before either task body ran -- the exact duplicate-work bug this
+    item exists to remove."""
+    gate = asyncio.Event()
+    agent = _make_agent(monkeypatch, consolidation_gate=gate)
+
+    await asyncio.wait_for(agent._on_system_tick({"timestamp": 1.0}), timeout=5)
+    first_task = agent._consolidation_task
+
+    await asyncio.wait_for(agent._on_system_tick({"timestamp": 2.0}), timeout=5)
+
+    # The second tick must not have dispatched a second pass.
+    assert agent._consolidation_task is first_task
+    assert agent.memory_store.get_recent_unconsolidated_episodes.await_count == 0
+
+    gate.set()
+    await first_task
+    assert agent.memory_store.get_recent_unconsolidated_episodes.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatched_consolidation_task_is_retained(monkeypatch):
+    """M1-A13: a bare asyncio.create_task is only weakly referenced by the
+    loop and can be garbage-collected mid-flight. The task must be held on
+    the agent, not dropped on the floor."""
+    gate = asyncio.Event()
+    agent = _make_agent(monkeypatch, consolidation_gate=gate)
+
+    await asyncio.wait_for(agent._on_system_tick({"timestamp": 1.0}), timeout=5)
+
+    assert isinstance(agent._consolidation_task, asyncio.Task)
+    gate.set()
+    await agent._consolidation_task
+
+
+@pytest.mark.asyncio
+async def test_consolidation_guard_clears_even_when_the_pass_raises(monkeypatch):
+    """If the guard leaked on failure, one failed pass would wedge
+    consolidation off permanently -- silently, since the tick keeps
+    arriving and keeps returning early."""
+    agent = _make_agent(monkeypatch)
+    agent.memory_store.get_recent_unconsolidated_episodes = AsyncMock(
+        side_effect=RuntimeError("graph down")
+    )
+
+    await agent._on_system_tick({"timestamp": 1.0})
+    await agent._consolidation_task
+
+    assert agent._is_consolidating is False
+
+
+@pytest.mark.asyncio
+async def test_tick_subscription_states_its_ack_deadline_and_redelivery_bound():
+    """Previously implicit: a 30s server-default ack_wait with UNLIMITED
+    max_deliver. Unlimited redelivery is what turned one slow pass into an
+    endless loop of duplicate proactive utterances."""
+    from app.agents.subconscious_agent import SubconsciousAgent
+    from app.contracts import Topics
+
+    agent = SubconsciousAgent(state_service=MagicMock(), graph_db=MagicMock())
+    agent.connect = AsyncMock()
+    agent.subscribe = AsyncMock()
+    agent.graph_db.initialize = AsyncMock()
+    agent.state_service.hydrate_state = AsyncMock()
+    agent.memory_store = MagicMock()
+    agent.reflection_service = MagicMock()
+    agent._continuous_monologue_loop = AsyncMock()
+
+    await agent.start()
+
+    tick_calls = [
+        c for c in agent.subscribe.await_args_list if c.args[0] == Topics.SYSTEM_TICK
+    ]
+    assert len(tick_calls) == 1
+    kwargs = tick_calls[0].kwargs
+    assert kwargs["ack_wait"] == Config.MESH_CONTROL_ACK_WAIT_S
+    assert kwargs["max_deliver"] == Config.MESH_CONTROL_MAX_DELIVER
+
+
+# --------------------------------------------------------------------------
+# Durable-consumer drift. Without this, sizing ack_wait is a no-op on every
+# deployment that has run before -- correct in review, correct on a fresh
+# mesh, silently inert in production.
+# --------------------------------------------------------------------------
+
+
+def _agent_with_js(existing_ack_wait, existing_max_deliver):
+    from app.agents.base import BaseAgent
+
+    agent = object.__new__(BaseAgent)
+    agent.name = "subconscious"
+
+    stored = MagicMock()
+    stored.ack_wait = existing_ack_wait
+    stored.max_deliver = existing_max_deliver
+    info = MagicMock()
+    info.config = stored
+
+    jsm = MagicMock()
+    jsm.consumer_info = AsyncMock(return_value=info)
+    jsm.delete_consumer = AsyncMock()
+
+    js = MagicMock()
+    js.find_stream_name_by_subject = AsyncMock(return_value="AI_MESSAGES")
+    js._jsm = jsm
+    agent.js = js
+    return agent, jsm
+
+
+@pytest.mark.asyncio
+async def test_drifted_durable_is_deleted_so_the_new_ack_wait_takes_effect():
+    """JetStreamContext.subscribe does `config = consumer_info.config` when a
+    durable already exists -- it DISCARDS the ConsumerConfig passed in and
+    adopts the stored one (nats-py marks the spot `TODO: Detect
+    configuration drift`). So without an explicit delete, the new deadline
+    applies on a fresh mesh and in every test, and nowhere that matters,
+    while still logging a successful subscribe."""
+    agent, jsm = _agent_with_js(existing_ack_wait=30.0, existing_max_deliver=None)
+
+    await agent._reconcile_consumer_config(
+        subject="system.tick",
+        durable="subconscious_system_tick",
+        ack_wait=30.0,
+        max_deliver=3,
+    )
+
+    jsm.delete_consumer.assert_awaited_once_with(
+        "AI_MESSAGES", "subconscious_system_tick"
+    )
+
+
+@pytest.mark.asyncio
+async def test_matching_durable_is_left_alone():
+    """Deleting a durable discards its delivery cursor, so this must fire
+    only on genuine drift -- not on every agent restart."""
+    agent, jsm = _agent_with_js(existing_ack_wait=30.0, existing_max_deliver=3)
+
+    await agent._reconcile_consumer_config(
+        subject="system.tick",
+        durable="subconscious_system_tick",
+        ack_wait=30.0,
+        max_deliver=3,
+    )
+
+    jsm.delete_consumer.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_absent_durable_is_not_an_error():
+    """The normal first-run path: no consumer exists yet, so there is
+    nothing to reconcile and subscribe creates it correctly anyway."""
+    from app.agents.base import BaseAgent
+
+    agent = object.__new__(BaseAgent)
+    agent.name = "subconscious"
+    js = MagicMock()
+    js.find_stream_name_by_subject = AsyncMock(return_value="AI_MESSAGES")
+    js._jsm = MagicMock()
+    js._jsm.consumer_info = AsyncMock(side_effect=Exception("not found"))
+    js._jsm.delete_consumer = AsyncMock()
+    agent.js = js
+
+    await agent._reconcile_consumer_config(
+        subject="system.tick",
+        durable="subconscious_system_tick",
+        ack_wait=30.0,
+        max_deliver=3,
+    )
+
+    js._jsm.delete_consumer.assert_not_awaited()

--- a/backend/tests/test_multi_user_dialogue.py
+++ b/backend/tests/test_multi_user_dialogue.py
@@ -121,6 +121,9 @@ async def test_subconscious_agent_multi_user_pairing():
     # Mock dynamic config consolidation silence bypass
     with patch.object(Config, "TESTING_CONSOLIDATION_BYPASS_SILENCE", True):
         await agent._on_system_tick({})
+        # P1-1: consolidation is dispatched, not awaited inline - await the
+        # retained task, still inside the patch context, before asserting.
+        await agent._consolidation_task
 
     # Verify trigger_reflection was called with paired episodes
     mock_reflection.trigger_reflection.assert_called_once()

--- a/backend/tests/test_phase3_features.py
+++ b/backend/tests/test_phase3_features.py
@@ -301,6 +301,9 @@ async def test_subconscious_agent_silence_check_and_24h_window():
         # Now enable bypass
         Config.TESTING_CONSOLIDATION_BYPASS_SILENCE = True
         await agent._on_system_tick({"uptime": 2})
+        # P1-1: consolidation is dispatched, not awaited inline - await the
+        # retained task before asserting on its result.
+        await agent._consolidation_task
         ref_service.trigger_reflection.assert_called_once()
     finally:
         Config.TESTING_CONSOLIDATION_BYPASS_SILENCE = orig_bypass

--- a/backend/tests/test_stream_retention.py
+++ b/backend/tests/test_stream_retention.py
@@ -1,0 +1,136 @@
+"""
+P1-2: both core streams were declared with `name` and `subjects` only,
+inheriting JetStream's defaults -- limits retention, file storage, and
+UNLIMITED count/bytes/age. NATS' own docs warn that "an unbounded stream
+will eventually fill the disk", and AI_AUDIO binds `audio.>`, which carries
+raw PCM (ESTIMATED ~130 KB/s; actual growth NOT TESTED).
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from nats.js.api import StorageType
+
+from app.nats_streams import (
+    CORE_STREAMS,
+    STREAM_POLICIES,
+    _apply_policy_to_existing,
+    build_stream_config,
+)
+
+
+def test_every_core_stream_declares_a_retention_policy():
+    """Structural, so a stream added later cannot quietly ship unbounded --
+    which is exactly how both current streams got that way: NATS permits a
+    two-field declaration, so nobody was ever forced to decide."""
+    for name in CORE_STREAMS:
+        assert name in STREAM_POLICIES, f"{name} has no retention policy"
+
+
+@pytest.mark.parametrize("stream_name", sorted(CORE_STREAMS))
+def test_every_stream_config_names_storage_retention_and_a_limit(stream_name):
+    """The three fields whose absence is the defect. A stream with retention
+    set but no limit is still unbounded."""
+    config = build_stream_config(stream_name, list(CORE_STREAMS[stream_name]))
+
+    assert config.retention is not None
+    assert config.storage is not None
+    assert config.max_age and config.max_age > 0
+    assert config.max_bytes and config.max_bytes > 0
+
+
+def test_audio_stream_is_not_file_backed():
+    """Raw PCM must not be durably written to disk: it is worthless once the
+    utterance is transcribed, and a durable write sits directly in the audio
+    hot path. This is the single most load-bearing assertion in the file."""
+    config = build_stream_config("AI_AUDIO", ["audio.>"])
+
+    assert config.storage == StorageType.MEMORY
+
+
+def test_conversational_stream_is_file_backed():
+    """The inverse guard: conversation must survive a restart, so the
+    bounded-storage decision must not be applied to the wrong tier."""
+    config = build_stream_config("AI_MESSAGES", ["chat.>"])
+
+    assert config.storage == StorageType.FILE
+
+
+def test_audio_is_aged_out_far_sooner_than_conversation():
+    """The tiers exist because the data classes differ. If these ever
+    converge, one of them is wrong -- either PCM is being kept for days or
+    conversation is being discarded in minutes."""
+    audio = build_stream_config("AI_AUDIO", ["audio.>"])
+    messages = build_stream_config("AI_MESSAGES", ["chat.>"])
+
+    assert audio.max_age < messages.max_age
+
+
+def test_unknown_stream_degrades_to_subjects_only():
+    """A stream with no policy entry must not inherit limits meant for
+    something else -- it should behave exactly as it did before P1-2."""
+    config = build_stream_config("SOME_OTHER_STREAM", ["other.>"])
+
+    assert config.subjects == ["other.>"]
+    assert config.max_age is None
+
+
+def test_existing_stream_has_its_limits_brought_up_to_policy():
+    """Every deployment that has run before already has unbounded streams.
+    If only stream *creation* carried the policy, the fix would apply to
+    brand-new meshes and nowhere else, while still logging success."""
+    config = MagicMock()
+    config.max_age = None
+    config.max_bytes = -1
+    config.storage = StorageType.FILE
+
+    changed = _apply_policy_to_existing(config, "AI_MESSAGES")
+
+    assert changed is True
+    assert config.max_age == STREAM_POLICIES["AI_MESSAGES"]["max_age"]
+    assert config.max_bytes == STREAM_POLICIES["AI_MESSAGES"]["max_bytes"]
+
+
+def test_already_compliant_stream_reports_no_change():
+    """Avoids issuing a pointless update_stream on every agent start."""
+    policy = STREAM_POLICIES["AI_MESSAGES"]
+    config = MagicMock()
+    config.max_age = policy["max_age"]
+    config.max_bytes = policy["max_bytes"]
+    config.storage = StorageType.FILE
+
+    assert _apply_policy_to_existing(config, "AI_MESSAGES") is False
+
+
+@pytest.mark.asyncio
+async def test_both_creation_paths_declare_the_same_config():
+    """THE test for this item. There are two stream-creation paths --
+    nats_streams.setup_streams() and BaseAgent._bootstrap_mesh(), the latter
+    running on every agent start and usually reaching a fresh mesh first. If
+    they disagree, whichever runs first silently decides the policy. They
+    must be built from one definition."""
+    from app.agents.base import BaseAgent
+
+    agent = object.__new__(BaseAgent)
+    agent.name = "test_agent"
+
+    jsm = MagicMock()
+    jsm.add_stream = AsyncMock()
+    nc = MagicMock()
+    nc.jsm = MagicMock(return_value=jsm)
+    agent.nc = nc
+
+    await agent._bootstrap_mesh()
+
+    from_agent = {
+        c.kwargs["config"].name: c.kwargs["config"] for c in jsm.add_stream.await_args_list
+    }
+    assert set(from_agent) == set(CORE_STREAMS)
+
+    for name, subjects in CORE_STREAMS.items():
+        expected = build_stream_config(name, list(subjects))
+        actual = from_agent[name]
+        assert actual.storage == expected.storage, name
+        assert actual.max_age == expected.max_age, name
+        assert actual.max_bytes == expected.max_bytes, name
+        assert actual.retention == expected.retention, name

--- a/backend/tests/test_subconscious_consolidation.py
+++ b/backend/tests/test_subconscious_consolidation.py
@@ -253,6 +253,9 @@ async def test_subconscious_consolidation_pipeline(mock_llm_service, mock_graph_
 
         # Simulate a system.tick event manually
         await agent._on_system_tick({"uptime": 100})
+        # P1-1: consolidation is now dispatched, not awaited inline by
+        # _on_system_tick - await the retained task to observe its result.
+        await agent._consolidation_task
 
         # Verify graph write was attempted
         mock_graph_db.create_triplet.assert_called_once()
@@ -310,6 +313,7 @@ async def test_consecutive_user_messages_are_never_attributed_to_the_wrong_speak
     agent.engine.evaluate_and_think = AsyncMock(return_value=None)
 
     await agent._on_system_tick({"uptime": 100})
+    await agent._consolidation_task  # P1-1: dispatched, not inline - see above
 
     mock_reflection_service.trigger_reflection.assert_awaited_once()
     (episodes,), _ = mock_reflection_service.trigger_reflection.call_args


### PR DESCRIPTION
## Summary

Stage 2 of the audit implementation roadmap (`audit/ROADMAP.md` §7), landed in the roadmap's one mandatory sequencing order: P1-1 before P1-2.

- **P1-1** — `SubconsciousAgent._on_system_tick` awaited reflection, graph writes and ACT-R decay inline before ack (MEASURED ~16s idle, ~28s under two-model contention), against a 30s AckWait with unlimited MaxDeliver. Consolidation now dispatches to a retained task and the callback returns immediately. Also fixes the reason this would otherwise have been a no-op: `JetStreamContext.subscribe` discards a caller's `ConsumerConfig` when a durable already exists and adopts whatever is stored, so a new `ack_wait` silently never applied on any deployment that had run before. `BaseAgent._reconcile_consumer_config` now detects that drift and deletes the stale durable so it's recreated with the requested settings.
- **P1-2** — both core streams inherited JetStream's unbounded defaults. Added a two-tier retention policy (conversational: file-backed, 7-day age, 1 GiB; sensor/audio: memory-backed, 5-minute age, 256 MiB) applied from one shared builder consumed by both of this codebase's stream-creation paths, so they can't silently diverge — and brings pre-existing streams up to policy, not just newly-created ones.

Along the way, found and fixed a real gap in the test double for NATS (`tests/conftest.py`) — it was missing enough of `nats.js.api` that two code paths (real `subscribe()`, `_bootstrap_mesh`'s exception handling) had never actually been exercised by any test.

## Test plan

- [x] Full backend suite: 1019/1019 (`../.venv/bin/python -m pytest -q --junit-xml=...`)
- [x] `ruff check .` clean
- [x] 8 new tests across `test_mesh_ack_model.py` (P1-1) and `test_stream_retention.py` (P1-2)
- [x] 8 mutations tested, each caught by exactly the test written for it
- [ ] Docker-based verification (stream config applied against a real NATS, durable actually recreated on drift) — Docker was not running this session; deferred, tracked in the ledger

Ledger entry: `.agents/CONTEXT.md`, "Stage 2 (P1-1, P1-2)".

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>