### PR TITLE
fix: bound stt-agent partial-transcription window to a trailing slice (P2-9)

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -7977,6 +7977,68 @@ its bound.
   scope.
 - P2-3, P2-4, P2-6, P2-9 (the rest of Stage 4) and Stage 5/6 -- unstarted.
 
+## 2026-08-23 -- P2-9 (windowed partials), Stage 4 Part 3 -- stt-agent partial
+transcription bounded to a trailing window, the first change this crate has
+ever had genuinely test-executed rather than compile-checked
+
+Depends on Part 0 (P2-11): this branch is stacked on
+`fix/p2-11-stt-agent-tests-runnable`, not `main`, because `cargo test
+--package stt-agent` needs that branch's build.rs fix to run at all rather
+than being SIGKILLed at load. Neither P2-11 nor P2-6 is merged to `main`
+yet, so this PR should target `main` and be rebased once P2-11 lands --
+noted here rather than silently stacking without explanation.
+
+**The bug.** `crates/stt-agent/src/main.rs`'s `SpeechContinues` handler
+cloned the *entire* accumulated buffer on every partial
+(`let pcm = guard.buffer.clone()`), gated only by `partial_interval_ms`
+(default 500ms). A 30s utterance against `max_utterance_secs` issued ~60
+partials, each transcribing more of the same early audio than the last --
+summing to minutes of redundant inference and up to 5.8MB cloned twice a
+second by the end of a long utterance.
+
+**The fix.** New pure function `trailing_window(buffer, sample_rate,
+window_secs) -> &[f32]`, called at the `SpeechContinues` site instead of
+`.clone()`; new `STT_PARTIAL_WINDOW_SECS` config field (default 8.0). This
+is safe specifically because of what a partial feeds: barge-in keyword
+detection and acoustic affect, both fast/disposable by design -- the
+*final* transcript is untouched, since the endpoint branch still takes the
+whole buffer via `std::mem::take` (`:772` area, unchanged). A trailing
+window is arguably more correct for barge-in besides being cheaper: a
+keyword spoken 20 seconds ago should not still be able to interrupt the
+agent now. Interacts cleanly with #190's `speculative_fired_for`
+once-per-utterance duck scoping, which is what stops a windowed keyword
+from re-firing across successive partials.
+
+**Files:** `crates/stt-agent/src/main.rs`.
+
+**Verified -- for the first time against real execution, not just
+compiled.** `cargo test --package stt-agent`: 35/35, including the two new
+`trailing_window` tests and, notably, the two `speculative_fire_*` tests
+from #190's P1-4 work, which had only ever been compile-checked and
+manually traced (P2-11 blocked them at the time). Both pass unmodified
+against real code now that they can actually run. `cargo check
+--workspace`: clean. New tests mutation-tested: (1) `trailing_window`
+short-circuited to always return the full buffer (the exact bug this pass
+removes) -- the long-buffer test caught it (`left: 160000, right: 64000`);
+reverted. (2) confirmed the short-buffer pass-through path independently
+via its own dedicated test rather than relying on the long-buffer test to
+also cover it.
+
+**NOT done:**
+- Measurement 1.4 (end-to-end partial-transcription latency) is not
+  re-measured here -- per the plan, 1.4 profiles the *final*/accurate
+  path, which the still-unresolved whisper hang blocks regardless of this
+  change, so it was never this item's gate.
+- `STT_PARTIAL_WINDOW_SECS`'s default (8.0s) is a judgment call, not a
+  measured optimum -- chosen as generously larger than
+  `endpoint_silence_ms` (700ms) and typical barge-in reaction time, with
+  headroom. Worth revisiting once/if 1.4 is unblocked and partial-path
+  latency can be measured directly.
+- This branch is stacked on Part 0's, per the dependency above -- retarget
+  to `main` once `fix/p2-11-stt-agent-tests-runnable` merges, per
+  CLAUDE.md's stacked-PR convention.
+- P2-4 (the rest of Stage 4) and Stage 5/6 -- unstarted.
+
 ## 2026-08-23 -- Stage 4, Part 0 -- P2-11's SIGKILL root-caused and fixed: an
 invalid code signature, not the missing rpath alone
 

--- a/backend/crates/stt-agent/src/main.rs
+++ b/backend/crates/stt-agent/src/main.rs
@@ -65,6 +65,10 @@ struct SttConfig {
     min_speech_ms: f64,
     partial_interval_ms: f64,
     max_utterance_secs: f64,
+    /// P2-9: partials transcribe only this trailing window of the buffer, not the
+    /// whole accumulated utterance. A keyword from 20 seconds ago should not still
+    /// be able to interrupt the agent.
+    partial_window_secs: f64,
 }
 
 impl SttConfig {
@@ -94,6 +98,7 @@ impl SttConfig {
             min_speech_ms: parse_env("STT_MIN_SPEECH_MS", 250.0),
             partial_interval_ms: parse_env("STT_PARTIAL_INTERVAL_MS", 500.0),
             max_utterance_secs: parse_env("STT_MAX_UTTERANCE_SECS", 30.0),
+            partial_window_secs: parse_env("STT_PARTIAL_WINDOW_SECS", 8.0),
         }
     }
 }
