### PR TITLE
fix: take the SQLite fallback off the event loop (P2-6)

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -8135,3 +8135,74 @@ entry beyond the standard pre-existing baseline).
   `backend/models/` provisioned to check end to end, which remains absent.
 - P2-9 (windowed partials, the reason this had to happen first), P2-3,
   P2-4, P2-6 -- Stage 4 Parts 1-4, next.
+## 2026-08-23 -- Stage 4, Part 1 -- P2-6: the SQLite fallback comes off the
+event loop
+
+**Files:** `backend/app/state/sqlite_fallback.py`,
+`backend/app/state/memory_store.py`, `backend/tests/test_sqlite_fallback.py`.
+
+M2-P3 (CRITICAL as filed, stays MEDIUM after Q-M2-2 -- SQLite is
+emergency-only, not a supported mode): `SQLiteConnection.execute/fetch/
+fetchrow/fetchval` were `async def` with no `await` inside them --
+coroutines that never yield. Because every agent in this mesh runs a single
+asyncio loop, a call on this path stalled the NATS client and every other
+in-flight cognitive turn, not just the caller, for the full duration of
+every SQLite call while the fallback was active.
+
+**Fix, mirroring an existing pattern rather than inventing one.**
+`working_memory_store.py`'s own L2 SQLite fallback solved this identically
+already -- its comments name the trap directly: `check_same_thread=False`
+is required because calls arrive on whichever `asyncio.to_thread` worker
+happens to run them, and a `threading.Lock` held by every call site is what
+actually makes sharing one connection across threads safe (the flag alone
+does not). Each of the four public methods is now a thin
+`asyncio.to_thread` wrapper around a `_sync_*` body that holds `self._lock`
+for its duration; `SQLiteConnection.__init__` now connects with
+`check_same_thread=False`. `:memory:` databases stay correct under this --
+the same single `sqlite3.Connection` object is reused across worker
+threads, never recreated, so there is nothing for `:memory:`'s
+connection-scoping to lose track of.
+
+**`_fetch_sqlite_candidates` (`memory_store.py`).** `SELECT * FROM memories
+WHERE wing = ?` had no `LIMIT` at all -- a full-table scan on every cache
+miss, unlike its Postgres sibling `_fetch_postgres_candidates`, which
+already receives and applies `candidate_limit`; that value was already
+computed and in scope at the SQLite call site, just never threaded through.
+Added `candidate_limit` as a parameter and `ORDER BY last_recalled_at DESC
+LIMIT ?` to both query variants (with and without `room`). **`embedding`
+stays in the projection**, despite M2-P3's "excludes embedding where
+unused" phrasing -- read `cognitive_rust::score_memories_actr_sqlite`
+(`crates/cognitive-rust/src/lib.rs:387`) before assuming that applied here:
+SQLite has no pgvector, so this column is exactly what the Rust kernel
+parses to compute cosine similarity in-process; dropping it would silently
+zero every candidate's similarity, not save bytes. `ORDER BY
+last_recalled_at DESC` biases a hard cap toward recently-relevant memories
+rather than an arbitrary rowid-order slice; SQLite sorts NULL as smallest,
+so never-recalled rows land last under DESC and are the right side of the
+cut to lose first.
+
+**Tests, mutation-tested.** `test_execute_does_not_block_the_event_loop`
+proves the yield genuinely happens: a monkeypatched `_sync_execute` sleeps
+0.2s on its worker thread while a concurrent `asyncio.sleep(0.01)` ticker
+keeps advancing -- a blocked loop would stall the ticker for the same
+0.2s regardless of tick interval, so `ticks >= 10` only holds if control
+really returned to the loop. Removing the `to_thread` wrap (calling
+`_sync_execute` directly) makes it fail, confirmed and reverted.
+`test_sqlite_candidate_fetch_does_not_scan_the_whole_table` seeds 5 rows
+with distinct `last_recalled_at` timestamps, requests `candidate_limit=3`,
+and asserts both the count and that the 3 *most recent* rows are the ones
+returned -- proving the cap and the ordering together, not just one. Both
+mutations (dropping `LIMIT`/`ORDER BY`; calling the sync body directly)
+confirmed to fail before reverting.
+
+**Verified:** full backend suite 1039/1039 (1037 baseline + 2 new). Its
+own terminal summary was swallowed again this session -- reproduced even
+with output redirected straight to a file, matching `CLAUDE.md`'s
+documented finding exactly; parsed the JUnit XML instead, per that same
+note. `ruff check .` clean.
+
+**NOT done:**
+- `_create_schema()` (called synchronously from `__init__`) is unchanged --
+  P2-6's finding named `execute/fetch/fetchrow/fetchval` specifically;
+  schema creation runs once at startup, not on the hot path.
+- P2-3, P2-4, P2-9 -- the rest of Stage 4, next.

--- a/backend/app/state/memory_store.py
+++ b/backend/app/state/memory_store.py
@@ -1247,19 +1247,42 @@ class MemoryStore:
         current_arousal,
         current_cortisol,
         current_time,
+        candidate_limit,
     ) -> tuple[list, float]:
         """SQLite fallback: fetch rows and score them via the Rust ACT-R kernel.
 
         Returns the candidates plus the `now_ts` it computed, because the
         original inlined body rebound the enclosing now_ts here and that value
         is what later stamps the L1 cache entry.
+
+        audit/ROADMAP.md P2-6 (M2-P3): this used to `SELECT *` with no
+        `LIMIT` -- a full-table scan on every cache miss, unlike its Postgres
+        sibling (`_fetch_postgres_candidates`), which already receives and
+        applies `candidate_limit`. `embedding` stays in the projection
+        despite M2-P3's "excludes embedding where unused" suggestion --
+        SQLite has no pgvector, so `cognitive_rust.score_memories_actr_sqlite`
+        computes cosine similarity from this column in Rust; dropping it
+        would silently zero out every candidate's similarity, not just save
+        bytes. `ORDER BY last_recalled_at DESC` biases a hard cap toward
+        recently-relevant memories rather than an arbitrary rowid-order
+        slice; SQLite sorts NULL as smallest, so never-recalled rows land
+        last under DESC, which is the right side of the cut to lose first.
         """
         if room is not None:
             rows = await conn.fetch(
-                "SELECT * FROM memories WHERE wing = ? AND room = ?", wing, room
+                "SELECT * FROM memories WHERE wing = ? AND room = ? "
+                "ORDER BY last_recalled_at DESC LIMIT ?",
+                wing,
+                room,
+                candidate_limit,
             )
         else:
-            rows = await conn.fetch("SELECT * FROM memories WHERE wing = ?", wing)
+            rows = await conn.fetch(
+                "SELECT * FROM memories WHERE wing = ? "
+                "ORDER BY last_recalled_at DESC LIMIT ?",
+                wing,
+                candidate_limit,
+            )
 
         # Manual cosine similarity and ACT-R scoring (delegated to Rust PyO3).
         # Imported lazily: the compiled extension is optional in some envs and
@@ -2516,6 +2539,7 @@ class MemoryStore:
                             current_arousal=current_arousal,
                             current_cortisol=current_cortisol,
                             current_time=current_time,
+                            candidate_limit=candidate_limit,
                         )
                     else:
                         raw_candidates = await self._fetch_postgres_candidates(

--- a/backend/app/state/sqlite_fallback.py
+++ b/backend/app/state/sqlite_fallback.py
@@ -1,7 +1,9 @@
+import asyncio
 import logging
 import os
 import re
 import sqlite3
+import threading
 
 logger = logging.getLogger("sqlite_fallback")
 
@@ -12,8 +14,18 @@ class SQLiteConnection:
         if db_path != ":memory:":
             os.makedirs(os.path.dirname(os.path.abspath(db_path)), exist_ok=True)
 
-        self.conn = sqlite3.connect(db_path, detect_types=sqlite3.PARSE_DECLTYPES)
+        # audit/ROADMAP.md P2-6 (M2-P3): every public method below now runs
+        # its body via asyncio.to_thread, so calls arrive on whichever worker
+        # thread happens to run them rather than always the caller's thread.
+        # check_same_thread=False lifts sqlite3's same-thread restriction on
+        # this connection object; it does not make concurrent access safe by
+        # itself, which is what self._lock is for. Mirrors the fix already
+        # applied to working_memory_store.py's own L2 SQLite fallback.
+        self.conn = sqlite3.connect(
+            db_path, detect_types=sqlite3.PARSE_DECLTYPES, check_same_thread=False
+        )
         self.conn.row_factory = sqlite3.Row
+        self._lock = threading.Lock()
         self._create_schema()
 
     def _create_schema(self):
@@ -334,7 +346,20 @@ class SQLiteConnection:
 
         return translated
 
+    # Every public method below is a thin `asyncio.to_thread` wrapper
+    # around a `_sync_*` body holding `self._lock`. Called directly (as this
+    # class was before P2-6), each call blocked the event loop for the full
+    # duration of the query -- and because every agent runs a single asyncio
+    # loop, that stalled the NATS client and every concurrent cognitive turn
+    # for as long as the fallback stayed active, not just the caller. See
+    # working_memory_store.py's own `_sqlite_lock` comment for why the lock
+    # (not just check_same_thread=False) is what makes sharing one
+    # connection across to_thread's worker threads safe.
+
     async def execute(self, query, *args):
+        await asyncio.to_thread(self._sync_execute, query, args)
+
+    def _sync_execute(self, query, args):
         translated = self._translate_query(query)
         cleaned_args = [str(arg) if hasattr(arg, "hex") else arg for arg in args]
 
@@ -345,59 +370,72 @@ class SQLiteConnection:
             if not line.strip().startswith("--")
         )
 
-        cursor = self.conn.cursor()
-        try:
-            # Handle multiple SQL statements separated by semicolons
-            if ";" in translated and len(translated.strip().split(";")) > 2:
-                cursor.executescript(translated)
-            else:
-                cursor.execute(translated, cleaned_args)
-            self.conn.commit()
-        except sqlite3.OperationalError as e:
-            # Guard against pg-specific extension checks like "create extension" or indexing
-            if "vector" in str(e) or "hnsw" in str(e) or "pgcrypto" in str(e):
-                logger.debug(
-                    f"SQLite Schema Guard: Ignored PG-specific index/extension statement: {e}"
-                )
-            else:
-                logger.error(
-                    f"SQLite execution failed for query: {query}\nTranslated: {translated}\nError: {e}"
-                )
-                raise
+        with self._lock:
+            cursor = self.conn.cursor()
+            try:
+                # Handle multiple SQL statements separated by semicolons
+                if ";" in translated and len(translated.strip().split(";")) > 2:
+                    cursor.executescript(translated)
+                else:
+                    cursor.execute(translated, cleaned_args)
+                self.conn.commit()
+            except sqlite3.OperationalError as e:
+                # Guard against pg-specific extension checks like "create extension" or indexing
+                if "vector" in str(e) or "hnsw" in str(e) or "pgcrypto" in str(e):
+                    logger.debug(
+                        f"SQLite Schema Guard: Ignored PG-specific index/extension statement: {e}"
+                    )
+                else:
+                    logger.error(
+                        f"SQLite execution failed for query: {query}\nTranslated: {translated}\nError: {e}"
+                    )
+                    raise
 
     async def fetch(self, query, *args):
+        return await asyncio.to_thread(self._sync_fetch, query, args)
+
+    def _sync_fetch(self, query, args):
         translated = self._translate_query(query)
         cleaned_args = [str(arg) if hasattr(arg, "hex") else arg for arg in args]
-        cursor = self.conn.cursor()
-        cursor.execute(translated, cleaned_args)
-        rows = cursor.fetchall()
-        # Commits a statement that both writes and returns rows (e.g. `UPDATE
-        # ... RETURNING`), which arrives through the fetch path rather than
-        # execute(). Unconditional rather than prefix-sniffed on the first
-        # keyword: `fetchval` used exactly that check and, having none for
-        # RETURNING statements, never committed one at all. A commit after a
-        # plain SELECT is a no-op -- sqlite3 opens a transaction for DML only
-        # -- so there's no correctness reason to guess whether a query wrote.
-        self.conn.commit()
-        return [dict(row) for row in rows]
+        with self._lock:
+            cursor = self.conn.cursor()
+            cursor.execute(translated, cleaned_args)
+            rows = cursor.fetchall()
+            # Commits a statement that both writes and returns rows (e.g. `UPDATE
+            # ... RETURNING`), which arrives through the fetch path rather than
+            # execute(). Unconditional rather than prefix-sniffed on the first
+            # keyword: `fetchval` used exactly that check and, having none for
+            # RETURNING statements, never committed one at all. A commit after a
+            # plain SELECT is a no-op -- sqlite3 opens a transaction for DML only
+            # -- so there's no correctness reason to guess whether a query wrote.
+            self.conn.commit()
+            return [dict(row) for row in rows]
 
     async def fetchrow(self, query, *args):
