### PR TITLE
fix: resolve the six one-ended NATS subjects from P1-8 (backlog Part 5)

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -7785,3 +7785,64 @@ failure led to finding it), caught before commit.
   unwrapped -- it is LLM-inferred *about* the user, not retrieved/perceived
   raw content, so it does not carry the same untrusted-content risk P1-9
   was scoped to.
+
+## 2026-08-22 -- backlog clearing, Part 5 (final) -- the six one-ended NATS
+subjects from P1-8 resolved: two real gaps closed, four sharpened from
+"needs investigation" to a decided disposition
+
+Last item of the backlog-clearing pass (Parts 1-4: #187, #188). Per-subject
+disposition, decided with the user (`check_subject_wiring.py:51`'s
+`ALLOWLIST`):
+
+**`vision.frames` -- RESOLVED, entry removed.** Wired end-to-end in Part 3
+(#188). Rebased this branch onto `main` after #188 merged so the removal
+could be verified against the real checker output rather than asserted --
+`python scripts/check_subject_wiring.py` now reports it fully wired, no
+allowlist entry needed.
+
+**`control.interrupt` -- DELETE, entry removed.** Redundant with `audio.stop`,
+published in the same call (`action.py`'s `_announce_self_correction`) with
+an overlapping payload (`{"interrupt": True, "reason": ...}`); zero
+subscribers ever existed for `control.interrupt` itself, and `audio.stop`'s
+existing subscribers already act on the interruption. Removed the dead
+publish call rather than build it a consumer it never needed.
+`tests/test_phase6_advanced_cognition.py::test_metacognitive_self_correction`
+asserted `control.interrupt` was published -- updated to assert `audio.stop`
+fires and `control.interrupt` does not, and mutation-tested (reintroducing
+the dead publish call makes the updated assertion fail, confirming it is
+load-bearing, not just updated to match).
+
+**Four subjects kept allowlisted, reasons sharpened from "NEW... needs
+investigation" (Stage 3's placeholder, once this check first landed) to a
+decided disposition, so a future pass doesn't re-run this same
+investigation:**
+- `voice.segmentation_feedback` -- `voice-agent`'s Rust source has no
+  chunk-size/segmentation-reporting code at all to hook a publisher into;
+  real new Rust feature work, not a missing call.
+- `audio.pre_generate` -- the speculative-pregeneration consumer
+  (voice-agent pre-warming TTS on a VAP>=0.7 signal) was never built; same
+  shape, real feature work.
+- `telemetry.reflection` -- fire-and-forget observability with zero
+  subscribers; explicitly tied to `P3-2` (telemetry) as its likely future
+  consumer, so the connection isn't re-discovered as new later.
+- `state.subconscious` -- the agent's internal monologue, zero subscribers;
+  no consumer has a decided purpose yet (a UI surface? a persistence
+  sink?), so this needs a product decision before it needs wiring.
+
+**Verified:** `python scripts/check_subject_wiring.py` -- 8 allowlisted
+issues (down from the prior 6+2), `control.interrupt` and `vision.frames`
+absent from its output entirely rather than allowlisted. Full backend suite
+1027/1027 (matching post-#188 `main`'s baseline, no new tests beyond the
+one updated one), `ruff check .` clean.
+
+**NOT done:**
+- Building real publishers for `voice.segmentation_feedback` or
+  `audio.pre_generate` -- both are new Rust feature work, decided against
+  for this pass, per the plan that scoped Parts 1-5.
+- A telemetry sink for `telemetry.reflection` -- `P3-2`'s scope.
+- A consumer/purpose for `state.subconscious` -- no decided purpose to
+  build against yet.
+- Stage 4 (P1-3, P1-4, P2-3, P2-4, P2-6, P2-9) -- this closes what blocked
+  it; Stage 4 itself is the next, separate piece of work. Measurement
+  1.1's `worst_case_no_flush_latency` is still `UNKNOWN` (per the Part 1+2
+  entry above), so P1-3/P1-4 still cannot be built against a real number.

--- a/backend/app/cognitive/action.py
+++ b/backend/app/cognitive/action.py
@@ -989,9 +989,6 @@ class ActionService:
         if self.publish_cb:
             try:
                 await self.publish_cb(
-                    "control.interrupt", {"reason": reason, "interrupt": True}
-                )
-                await self.publish_cb(
                     "audio.stop", {"interrupt": True, "reason": reason}
                 )
             except Exception as pe:

--- a/backend/scripts/check_subject_wiring.py
+++ b/backend/scripts/check_subject_wiring.py
@@ -72,14 +72,16 @@ ALLOWLIST: dict[str, str] = {
     "audio.stream": "ROADMAP P4-11a: Rust-side core-NATS subscriber, not JetStream-visible to this scan",
     # Discovered while building this check (not one of the audit's original
     # eight) -- genuinely new findings, allowlisted so this check can land
-    # enforcing rather than warn-only, per ROADMAP P1-8. Each needs its own
-    # look, tracked here rather than silently fixed as a drive-by.
-    "audio.pre_generate": "NEW (found building this check): published by cognitive/pipeline.py mesh_signal, zero subscribers anywhere -- needs investigation, not yet in ROADMAP",
-    "telemetry.reflection": "NEW (found building this check): published by cognitive/core.py, matches no declared stream pattern and has zero subscribers -- needs investigation, not yet in ROADMAP",
-    "state.subconscious": "NEW (found building this check): subconscious_agent's internal-monologue thought is published, zero subscribers anywhere -- needs investigation, not yet in ROADMAP",
-    "voice.segmentation_feedback": "NEW (found building this check): brain_agent subscribes, zero publishers anywhere in Python or Rust -- needs investigation, not yet in ROADMAP",
-    "control.interrupt": "NEW (found building this check): cognitive/action.py's self-correction path publishes this alongside audio.stop (which IS subscribed); control.interrupt itself has zero subscribers -- needs investigation, not yet in ROADMAP",
-    "vision.frames": "NEW (found building this check): the only publish call is commented out in vision/agent.py ('TEMPORARILY DISABLED FOR DIAGNOSTICS'), brain_agent still subscribes -- deliberately not silently re-enabled by this batch, needs its own investigation",
+    # enforcing rather than warn-only, per ROADMAP P1-8. Investigated during
+    # the 2026-08-22 backlog-clearing pass (see .agents/CONTEXT.md): two
+    # were real gaps now closed (vision.frames wired, control.interrupt
+    # deleted as dead code); the other four are real feature work with no
+    # decided consumer, not unfinished wiring -- reasons sharpened below so
+    # a future pass doesn't re-investigate them from scratch.
+    "audio.pre_generate": "cognitive/pipeline.py publishes on VAP>=0.7 for speculative TTS pre-generation; the consumer side (voice-agent pre-warming TTS on this signal) was never built -- real Rust feature work, out of scope for a wiring fix",
+    "telemetry.reflection": "cognitive/core.py publishes duration_ms + episode count on background reflection; matches no declared stream pattern and has zero subscribers -- a strong candidate for promotion once P3-2 (telemetry) is built, not before",
+    "state.subconscious": "subconscious_agent's internal-monologue thought, zero subscribers -- no consumer has a decided purpose yet (UI surface? persistence sink?); needs a product decision before it needs wiring",
+    "voice.segmentation_feedback": "brain_agent subscribes with an adaptive alpha-damped tuning loop, but voice-agent's Rust source has no chunk-size/segmentation-reporting code at all to hook a publisher into -- real new Rust feature work, not a missing call",
 }
 
 PUBLISH_METHODS = {"publish", "publish_cb", "publish_with_headers", "publish_pcm"}

--- a/backend/tests/test_phase6_advanced_cognition.py
+++ b/backend/tests/test_phase6_advanced_cognition.py
@@ -116,7 +116,13 @@ async def test_paralinguistic_tag_injection():
 
 @pytest.mark.asyncio
 async def test_metacognitive_self_correction():
-    # Simulates an identity drift detection, verifies that control.interrupt is sent, and asserts that a correction phrase is injected.
+    # Simulates an identity drift detection, verifies that audio.stop is sent
+    # to interrupt playback, and asserts that a correction phrase is injected.
+    # control.interrupt used to be published alongside audio.stop here, but
+    # had zero subscribers anywhere (P1-8) and was redundant with audio.stop,
+    # which already carries the same {"interrupt": True, "reason": ...}
+    # payload and is the one subscribers actually act on -- removed rather
+    # than given a consumer it never needed.
     llm = MagicMock()
 
     async def mock_stream_violating(*args, **kwargs):
@@ -156,10 +162,10 @@ async def test_metacognitive_self_correction():
         chunks.append(chunk)
 
     publish_mock.assert_awaited()
-    assert any(
+    assert any(call.args[0] == "audio.stop" for call in publish_mock.call_args_list)
+    assert not any(
         call.args[0] == "control.interrupt" for call in publish_mock.call_args_list
     )
-    assert any(call.args[0] == "audio.stop" for call in publish_mock.call_args_list)
 
     content_chunks = [c["data"] for c in chunks if c["type"] == "content"]
     assert any("Wait, let me rephrase that..." in c for c in content_chunks)


### PR DESCRIPTION
## Summary
- `vision.frames`: **RESOLVED**, allowlist entry removed — wired end-to-end in #188.
- `control.interrupt`: **DELETE**, allowlist entry removed — redundant with `audio.stop` (published in the same call with an overlapping payload), zero subscribers of its own. Removed the dead publish call.
- The remaining four (`voice.segmentation_feedback`, `audio.pre_generate`, `telemetry.reflection`, `state.subconscious`) stay allowlisted, but each reason is sharpened from "NEW ... needs investigation" to a decided disposition (real out-of-scope Rust feature work, or waiting on a product decision), so a future pass doesn't re-investigate them from scratch.

This is the final part of the backlog-clearing pass that started with #187 and #188, closing out everything blocking Stage 4 except measurement 1.1's real worst-case number (still `UNKNOWN`, tracked in #187).

## Test plan
- [x] `python scripts/check_subject_wiring.py` — 8 allowlisted issues (down from 6+2), `vision.frames`/`control.interrupt` absent from output entirely
- [x] `../.venv/bin/python -m pytest -q --junit-xml=...` — 1027 passed, 0 failed/errored (matches post-#188 `main` baseline)
- [x] `../.venv/bin/python -m ruff check .` — clean
- [x] `test_metacognitive_self_correction` updated and mutation-tested: reintroducing the dead `control.interrupt` publish makes the updated assertion fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)