@@ -749,7 +754,9 @@ async fn handle_audio_inbound(
             let confirmed = guard.endpointer.speech_confirmed();
             if confirmed && now - guard.last_partial_at >= config.partial_interval_ms / 1000.0 {
                 guard.last_partial_at = now;
-                let pcm = guard.buffer.clone();
+                let pcm =
+                    trailing_window(&guard.buffer, source_rate, config.partial_window_secs)
+                        .to_vec();
                 let utt = guard.utterance_id.clone();
                 let rate = source_rate;
                 drop(guard);
@@ -796,6 +803,25 @@ async fn handle_audio_inbound(
     }
 
     Ok(())
+}
+
+/// P2-9: the trailing slice of `buffer` a partial should transcribe, instead of
+/// the whole accumulated utterance.
+///
+/// Every `SpeechContinues` partial used to clone the entire buffer, so a 30s
+/// utterance issued ~60 partials (one per `partial_interval_ms`) summing to
+/// minutes of inference over the same early seconds, transcribed again and
+/// again. This does not change what the *final* transcript sees — that still
+/// takes the whole buffer via `std::mem::take` on the endpoint branch — only
+/// the fast, disposable hypothesis partials feed to barge-in keyword detection
+/// and acoustic affect.
+fn trailing_window(buffer: &[f32], sample_rate: u32, window_secs: f64) -> &[f32] {
+    let window_samples = (sample_rate as f64 * window_secs) as usize;
+    if buffer.len() > window_samples {
+        &buffer[buffer.len() - window_samples..]
+    } else {
+        buffer
+    }
 }
 
 /// Autocorrelation pitch estimate over the 80-400 Hz band, at the true rate.
@@ -943,6 +969,41 @@ mod tests {
         let decoded = audio::decode_mono_f32(br#"{"audio":"legacy-json"}"#, 1);
         assert!(!decoded.is_empty());
         assert!(build_speculative_intent("", "utt-1").is_none());
+    }
+
+    /// P2-9: a buffer longer than the configured window must be clipped to the
+    /// trailing slice, not transcribed in full -- this is the whole point of the
+    /// fix, so a mutation that drops the clipping (e.g. always returning `buffer`)
+    /// must fail this test.
+    #[test]
+    fn trailing_window_clips_a_long_buffer_to_the_tail() {
+        let sample_rate = 16_000u32;
+        // 10s of buffer, distinguishable by value so we can check *which* end survives.
+        let mut buffer = vec![0.0f32; sample_rate as usize * 10];
+        for (i, sample) in buffer.iter_mut().enumerate() {
+            *sample = i as f32;
+        }
+
+        let windowed = trailing_window(&buffer, sample_rate, 4.0);
+
+        assert_eq!(windowed.len(), sample_rate as usize * 4);
+        // It's the tail, not the head, that survives.
+        assert_eq!(windowed[0], buffer[buffer.len() - windowed.len()]);
+        assert_eq!(windowed.last(), buffer.last());
+    }
+
+    /// A buffer shorter than the window must pass through unclipped -- there is
+    /// nothing to trim yet, and clipping here would silently drop early speech
+    /// from a short utterance rather than leaving it whole.
+    #[test]
+    fn trailing_window_does_not_pad_or_clip_a_short_buffer() {
+        let sample_rate = 16_000u32;
+        let buffer = vec![1.0f32; sample_rate as usize * 2]; // 2s, window is 4s.
+
+        let windowed = trailing_window(&buffer, sample_rate, 4.0);
+
+        assert_eq!(windowed.len(), buffer.len());
+        assert_eq!(windowed, buffer.as_slice());
     }
 
     fn job(utterance_id: &str) -> Job {


### PR DESCRIPTION
## Summary

Stage 4 Part 3 of `audit/ROADMAP.md` §7 (P2-9), per the approved implementation plan.

**Stacked on #191 (P2-11), not `main`** — `cargo test --package stt-agent` needs that branch's build.rs signature/rpath fix to run at all; on `main` today the test binary is SIGKILLed at load before any test executes. This PR should be retargeted to `main` once #191 merges (per `CLAUDE.md`'s stacked-PR convention), at which point the diff will shrink to just this change.

- **The bug.** The `SpeechContinues` handler in `crates/stt-agent/src/main.rs` cloned the *entire* accumulated buffer on every partial (`partial_interval_ms`, default 500ms). A 30s utterance issued ~60 partials, each re-transcribing more of the same early audio than the last.
- **The fix.** New pure `trailing_window(buffer, sample_rate, window_secs) -> &[f32]`, used at the partial call site instead of `.clone()`; new `STT_PARTIAL_WINDOW_SECS` config (default 8.0s). Safe because of what a partial feeds — barge-in keyword detection and acoustic affect, both disposable by design. The *final* transcript is untouched: the endpoint branch still takes the whole buffer via `std::mem::take`. Arguably more correct for barge-in too — a keyword from 20s ago shouldn't still be able to interrupt.

## Test plan

- [x] `cargo test --package stt-agent`: **35/35** — the first time this crate's test binary has actually run rather than being compile-checked only. Includes the two new `trailing_window` tests, and (bonus) the two `speculative_fire_*` tests from #190/P1-4, which had only ever been compile-checked before P2-11 unblocked execution — both pass unmodified against real code.
- [x] `cargo check --workspace` — clean.
- [x] Mutation-tested: `trailing_window` short-circuited to always return the full buffer (the exact bug removed here) — caught by the long-buffer test (`left: 160000, right: 64000`); reverted.
- [x] Full backend Python suite: 1037/1037 (no Python touched by this change). `ruff check .` clean.
- [x] `.agents/CONTEXT.md` ledger entry appended with a "NOT done" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)