+        return await asyncio.to_thread(self._sync_fetchrow, query, args)
+
+    def _sync_fetchrow(self, query, args):
         translated = self._translate_query(query)
         cleaned_args = [str(arg) if hasattr(arg, "hex") else arg for arg in args]
-        cursor = self.conn.cursor()
-        cursor.execute(translated, cleaned_args)
-        row = cursor.fetchone()
-        self.conn.commit()
-        return dict(row) if row else None
+        with self._lock:
+            cursor = self.conn.cursor()
+            cursor.execute(translated, cleaned_args)
+            row = cursor.fetchone()
+            self.conn.commit()
+            return dict(row) if row else None
 
     async def fetchval(self, query, *args):
+        return await asyncio.to_thread(self._sync_fetchval, query, args)
+
+    def _sync_fetchval(self, query, args):
         translated = self._translate_query(query)
         cleaned_args = [str(arg) if hasattr(arg, "hex") else arg for arg in args]
-        cursor = self.conn.cursor()
-        cursor.execute(translated, cleaned_args)
-        row = cursor.fetchone()
-        self.conn.commit()
-        return row[0] if row else None
+        with self._lock:
+            cursor = self.conn.cursor()
+            cursor.execute(translated, cleaned_args)
+            row = cursor.fetchone()
+            self.conn.commit()
+            return row[0] if row else None
 
 
 class SQLitePoolAcquisition:

