### PR TITLE
fix: close measurement 1.1's real gap, bounded diagnostic pass on stt-agent hang

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -7607,3 +7607,105 @@ flag that stays false throughout the entire existing test suite's run.
 - Stage 4 (P1-4 then P1-3, gated on measurement 1.1's still-open worst-case
   question), P1-9 (prompt delimiters), and the six one-ended NATS subjects
   from P1-8 -- all still out of scope for this stage.
+
+## 2026-08-22 -- backlog clearing, Part 1 + Part 2 -- measurement 1.1's real
+gap closed (still `UNKNOWN`, now for the right reason), stt-agent hang
+diagnostic pass (3 hypotheses ruled out, root cause not found)
+
+Stage 3 (#186) left measurement 1.1's worst-case answer `UNKNOWN` and a new,
+undiagnosed stt-agent hang only documented. `audit/ROADMAP.md` lists
+measurement 1.1 as a literal dependency for both P1-3 and P1-4, so this had
+to close (one way or another) before Stage 4 could start on the right
+number. User instruction: "merge it and do whatever you think is next,
+clear all backlog before we move to next stage."
+
+**Part 1 -- `tools/measure/m11_bargein.py`.** The working theory going in was
+that Stage 3's near-zero backlog was an artifact of publishing a track with
+no subscriber -- no real playback-rate backpressure to make buffer 3
+back up. Built `_RealConsumer`: a second, throwaway LiveKit participant that
+joins the same room, subscribes to the published audio track, and drains it
+via `rtc.AudioStream`. Re-ran the same synthetic-burst methodology (50
+frames, `_RealConsumer` connected and subscribed before the burst) --
+**identical near-zero result** (`backlog_frames_at_stop_instant: 0`,
+`residual_drain_time_python_side_s: 0.040s`). Rather than accept a second
+inconclusive negative result, read `rtc.AudioSource.capture_frame()`'s and
+`rtc.AudioSource.wait_for_playout()`'s actual source via
+`inspect.getsource()` (not just the docstring, which claims real-time
+pacing backpressure). Finding: `capture_frame()` only awaits an FFI
+round-trip acknowledgment that the frame reached the native client's
+buffer; the real-time pacing machinery it schedules (`_q_size`, `_join_fut`,
+a `call_later` releasing a waiter) is never awaited inside
+`capture_frame()` -- it's resolved by a separate, unrelated method,
+`wait_for_playout()`, which `TransportAgent` never calls anywhere. Buffer 3
+was never going to show a backlog under the current code, with or without a
+listener -- the real, unbounded, real-time-paced buffer is entirely on the
+native side of the FFI boundary, a fifth buffer M3-R1's original
+four-buffer enumeration did not name and this harness cannot introspect or
+drive from Python.
+
+`worst_case_no_flush_latency` stays `UNKNOWN`, but the `reason` field now
+states the real, code-verified cause instead of the wrong "no consumer
+attached" theory. `buffer4_livekit_frames_received` (new figure, 6 of 50
+frames observed reaching the real consumer by snapshot time) confirms the
+pipeline delivers end-to-end; it just cannot be timed from the Python side
+past `capture_frame()`. Report title and notes rewritten to narrate this as
+a second, sharper negative result rather than a resolved measurement.
+
+**Consequence for P1-3.** Its flush logic (still not built, correctly
+gated on this measurement) needs to reach past `capture_frame()` -- via
+`wait_for_playout()` or a native-side API -- to affect the buffer that
+actually matters. A flush that only clears `TransportAgent.audio_queue`
+would fix nothing a user could hear.
+
+**Part 2 -- stt-agent hang, bounded diagnostic pass.** No interactive
+debugger reachable inside the container from this harness, so this tested
+three cheap, falsifiable hypotheses against fresh single-utterance
+containers, per the approved plan, stopping if none resolved it:
+
+1. `params.set_n_threads(1)` in `whisper.rs::transcribe` (temporary local
+   build) -- still hung. Rules out an internal ggml multi-thread race.
+2. `STT_SENSEVOICE=off` -- still hung (falls the fast path back to Whisper
+   `tiny.en` too, so both paths were pure-Whisper). Rules out SenseVoice/
+   ONNX Runtime resource contention.
+3. A 0.6s utterance, just above the `pcm_16k.len() < 16_000/2` floor --
+   still hung at the identical point. Rules out a length-dependent path.
+
+All three stalled identically: right after whisper's `compute buffer
+(decode)` init log, zero completion, zero error logged, `docker stats`
+pinned at 0.00% CPU for the full observation window (not the near-100%-
+on-one-core signature of slow-but-working inference). A fourth pass under
+`RUST_LOG=trace` added one real finding: the tokio runtime keeps running
+normally for 70+ seconds after the stall begins -- NATS PING/PONG and
+`audio.inbound` dispatch continue in the trace log with no gap -- so this is
+not a runtime-wide stall from a missing `spawn_blocking` (`run_final_job`
+already wraps the accurate call correctly). Only that one spawned blocking
+task itself never returns and burns no CPU while not returning: blocked,
+not busy, consistent with a wait on a synchronization primitive inside
+whisper.cpp's C code that is never signaled, not an infinite compute loop.
+
+No source change ships from this pass, per the plan's own rule against
+shipping a blind fix without the ability to verify it. `whisper.rs` reverted
+to its pre-diagnostic state (`git diff` against `main` is empty). Findings
+written into `tools/measure/m14_stt_cost.py`'s docstring, immediately below
+the original finding, so the next person who reaches for a debugger starts
+from three ruled-out causes and one substantive lead instead of zero.
+
+**Verified:** full backend suite 1019/1019, `ruff check .` clean on the
+changed files. No new tests -- no new decision logic shipped, only measurement-
+harness and docstring changes.
+
+**NOT done:**
+- Root-causing the stt-agent hang -- still open, now with three hypotheses
+  ruled out and one lead (a synchronization primitive inside whisper.cpp)
+  instead of none. Needs an actual debugger (lldb/gdb) attached inside the
+  container, out of reach of this harness.
+- Instrumenting past the LiveKit FFI boundary to get a real
+  `worst_case_no_flush_latency` figure -- would need LiveKit Rust/FFI-level
+  work or calling `wait_for_playout()` from a modified
+  `_audio_playback_worker`, both out of scope for a Python-only measurement
+  harness.
+- `buffer2_nats_pending` -- still `UNKNOWN`, unchanged from Stage 3 (would
+  need nats-py internals not exposed on the public subscription object).
+- Parts 3-5 of the same backlog-clearing pass (visual grounding wiring,
+  P1-9 prompt delimiters, the six one-ended NATS subjects) and Stage 4
+  itself -- all still ahead.

--- a/backend/tools/measure/m11_bargein.py
+++ b/backend/tools/measure/m11_bargein.py
@@ -16,6 +16,28 @@ repo (see Stage 3 plan Context). Synthetic PCM published directly onto
 audio.stream at the real wire rate fills TransportAgent's buffers exactly as
 real PCM would; it cannot include synthesis latency upstream of the queue,
 and this report says so rather than estimating it.
+
+**A second, deeper finding, from actually reading the LiveKit Python SDK's
+source rather than assuming its docstring's behavior.** The first version of
+this measurement published a track with no subscriber attached and observed
+buffer 3 (TransportAgent's own `audio_queue`) drain instantly regardless of
+burst size -- the working theory was that a real downstream listener would
+supply the missing playback-rate backpressure. It does not.
+`rtc.AudioSource.capture_frame()`'s own docstring claims it "will wait until
+there is enough space in the queue" once real-time pacing falls behind, but
+reading its actual implementation (`inspect.getsource`) shows the pacing
+machinery (`_q_size`, `_join_fut`, scheduled via `call_later`) is wired to a
+*different* method, `wait_for_playout()` -- `capture_frame()` itself only
+awaits an FFI round-trip acknowledgment that the frame reached the native
+client's internal buffer, never the future the pacing machinery resolves.
+`TransportAgent._audio_playback_worker` never calls `wait_for_playout()`
+anywhere. `_RealConsumer` below (a second LiveKit participant that actually
+subscribes to and drains the track) was built to test the
+missing-listener theory and confirms it wrong: buffer 3 drains identically
+fast with a real consumer attached. The real, unbounded, real-time-paced
+buffer sits entirely inside the native LiveKit client past the FFI
+boundary -- a fifth buffer M3-R1's original four-buffer enumeration did not
+name, and one this harness cannot introspect or drive from Python at all.
 """
 
 from __future__ import annotations
@@ -24,6 +46,9 @@ import argparse
 import asyncio
 import os
 import time
+
+from livekit import rtc
+from livekit.api import AccessToken, VideoGrants
 
 from app.agents.transport_agent import TransportAgent
 from app.config import Config
@@ -35,6 +60,60 @@ _SAMPLE_RATE = 32000
 _BYTES_PER_SAMPLE = 2
 _FRAME_MS = 20
 _FRAME_BYTES = int(_SAMPLE_RATE * _BYTES_PER_SAMPLE * (_FRAME_MS / 1000))
+
+
+class _RealConsumer:
+    """A second LiveKit participant that actually subscribes to and drains
+    the published track.
+
+    Originally built to test the theory that capture_frame() needs a real
+    listener to apply playback-rate backpressure. It does not -- see this
+    module's docstring for what reading capture_frame()'s actual source
+    revealed instead. Kept because it still answers one real question this
+    measurement can otherwise only guess at: whether frames published on
+    audio.stream actually reach a receiving client at all
+    (frames_consumed), as a coarse proxy for buffer 4.
+    """
+
+    def __init__(self, lk_url: str, api_key: str, api_secret: str) -> None:
+        self.room = rtc.Room()
+        self._lk_url = lk_url
+        self._token = (
+            AccessToken(api_key, api_secret)
+            .with_identity("m11-real-consumer")
+            .with_name("Measurement Listener")
+            .with_grants(VideoGrants(room_join=True, room="ai-friend-room"))
+            .to_jwt()
+        )
+        self.frames_consumed = 0
+        self._consume_task: asyncio.Task | None = None
+        self._track_subscribed = asyncio.Event()
+
+    async def connect(self) -> None:
+        self.room.on("track_subscribed", self._on_track_subscribed)
+        await self.room.connect(self._lk_url, self._token)
+
+    def _on_track_subscribed(self, track, publication, participant) -> None:
+        if track.kind == rtc.TrackKind.KIND_AUDIO:
+            self._consume_task = asyncio.create_task(self._consume(track))
+            self._track_subscribed.set()
+
+    async def _consume(self, track: rtc.RemoteAudioTrack) -> None:
+        audio_stream = rtc.AudioStream(track)
+        async for _event in audio_stream:
+            self.frames_consumed += 1
+
+    async def wait_subscribed(self, timeout_s: float = 15.0) -> None:
+        await asyncio.wait_for(self._track_subscribed.wait(), timeout=timeout_s)
+
+    async def close(self) -> None:
+        if self._consume_task:
+            self._consume_task.cancel()
+            try:
+                await self._consume_task
+            except asyncio.CancelledError:
+                pass
+        await self.room.disconnect()
 
 
 async def _prime_backlog(agent: TransportAgent, backlog_frames: int) -> None:
@@ -61,8 +140,19 @@ async def run(allow_mock: bool = False, backlog_frames: int = 100) -> Measuremen
         lk_api_secret=Config.LIVEKIT_API_SECRET,
     )
 
+    consumer = _RealConsumer(lk_url, Config.LIVEKIT_API_KEY, Config.LIVEKIT_API_SECRET)
+
     with collecting_trace() as events:
         await agent.start()
+
+        # The real fix from the first version of this measurement: connect a
+        # second participant that actually subscribes to and drains the
+        # track, so capture_frame() has real playback-rate backpressure to
+        # push against. Must be subscribed *before* priming, or the burst
+        # races the subscription and some early frames drain unpaced.
+        await consumer.connect()
+        await consumer.wait_subscribed()
+
         burst_t0 = time.monotonic()
         await _prime_backlog(agent, backlog_frames)
         burst_s = time.monotonic() - burst_t0
@@ -84,6 +174,7 @@ async def run(allow_mock: bool = False, backlog_frames: int = 100) -> Measuremen
         await asyncio.sleep(_FRAME_MS / 1000 * 2)
         drain_complete = time.monotonic()
 
+        await consumer.close()
         await agent.stop()
 
     drain_s = drain_complete - stop_instant
@@ -92,6 +183,11 @@ async def run(allow_mock: bool = False, backlog_frames: int = 100) -> Measuremen
     figures = {
         "backlog_frames_at_stop_instant": Figure(
             label="MEASURED", value=queue_depth_at_stop, unit="frames (buffer 3)"
+        ),
+        "backlog_ms_at_stop_instant": Figure(
+            label="MEASURED",
+            value=queue_depth_at_stop * _FRAME_MS,
+            unit="ms of audio queued in buffer 3 at the stop instant",
         ),
         "burst_publish_time_s": Figure(
             label="MEASURED",
@@ -105,27 +201,42 @@ async def run(allow_mock: bool = False, backlog_frames: int = 100) -> Measuremen
         "dropped_frames_before_stop": Figure(
             label="MEASURED", value=dropped_at_stop, unit="frames"
         ),
-        "residual_drain_time_s": Figure(
+        "residual_drain_time_python_side_s": Figure(
             label="MEASURED",
             value=drain_s,
             unit="seconds",
             derivation=(
-                f"{queue_depth_at_stop} frames still queued at the stop "
-                f"instant; wall-clock to the last buffer3_to_4 crossing was "
-                f"{drain_s:.3f}s"
+                f"{queue_depth_at_stop} frames queued in buffer 3 at the stop "
+                f"instant (with a real LiveKit consumer attached -- see notes "
+                f"for why this made no observable difference); wall-clock to "
+                f"the last buffer3_to_4 crossing was {drain_s:.3f}s. This is "
+                f"NOT the answer to M3-R1's question -- it times only "
+                f"TransportAgent's own queue-to-capture_frame() handoff, which "
+                f"this run's own evidence (module docstring) shows is not "
+                f"where real-time pacing happens."
             ),
         ),
         "worst_case_no_flush_latency": Figure(
             label="UNKNOWN",
             reason=(
-                "this run's queue_depth_at_stop is near zero (see notes): "
-                "capture_frame() does not pace to real-time or apply "
-                "backpressure without a connected subscriber actually "
-                "consuming the published track, so no realistic backlog "
-                "accumulated in buffer 3 for this harness to time a drain of "
-                "-- M3-R1's worst-case scenario needs a real (or "
-                "artificially paced) consumer on the other end, which this "
-                "run does not attach"
+                "buffer 3 (TransportAgent's audio_queue) is not the site of "
+                "real-time playback pacing: rtc.AudioSource.capture_frame() "
+                "only awaits an FFI handoff acknowledgment, never the future "
+                "its own _q_size/wait_for_playout() pacing machinery resolves "
+                "(confirmed by reading capture_frame()'s and "
+                "wait_for_playout()'s actual source -- see module docstring). "
+                "A real consumer attached to the track (this run) makes no "
+                "difference to buffer 3's drain speed, confirming the theory "
+                "that a missing listener explained the first version's "
+                "near-zero result was wrong. The real, unbounded, "
+                "real-time-paced buffer sits inside the native LiveKit client "
+                "past the FFI boundary and is not introspectable or drivable "
+                "from this harness -- a fifth buffer M3-R1's original "
+                "four-buffer enumeration did not name. Answering this for "
+                "real needs either LiveKit Rust/FFI-level instrumentation, or "
+                "calling wait_for_playout() from a modified "
+                "_audio_playback_worker and timing that -- both out of scope "
+                "for a Python-only measurement harness."
             ),
         ),
         "buffer2_nats_pending": Figure(
@@ -137,21 +248,33 @@ async def run(allow_mock: bool = False, backlog_frames: int = 100) -> Measuremen
                 "to avoid depending on undocumented internals"
             ),
         ),
-        "buffer4_livekit_internal": Figure(
-            label="UNKNOWN",
-            reason=(
-                "requires a receiving LiveKit client actually subscribed to "
-                "the published track to observe sink-side buffering; this "
-                "run publishes a track but attaches no subscriber"
+        "buffer4_livekit_frames_received": Figure(
+            label="MEASURED",
+            value=consumer.frames_consumed,
+            unit="frames received by the real consumer (buffer 4 proxy)",
+            derivation=(
+                "counts AudioStream frame-events on the listener side; not "
+                "the same as buffer 4's internal queue depth (LiveKit's SDK "
+                "internals are not introspectable from here), but confirms "
+                "frames actually reached a sink rather than being lost"
             ),
         ),
     }
 
     return MeasurementReport(
         measurement_id="1.1",
-        title="End-to-end barge-in latency (buffer-drain timing, synthetic PCM)",
+        title="End-to-end barge-in latency (buffer 3 is not the pacing site; worst case still UNKNOWN)",
         provenance=provenance,
-        runs=[Run(figures=figures, raw={"buffer3_to_4_event_count": len(buffer3_to_4_events)})],
+        runs=[
+            Run(
+                figures=figures,
+                raw={
+                    "buffer3_to_4_event_count": len(buffer3_to_4_events),
+                    "drained_events_before_stop": drained_events_before_stop,
+                    "consumer_frames_consumed": consumer.frames_consumed,
+                },
+            )
+        ],
         notes=[
             (
                 "Synthetic PCM, not real speech synthesis -- no CUDA/GPT-SoVITS "
@@ -160,41 +283,51 @@ async def run(allow_mock: bool = False, backlog_frames: int = 100) -> Measuremen
                 "capture_frame), not synthesis latency upstream of it."
             ),
             (
-                f"IMPORTANT negative result: {drained_events_before_stop} of "
-                f"{backlog_frames} frames had already crossed buffer3_to_4 "
-                "(reached capture_frame) by the time the 'stop instant' was "
-                f"sampled, leaving only {queue_depth_at_stop} still queued. "
-                "rtc.AudioSource.capture_frame() does not block or pace to "
-                "real-time when nothing is actually consuming the published "
-                "track -- this run publishes a track but attaches no receiving "
-                "client, so there is no playback-rate backpressure and the "
-                "queue drains at publish speed instead of speech speed. This is "
-                "itself informative: it means M3-R1's buffer-3 backlog scenario "
-                "specifically requires an actively-playing listener, and cannot "
-                "be reproduced by publishing alone."
+                "SECOND negative result, and a sharper one. The first version "
+                "of this measurement published a track with no subscriber and "
+                "found buffer 3 drained instantly; the working theory was that "
+                "a real listener would supply missing playback-rate "
+                "backpressure. This run attaches one (_RealConsumer, a real "
+                "second LiveKit participant that subscribes to and drains the "
+                "track) and gets the SAME near-zero backlog. Reading "
+                "capture_frame()'s actual source (not just its docstring) "
+                "explains why: it only awaits an FFI round-trip "
+                "acknowledgment that the frame reached the native client's "
+                "buffer, never the future its own pacing machinery "
+                "(_q_size/_join_fut, resolved by a separate method, "
+                "wait_for_playout()) would resolve. TransportAgent never "
+                "calls wait_for_playout(). Buffer 3 was never going to show a "
+                "backlog under the current implementation, with or without a "
+                "listener -- the real, unbounded, real-time-paced buffer is "
+                "entirely on the far side of the FFI boundary, invisible to "
+                "this harness and to TransportAgent itself."
             ),
             (
-                "residual_drain_time_s and backlog_frames_at_stop_instant are "
-                "real measurements of what they say, but do NOT answer M3-R1's "
-                "actual question (see worst_case_no_flush_latency, UNKNOWN) -- "
-                "that needs either a real LiveKit-connected client pacing "
-                "consumption, or capture_frame() driven under an explicit clock "
-                "budget so backpressure is simulated rather than absent. Left "
-                "for a follow-up with that harness piece built; recorded here "
-                "as UNKNOWN rather than reporting this run's near-zero number "
-                "as if it were the answer."
+                f"{drained_events_before_stop} of {backlog_frames} frames had "
+                f"already crossed buffer3_to_4 by the stop instant, leaving "
+                f"{queue_depth_at_stop} in buffer 3 -- consistent with the "
+                "above: capture_frame() completes as fast as the FFI "
+                "round-trip allows, not at real playback speed."
+            ),
+            (
+                "buffer4_livekit_frames_received confirms frames DO reach a "
+                "real subscriber (6 of 50 by the time this run's snapshot was "
+                "taken) -- so the pipeline works end-to-end; it just cannot "
+                "be timed from the Python side past the capture_frame() call."
             ),
             (
                 "TransportAgent still has no audio.stop subscriber (P1-3 not "
                 "yet built, correctly gated on this measurement per "
-                "audit/ROADMAP.md §7's sequencing) -- even with a real backlog, "
-                "nothing today drains it faster than playback pace regardless "
-                "of when a stop is requested."
+                "audit/ROADMAP.md §7's sequencing). P1-3's flush would need to "
+                "reach past capture_frame() -- e.g. via wait_for_playout() or "
+                "a native-side API -- to have any effect on the buffer that "
+                "actually matters, which this measurement now shows is not "
+                "buffer 3."
             ),
             (
-                "buffer2 and buffer4 are UNKNOWN for the reasons stated per "
-                "figure, matching HARDWARE.md §0's rule against filling an "
-                "unmeasured figure with a plausible number."
+                "buffer2 is still UNKNOWN for the reason stated per figure, "
+                "matching HARDWARE.md §0's rule against filling an unmeasured "
+                "figure with a plausible number."
             ),
         ],
     )

--- a/backend/tools/measure/m14_stt_cost.py
+++ b/backend/tools/measure/m14_stt_cost.py
@@ -44,6 +44,48 @@ inside the container or bisecting which whisper.cpp call blocks. Filed
 alongside P2-11 (native macOS binary can't even start) as a second,
 independent stt-agent reliability gap worth its own investigation, not
 folded into this measurement's own scope.
+
+**Bounded diagnostic pass, 2026-08-22 (backlog Part 2).** Three cheap,
+falsifiable hypotheses were tested against fresh single-utterance
+containers, in order, each ruled out by an identical symptom (stall
+immediately after whisper's `compute buffer (decode)` init log, zero
+completion, zero error, and `docker stats` pinned at **0.00% CPU** for the
+full observation window rather than the near-100%-on-one-core signature of
+slow-but-working inference):
+
+1. `params.set_n_threads(1)` in `whisper.rs::transcribe` (temporary local
+   build) -- still hung. Rules out an internal ggml multi-thread race: a
+   single decode thread cannot deadlock against other ggml threads that
+   don't exist in this run.
+2. `STT_SENSEVOICE=off` -- still hung (this also falls back the fast path to
+   Whisper `tiny.en`, so both paths were pure-Whisper and it still hung on
+   the accurate call). Rules out resource contention between SenseVoice's
+   ONNX Runtime and whisper.cpp's ggml runtime as the cause.
+3. A 0.6s utterance, just above the `pcm_16k.len() < 16_000/2` floor --
+   still hung at the same point. Rules out a length- or buffer-size-
+   dependent path.
+
+A fourth pass under `RUST_LOG=trace` added one real finding beyond ruling
+hypotheses out: the tokio runtime keeps running normally for 70+ seconds
+after the stall begins -- NATS PING/PONG keepalives and unrelated
+`audio.inbound` message dispatch continue in the trace log throughout, with
+no gap. This means the hang is *not* a runtime-wide stall (e.g. a blocking
+call made without `spawn_blocking`) -- `run_final_job` correctly wraps the
+accurate call in `spawn_blocking`, and that wrapping is doing its job; only
+that one spawned blocking task itself never returns and burns no CPU while
+not returning. That combination -- blocked, not busy -- is the signature of
+a wait on a synchronization primitive (a mutex, condvar, or semaphore)
+inside whisper.cpp's C code that is never signaled, not an infinite compute
+loop.
+
+No source change ships from this pass -- none of the three hypotheses
+produced a fix to verify, and the plan's own rule is not to ship a blind fix
+without the ability to confirm it resolves the real issue. Root-causing
+further needs an actual debugger (lldb/gdb) attached inside the container,
+out of reach of this harness. Filed as the same open reliability gap noted
+above, now with three ruled-out causes and one substantive lead (blocked
+inside a whisper.cpp synchronization primitive, not multi-threading, not
+SenseVoice, not utterance length) for whoever picks up a debugger next.
 """
 
 from __future__ import annotations

--- a/backend/tools/measure/out/m11_bargein.json
+++ b/backend/tools/measure/out/m11_bargein.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
-  "created_at": "2026-08-22T14:23:22.773816+00:00",
+  "created_at": "2026-08-22T15:12:14.109909+00:00",
   "measurement_id": "1.1",
-  "title": "End-to-end barge-in latency (buffer-drain timing, synthetic PCM)",
+  "title": "End-to-end barge-in latency (buffer 3 is not the pacing site; worst case still UNKNOWN)",
   "provenance": "live",
   "runs": [
     {
@@ -14,16 +14,23 @@
           "derivation": "",
           "reason": ""
         },
+        "backlog_ms_at_stop_instant": {
+          "label": "MEASURED",
+          "value": 0,
+          "unit": "ms of audio queued in buffer 3 at the stop instant",
+          "derivation": "",
+          "reason": ""
+        },
         "burst_publish_time_s": {
           "label": "MEASURED",
-          "value": 0.02214258299954963,
+          "value": 0.023543416000393336,
           "unit": "seconds",
           "derivation": "wall-clock to publish 50 frames sequentially",
           "reason": ""
         },
         "ai_audio_stream_bytes_at_stop": {
           "label": "MEASURED",
-          "value": 3207046,
+          "value": 152347,
           "unit": "bytes (buffer 1)",
           "derivation": "",
           "reason": ""
@@ -35,11 +42,11 @@
           "derivation": "",
           "reason": ""
         },
-        "residual_drain_time_s": {
+        "residual_drain_time_python_side_s": {
           "label": "MEASURED",
-          "value": 0.0403341659994112,
+          "value": 0.04040162499950384,
           "unit": "seconds",
-          "derivation": "0 frames still queued at the stop instant; wall-clock to the last buffer3_to_4 crossing was 0.040s",
+          "derivation": "0 frames queued in buffer 3 at the stop instant (with a real LiveKit consumer attached -- see notes for why this made no observable difference); wall-clock to the last buffer3_to_4 crossing was 0.040s. This is NOT the answer to M3-R1's question -- it times only TransportAgent's own queue-to-capture_frame() handoff, which this run's own evidence (module docstring) shows is not where real-time pacing happens.",
           "reason": ""
         },
         "worst_case_no_flush_latency": {
@@ -47,7 +54,7 @@
           "value": null,
           "unit": "",
           "derivation": "",
-          "reason": "this run's queue_depth_at_stop is near zero (see notes): capture_frame() does not pace to real-time or apply backpressure without a connected subscriber actually consuming the published track, so no realistic backlog accumulated in buffer 3 for this harness to time a drain of -- M3-R1's worst-case scenario needs a real (or artificially paced) consumer on the other end, which this run does not attach"
+          "reason": "buffer 3 (TransportAgent's audio_queue) is not the site of real-time playback pacing: rtc.AudioSource.capture_frame() only awaits an FFI handoff acknowledgment, never the future its own _q_size/wait_for_playout() pacing machinery resolves (confirmed by reading capture_frame()'s and wait_for_playout()'s actual source -- see module docstring). A real consumer attached to the track (this run) makes no difference to buffer 3's drain speed, confirming the theory that a missing listener explained the first version's near-zero result was wrong. The real, unbounded, real-time-paced buffer sits inside the native LiveKit client past the FFI boundary and is not introspectable or drivable from this harness -- a fifth buffer M3-R1's original four-buffer enumeration did not name. Answering this for real needs either LiveKit Rust/FFI-level instrumentation, or calling wait_for_playout() from a modified _audio_playback_worker and timing that -- both out of scope for a Python-only measurement harness."
         },
         "buffer2_nats_pending": {
           "label": "UNKNOWN",
@@ -56,24 +63,27 @@
           "derivation": "",
           "reason": "nats-py's JetStream push-subscription pending count is not exposed on the public subscription object used here; would need the client's internal _sub.pending_msgs, not queried to avoid depending on undocumented internals"
         },
-        "buffer4_livekit_internal": {
-          "label": "UNKNOWN",
-          "value": null,
-          "unit": "",
-          "derivation": "",
-          "reason": "requires a receiving LiveKit client actually subscribed to the published track to observe sink-side buffering; this run publishes a track but attaches no subscriber"
+        "buffer4_livekit_frames_received": {
+          "label": "MEASURED",
+          "value": 6,
+          "unit": "frames received by the real consumer (buffer 4 proxy)",
+          "derivation": "counts AudioStream frame-events on the listener side; not the same as buffer 4's internal queue depth (LiveKit's SDK internals are not introspectable from here), but confirms frames actually reached a sink rather than being lost",
+          "reason": ""
         }
       },
       "raw": {
-        "buffer3_to_4_event_count": 50
+        "buffer3_to_4_event_count": 50,
+        "drained_events_before_stop": 50,
+        "consumer_frames_consumed": 6
       }
     }
   ],
   "notes": [
     "Synthetic PCM, not real speech synthesis -- no CUDA/GPT-SoVITS on this host. This measures the buffer-drain portion of the chain (JetStream -> NATS client -> audio_queue -> LiveKit capture_frame), not synthesis latency upstream of it.",
-    "IMPORTANT negative result: 50 of 50 frames had already crossed buffer3_to_4 (reached capture_frame) by the time the 'stop instant' was sampled, leaving only 0 still queued. rtc.AudioSource.capture_frame() does not block or pace to real-time when nothing is actually consuming the published track -- this run publishes a track but attaches no receiving client, so there is no playback-rate backpressure and the queue drains at publish speed instead of speech speed. This is itself informative: it means M3-R1's buffer-3 backlog scenario specifically requires an actively-playing listener, and cannot be reproduced by publishing alone.",
-    "residual_drain_time_s and backlog_frames_at_stop_instant are real measurements of what they say, but do NOT answer M3-R1's actual question (see worst_case_no_flush_latency, UNKNOWN) -- that needs either a real LiveKit-connected client pacing consumption, or capture_frame() driven under an explicit clock budget so backpressure is simulated rather than absent. Left for a follow-up with that harness piece built; recorded here as UNKNOWN rather than reporting this run's near-zero number as if it were the answer.",
-    "TransportAgent still has no audio.stop subscriber (P1-3 not yet built, correctly gated on this measurement per audit/ROADMAP.md §7's sequencing) -- even with a real backlog, nothing today drains it faster than playback pace regardless of when a stop is requested.",
-    "buffer2 and buffer4 are UNKNOWN for the reasons stated per figure, matching HARDWARE.md §0's rule against filling an unmeasured figure with a plausible number."
+    "SECOND negative result, and a sharper one. The first version of this measurement published a track with no subscriber and found buffer 3 drained instantly; the working theory was that a real listener would supply missing playback-rate backpressure. This run attaches one (_RealConsumer, a real second LiveKit participant that subscribes to and drains the track) and gets the SAME near-zero backlog. Reading capture_frame()'s actual source (not just its docstring) explains why: it only awaits an FFI round-trip acknowledgment that the frame reached the native client's buffer, never the future its own pacing machinery (_q_size/_join_fut, resolved by a separate method, wait_for_playout()) would resolve. TransportAgent never calls wait_for_playout(). Buffer 3 was never going to show a backlog under the current implementation, with or without a listener -- the real, unbounded, real-time-paced buffer is entirely on the far side of the FFI boundary, invisible to this harness and to TransportAgent itself.",
+    "50 of 50 frames had already crossed buffer3_to_4 by the stop instant, leaving 0 in buffer 3 -- consistent with the above: capture_frame() completes as fast as the FFI round-trip allows, not at real playback speed.",
+    "buffer4_livekit_frames_received confirms frames DO reach a real subscriber (6 of 50 by the time this run's snapshot was taken) -- so the pipeline works end-to-end; it just cannot be timed from the Python side past the capture_frame() call.",
+    "TransportAgent still has no audio.stop subscriber (P1-3 not yet built, correctly gated on this measurement per audit/ROADMAP.md §7's sequencing). P1-3's flush would need to reach past capture_frame() -- e.g. via wait_for_playout() or a native-side API -- to have any effect on the buffer that actually matters, which this measurement now shows is not buffer 3.",
+    "buffer2 is still UNKNOWN for the reason stated per figure, matching HARDWARE.md §0's rule against filling an unmeasured figure with a plausible number."
   ]
 }


### PR DESCRIPTION
## Summary
- Measurement 1.1 (M3-R1): attached a real LiveKit consumer to the published audio track and re-ran the barge-in backlog burst. Result is unchanged (near-zero backlog), but reading `capture_frame()`'s actual source (not just its docstring) explains why — it never awaits the real-time pacing future its own machinery schedules, and `TransportAgent` never calls the method that does. `worst_case_no_flush_latency` stays `UNKNOWN`, now for the correct, code-verified reason.
- stt-agent's whisper-transcription hang (found in Stage 3): ran a bounded diagnostic pass — three falsifiable hypotheses (single-threaded decode, SenseVoice disabled, near-floor utterance length) all still hang identically at 0% CPU. A trace-level capture narrows it further: the tokio runtime keeps running normally throughout, so the stall is isolated to the spawned blocking decode task itself. No fix ships — findings are recorded for the next debugging pass.

## Test plan
- [x] `../.venv/bin/python -m pytest -q --junit-xml=...` — 1019 passed, 0 failed/errored
- [x] `../.venv/bin/python -m ruff check .` — clean
- [x] `tools/measure/m11_bargein.py` re-run against real infra, output committed
- [x] `whisper.rs` diagnostic edit reverted (`git diff` against `main` is empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)