--- a/backend/tests/test_sqlite_fallback.py
+++ b/backend/tests/test_sqlite_fallback.py
@@ -1,7 +1,10 @@
 import asyncio
 import sqlite3
+import time
+from unittest.mock import MagicMock
 
-from app.state.sqlite_fallback import SQLiteConnection
+from app.state.memory_store import MemoryStore
+from app.state.sqlite_fallback import SQLiteConnection, SQLitePool
 
 
 def test_update_returning_persists_after_reconnect(tmp_path):
@@ -60,3 +63,100 @@ def test_fetchval_on_mutating_returning_statement_persists(tmp_path):
     reopened.close()
 
     assert row[0] == 0.42
+
+
+async def test_execute_does_not_block_the_event_loop(tmp_path):
+    """P2-6 (M2-P3): `SQLiteConnection`'s methods were `async def` with no
+    `await` inside them -- coroutines that never yield. Because every agent
+    in this mesh runs one asyncio loop, a slow SQLite call used to stall the
+    NATS client and every other in-flight cognitive turn for its full
+    duration, not just the caller. This proves `execute()` now genuinely
+    yields: a concurrent task keeps making progress while a (deliberately
+    slowed) query runs on its own worker thread.
+    """
+    db_path = str(tmp_path / "yield.db")
+    conn = SQLiteConnection(db_path)
+
+    real_sync_execute = conn._sync_execute
+
+    def slow_sync_execute(query, args):
+        time.sleep(0.2)
+        return real_sync_execute(query, args)
+
+    conn._sync_execute = slow_sync_execute
+
+    ticks = 0
+
+    async def ticker():
+        nonlocal ticks
+        while True:
+            ticks += 1
+            await asyncio.sleep(0.01)
+
+    ticker_task = asyncio.create_task(ticker())
+    await conn.execute("INSERT INTO sessions (id) VALUES ($1)", "s1")
+    ticker_task.cancel()
+
+    # ~0.2s of blocking sleep against a 0.01s tick interval. A genuinely
+    # blocked loop lets this advance zero or one times regardless of how
+    # long the sleep runs, since nothing can service it until the single
+    # thread that's blocking returns.
+    assert ticks >= 10
+
+
+
+
+async def _seed_row(conn, *, id_, minutes_ago):
+    """Insert one `memories` row with a distinct, ordered `last_recalled_at`."""
+    await conn.execute(
+        "INSERT INTO memories "
+        "(id, content, raw_content, wing, embedding, last_recalled_at) "
+        "VALUES ($1, $2, $3, $4, $5, datetime('now', $6))",
+        id_,
+        f"memory {id_}",
+        f"memory {id_}",
+        "personal",
+        "[0.1,0.1]",
+        f"-{minutes_ago} minutes",
+    )
+
+
+def test_sqlite_candidate_fetch_does_not_scan_the_whole_table():
+    """P2-6 (M2-P3): `SELECT * FROM memories WHERE wing = ?` had no LIMIT at
+    all, unlike its Postgres sibling (`_fetch_postgres_candidates`, which
+    already receives `candidate_limit`). This seeds more rows than the
+    requested limit and checks the cap is actually respected, and that the
+    most-recently-recalled rows are the ones kept rather than an arbitrary
+    slice.
+    """
+    pool = SQLitePool(":memory:")
+    store = MemoryStore(pool, MagicMock())
+    store.qdrant_store.client = None
+
+    async def run():
+        async with pool.acquire() as conn:
+            # Oldest first: id "m0" is the most recently recalled (0 minutes
+            # ago), "m4" the least (4 minutes ago).
+            for i in range(5):
+                await _seed_row(conn, id_=f"m{i}", minutes_ago=i)
+
+            raw_candidates, _now_ts = await store._fetch_sqlite_candidates(
+                conn,
+                query_vector=[0.1, 0.1],
+                wing="personal",
+                room=None,
+                excluded=set(),
+                threshold=-999.0,
+                current_valence=0.0,
+                current_arousal=0.5,
+                current_cortisol=0.0,
+                current_time=None,
+                candidate_limit=3,
+            )
+            return raw_candidates
+
+    raw_candidates = asyncio.run(run())
+
+    assert len(raw_candidates) == 3
+    returned_ids = {c["id"] for c in raw_candidates}
+    assert returned_ids == {"m0", "m1", "m2"}


### PR DESCRIPTION
## Summary

`SQLiteConnection.execute/fetch/fetchrow/fetchval` (`app/state/sqlite_fallback.py`) were `async def` with no `await` inside them — coroutines that never actually yield. Since every agent in this mesh runs a single asyncio loop, a call on this path stalled the NATS client and every other in-flight cognitive turn, not just the caller, for the duration of every SQLite call while the fallback (Postgres-down, emergency-only per Q-M2-2) was active. Filed as M2-P3.

**Fix.** Rather than invent a pattern, reused the one `working_memory_store.py` already built for its own identical L2 SQLite fallback: `check_same_thread=False` plus a `threading.Lock` held by every `asyncio.to_thread`-wrapped call — the flag alone permits cross-thread use, the lock is what makes it actually safe. Each of the four public methods is now a thin wrapper around a `_sync_*` body holding that lock. `:memory:` databases stay correct: it's the same `sqlite3.Connection` object reused across worker threads, never recreated.

**Also fixed `_fetch_sqlite_candidates`** (`app/state/memory_store.py`): `SELECT * FROM memories WHERE wing = ?` had no `LIMIT` at all — a full-table scan on every cache miss, unlike its Postgres sibling which already receives and applies `candidate_limit` (the value was already computed and in scope at the SQLite call site, just never threaded through). Added the parameter and `ORDER BY last_recalled_at DESC LIMIT ?`.

One correction to the roadmap's own text worth flagging: M2-P3's recommendation says to give this query "a projection that excludes `embedding` where unused" — but reading `cognitive_rust::score_memories_actr_sqlite` first shows `embedding` is never unused here. SQLite has no pgvector, so this column is exactly what the Rust kernel parses to compute cosine similarity in-process; excluding it would silently zero every candidate's similarity rather than save any bytes. Left it in the projection.

## Test plan

- [x] `test_execute_does_not_block_the_event_loop`: a monkeypatched sync body sleeps 0.2s on its worker thread while a concurrent `asyncio.sleep(0.01)` ticker keeps advancing — proves the loop genuinely isn't blocked, not just that the call completes
- [x] `test_sqlite_candidate_fetch_does_not_scan_the_whole_table`: seeds 5 rows with distinct `last_recalled_at`, requests `candidate_limit=3`, asserts both the count and that the 3 *most recent* rows are the ones kept
- [x] Both mutation-tested (dropping the `to_thread` wrap; dropping `LIMIT`/`ORDER BY`) — confirmed to fail, then reverted
- [x] Full backend suite: 1039/1039 (1037 baseline + 2 new)
- [x] `ruff check .` clean

Full account in `.agents/CONTEXT.md`'s 2026-08-23 Part 1 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)