### PR TITLE
feat: give evals a path that actually reaches ActionService (Stage 5 Part 0)

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -8444,3 +8444,115 @@ instruction was the blocker.
   separately-built prompt. Worth its own pass if `action.py`'s prompt logic
   becomes a recurring source of unverifiable changes.
 - Stage 5/6 -- unstarted.
+
+## 2026-08-23 -- Stage 5 Part 0 -- `evals/` can finally gate a change to
+`action.py`: the harness never once executed the code half its gating claims
+were about
+
+Stage 5's scope was taken with the user as the *correctness cluster* (P2-14's
+unlocked tick, P2-8's endpointer latch, P2-2's per-chunk ack) plus this, plus
+two documentation leftovers. This part comes first because it is the gate the
+rest eventually needs, and because P2-4 already proved it was missing.
+
+**The gap, restated precisely.** `evals/runner.py` built the system prompt
+itself (`IdentityManager.get_persona_prompt`) and called
+`OllamaClient.generate` directly; `conversation.py` does the same. **Neither
+ever constructed an `ActionService`.** So everything `action.py` contributes to
+a real turn -- `_CHAT_GUIDELINE`, `_build_tom_context`, the `- Goal:` line, the
+`User:`/`Assistant:` framing, incremental `<thought>` stripping,
+`ControlMarkupSanitizer`, `_validate_partial_response` and the self-correction
+retry -- was invisible to every report the harness had ever written. P2-4 hit
+this head-on: it appended a classification instruction to that exact system
+prompt, ran `evals run` before and after, and got an identical report both
+times. It was ultimately gated by a hand-written live smoke test, and dropped
+on what that smoke test found (see the P2-4 entry). The eval gap was filed
+there as a "NOT done"; this closes it.
+
+**What was built.** `evals/action_path.py` (new): `PinnedOptionsClient` wraps
+the real client and merges the run's pinned sampling *over* whatever the caller
+passes; `build_action_service` / `build_plan` / `generate_through_action_service`
+assemble a store-free `RESPOND_CHAT` turn and collect the visible `content`
+chunks. `runner.run_eval` grew a `path` parameter; `run_probe` grew an optional
+`generate` callable, so **the checks, the boundary delegation and the scoring
+are shared and unchanged** between paths -- a verdict means the same thing
+either way, and `compare` keeps one implementation. `--path llm|action` on the
+CLI, defaulting to `llm`.
+
+**Two things the design turns on, both found by reading the code rather than
+assumed.** First, `_compute_endocrine_options` maps cortisol to temperature,
+dopamine to top_p and fatigue to num_predict and hands them to
+`generate_stream` as `options_override` -- so without the pinning wrapper the
+eval's sampling would be silently replaced by simulated hormones, reintroducing
+exactly the run-to-run variance `reset_model_state` exists to remove. Second,
+omitting the three endocrine keys is *not* the neutral choice it looks like:
+`_compute_endocrine_options` returns `None` for an absent signal
+(`action.py:637`), and `generate_stream` then falls back to `num_predict=40`
+and `num_ctx=2048`, which truncates every probe answer and re-imposes the
+context ceiling `RunOptions.num_ctx` is pinned to 8192 to escape. They are
+supplied at rest and overridden instead. The consequence is stated rather than
+hidden: **this path does not measure the endocrine mapping.**
+
+The pinning lives in `evals/`, not as a hook in `action.py`. The dependency
+still points one way -- `evals` imports `app`, and nothing in `app` knows this
+file exists.
+
+**`compare` refuses a cross-path diff**, and this is the one input
+disagreement it refuses outright. Sampling options and persona edits are
+surfaced and left to the reader, on `diff_options`'s own stated reasoning: the
+caller may have changed one deliberately, the deltas still mean something, and
+a gate blocking a deliberate change just gets bypassed. A path difference is
+not that kind of disagreement. "llm" and "action" do not sample the same
+quantity, so every probe delta between them is attributable to the harness and
+there is no reading of the diff that says anything about the model. Exit 2
+(usage), deliberately *not* 1 (regression), so a consolidation loop reading
+only the exit code cannot mistake "you compared the wrong things" for "the
+adapter broke behavior". `path` defaults to `"llm"` on load, so every report
+written before the field existed still compares -- retiring valid baselines
+overnight would have been a real cost for no gain.
+
+**Verified against the real model, and the result is the argument for the
+whole part.** `qwen2.5:3b`, shipped packs, both paths. Same headline (6/9), and
+**zero of the nine responses shared** between them. The action path fired five
+metacognitive violations and one safe-fallback -- `persona.name-recall`, for
+instance, produced "My name is Pankudi. How can I assist you today?", tripped
+the forbidden-AI-phrase check, self-corrected, and answered "Pankudi."; the LLM
+path returned "Pankudi." with none of that machinery having run. The system
+prompt digests differ, as they must, because `_execute_respond_chat` appends
+`_CHAT_GUIDELINE` -- and the digest is read back from the client that saw the
+call rather than recomposed in the harness, so it cannot drift out of step with
+`action.py` the way a local copy would (silently, since both sides would still
+produce a plausible digest). Reproducibility carries over intact: two
+consecutive action-path runs were **9/9 byte-identical**, no verdict flips,
+stable digest.
+
+**Files:** `evals/action_path.py` (new), `evals/runner.py`, `evals/schema.py`,
+`evals/compare.py`, `evals/__main__.py`, `evals/README.md`,
+`tests/test_eval_harness.py`.
+
+**Verified.** Full backend suite 1044/1044 (1037 baseline + 7 new), `ruff
+check .` clean. All seven new tests mutation-tested, each against the specific
+defect it exists to catch: the action path not wired at all; the pinning
+removed so endocrine options win; the digest taken from the persona prompt
+instead of what the model saw; the cross-path guard removed; the `path` default
+flipped away from `"llm"`; internal `self_correction` chunks collected as
+speech; the CLI letting `PathMismatch` escape instead of exiting 2. Every one
+was caught. One test needed fixing first -- the sampling assertion originally
+read a combined options list and tripped on `reset_model_state`'s warm-up
+(`num_predict: 8`) rather than on the streamed call, so the stub now records
+stream options separately.
+
+**NOT done:**
+- `run-conversation` still has no action path. It has the same blind spot, and
+  the multi-turn suite is where retrieval actually gets measured, so this is
+  the natural follow-up -- but it needs a decision about how a scripted
+  transcript reaches `ActionService`, which is more than a flag.
+- The endocrine mapping remains ungated by any eval, on either path, by the
+  deliberate trade above. Gating it needs a different instrument: sampling
+  cannot be both pinned for reproducibility and varied to test the mapping.
+- Nothing was re-gated retroactively. P2-4 stays dropped on its live-smoke-test
+  evidence; this does not reopen it. Whether the merged call would now pass an
+  action-path eval is a genuine open question and the obvious first real use of
+  this path, once a model bigger than 3B is available (see
+  `hardware-and-deployment-roadmap`).
+- Stage 5's remaining parts -- P2-14's tick lock, P2-8's noise-floor latch,
+  P2-2's outbound ack, and the two documentation leftovers -- next.

--- a/backend/evals/README.md
+++ b/backend/evals/README.md
@@ -31,6 +31,46 @@ Three probe sources:
   set. `probes/sample_memory_recall.json` pins the format and is labeled the
   sample it is; against an untrained model its probes *should* fail.
 
+### `--path action`: the same probes through the real `ActionService`
+
+The LLM boundary is the right seam for an adapter swap, and it stays the
+default. But it is **not** the seam for a change to `action.py` itself, and for
+a long time nothing here said so. P2-4 proposed appending a classification
+instruction to the response call's system prompt, ran `evals run` before and
+after, and got identical reports — because the harness never executed the code
+the change lived in. The item ended up gated by a hand-written live smoke test.
+
+`--path action` closes that. Each probe is driven through a real
+`ActionService.execute()` turn, so the report also covers the chat guideline,
+the Theory-of-Mind block, the goal line, incremental `<thought>` stripping,
+`ControlMarkupSanitizer`, `_validate_partial_response` and the self-correction
+retry it triggers. Stores stay absent (`memory_store=None`,
+`self_knowledge=None`), so it still runs anywhere the model does.
+
+Measured on `qwen2.5:3b` against the shipped packs, the two paths agreed on the
+headline (6/9 both times) and shared **not one** of the nine responses. The
+action path fired five metacognitive violations and one safe-fallback; the LLM
+path, by construction, could not have reported any of them.
+
+Two consequences worth knowing before using it:
+
+- **Sampling is pinned over the endocrine layer.** `_compute_endocrine_options`
+  maps cortisol to temperature, dopamine to top_p and fatigue to num_predict;
+  `PinnedOptionsClient` overrides all three with the run's pinned options. So
+  this path does not measure the endocrine mapping — deliberately, because
+  sampling that drifts with simulated affect cannot answer "did the model
+  change". It is also what stops `generate_stream`'s own `num_predict=40` /
+  `num_ctx=2048` defaults from truncating every answer.
+- **Reports from the two paths cannot be compared.** `compare` refuses with a
+  usage exit rather than diffing them. Sampling and persona differences are
+  surfaced and left to the reader, because a caller may have changed one on
+  purpose; a path difference is not that kind of disagreement — the two do not
+  sample the same quantity, so every delta between them is the harness.
+
+```bash
+python -m evals run --model qwen2.5:3b --path action --out evals/out/action.json
+```
+
 ## Multi-turn recall (`run-conversation`)
 
 A second suite, answering a different question: **does a fact survive the

--- a/backend/evals/__main__.py
+++ b/backend/evals/__main__.py
@@ -9,7 +9,7 @@ from app import config as config_module
 from app.cognitive.identity import IdentityManager
 from app.llm.ollama_client import OllamaClient
 
-from .compare import compare_reports, render_comparison
+from .compare import PathMismatch, compare_reports, render_comparison
 from .conversation import (
     FullHistory,
     RecentWindow,
@@ -51,6 +51,7 @@ async def _cmd_run(args: argparse.Namespace) -> int:
             client, manager, probes,
             model=args.model,
             options=RunOptions(num_gpu=args.num_gpu),
+            path=args.path,
         )
     finally:
         await client.close()
@@ -62,7 +63,7 @@ async def _cmd_run(args: argparse.Namespace) -> int:
     total = len(report.results)
     passed = sum(1 for item in report.results if item.passed)
     print(f"model={report.model} persona={report.persona_name!r} "
-          f"provenance={report.provenance}")
+          f"provenance={report.provenance} path={report.path}")
     for category, summary in report.by_category.items():
         print(f"  {category:<10} {summary.passed}/{summary.probes} "
               f"(mean {summary.mean_score:.2f})")
@@ -240,7 +241,14 @@ def _cmd_compare(args: argparse.Namespace) -> int:
         )
         return 2
 
-    comparison = compare_reports(baseline, candidate)
+    try:
+        comparison = compare_reports(baseline, candidate)
+    except PathMismatch as exc:
+        # Exit 2 like the other input errors in this CLI: the reports are
+        # individually fine, the pairing is not.
+        print(str(exc), file=sys.stderr)
+        return 2
+
     print(render_comparison(comparison))
     if args.fail_on_regression and not comparison.gate_passed:
         return 1
@@ -268,6 +276,16 @@ def main(argv=None) -> int:
     run_parser.add_argument("--allow-mock", action="store_true",
                             help="permit running under MOCK_LLM_TEXT "
                                  "(report is stamped mock)")
+    run_parser.add_argument("--path", choices=["llm", "action"], default="llm",
+                            help="what to measure. 'llm' (default) probes the "
+                                 "persona prompt straight into the model -- "
+                                 "the seam a fine-tuned adapter changes. "
+                                 "'action' runs each probe through the real "
+                                 "ActionService, so the report also covers "
+                                 "action.py's prompt construction, <thought> "
+                                 "stripping, sanitization and self-correction. "
+                                 "Reports from the two paths cannot be "
+                                 "compared with each other")
 
     conv_parser = sub.add_parser(
         "run-conversation",

--- a/backend/evals/action_path.py
+++ b/backend/evals/action_path.py
@@ -1,0 +1,216 @@
+"""Run a probe through the real `ActionService`, not just the LLM boundary.
+
+`runner.py` evaluates the seam a fine-tuned adapter changes: the persona prompt
+in, `OllamaClient.generate` out. That is the right boundary for CVS-4, and it
+stays the default. But it means **everything `action.py` contributes to a turn
+is invisible to the eval pack** -- `_CHAT_GUIDELINE`, the Theory-of-Mind block,
+the goal line interpolated into the user prompt, the incremental `<thought>`
+stripping, `ControlMarkupSanitizer`, `_validate_partial_response` and the
+self-correction retry it triggers.
+
+That gap is not hypothetical. P2-4 (audit/ROADMAP.md, Stage 4 Part 4) proposed
+appending a classification instruction to exactly this system prompt, ran
+`evals run` before and after, and got an identical report both times -- because
+the harness never executed the code the change lived in. The item was
+ultimately gated by a hand-written live smoke test instead, and dropped on what
+that smoke test found. This module is the missing gate.
+
+**What this path measures, and what it deliberately does not.** It measures
+prompt construction, streaming-time parsing, sanitization and boundary
+validation -- everything between the probe text and the visible reply. It does
+*not* measure the endocrine sampling mapping (`_compute_endocrine_options`),
+because `PinnedOptionsClient` overrides sampling to the harness's pinned
+options. That is a deliberate trade, not an oversight: letting cortisol pick
+the temperature would reintroduce precisely the run-to-run variance
+`runner.reset_model_state` exists to eliminate, and an eval whose sampling
+drifts with simulated affect cannot answer "did the model change".
+
+The dependency points one way, as it must: this imports from `app/`, and
+nothing in `app/` knows this file exists. The pinning lives here, in the
+harness, rather than as a hook in `action.py` that would exist only for tests.
+"""
+
+import logging
+from typing import Any
+
+from app.cognitive.action import ActionService
+from app.cognitive.decision import ActionPlan
+from app.llm.ollama_client import OllamaClient
+
+from .schema import RunOptions
+
+logger = logging.getLogger("evals.action_path")
+
+# Interpolated verbatim into the user prompt as "- Goal: {goal}", so it is part
+# of what the model reads. Pinned to the same value the decision layer falls
+# back to when classification is unavailable, for the same reason the mood
+# directive is pinned: a goal that varied would measure the decision layer.
+EVAL_GOAL = "ENGAGE"
+
+# Neutral affect. `_prepended_affect_tag` emits a <breath_fast>/<sigh_soft>
+# opener outside these bounds, which would prepend a non-verbal marker to the
+# scored text; at valence 0.0 / arousal 0.5 it returns "" and the reply is the
+# model's own first token. Frozen for the same reason `EVAL_MOOD_DIRECTIVE` is.
+EVAL_VALENCE = 0.0
+EVAL_AROUSAL = 0.5
+EVAL_DOMINANCE = 0.5
+
+
+class PinnedOptionsClient:
+    """An `OllamaClient` whose sampling options cannot be overridden downstream.
+
+    Two separate problems make this necessary, and neither is optional:
+
+    1. **The endocrine layer picks sampling from affect.**
+       `ActionService._compute_endocrine_options` maps cortisol to temperature,
+       dopamine to top_p and fatigue to num_predict, and hands the result to
+       `generate_stream` as `options_override`. Whatever the harness pinned
+       would be silently replaced.
+    2. **`generate_stream`'s own defaults are unusable for evaluation.** It
+       passes `num_predict=40` and `num_ctx=2048` when nothing overrides them
+       (`ollama_client.py:91-99`, `:206`). Forty tokens truncates most probe
+       answers mid-sentence, and 2048 is the same context ceiling that
+       `RunOptions.num_ctx` is pinned to 8192 to escape.
+
+    So this wrapper merges the run's options *over* whatever the caller passed,
+    rather than under it. Delegation is explicit (only the two generate methods
+    plus the attributes the runner reads) rather than a `__getattr__` catch-all:
+    a silently forwarded method is how a future call path would escape the
+    pinning without anything failing.
+
+    It also records the system prompt it was actually handed, so the report can
+    fingerprint what the model really saw instead of a copy of `action.py`'s
+    prompt composition maintained here -- a copy that would drift the first
+    time that composition changed, and drift silently, since both sides would
+    still produce a digest.
+    """
+
+    def __init__(self, inner: OllamaClient, options: RunOptions):
+        self._inner = inner
+        self._pinned = options.as_override()
+        self.observed_system: str | None = None
+
+    # The runner reads both of these off the client it was given.
+    @property
+    def model(self) -> str:
+        return self._inner.model
+
+    @property
+    def base_url(self) -> str | None:
+        # `getattr` with a default, matching `reset_model_state`'s own reasoning
+        # (`runner.py`): a stand-in client declines the unload by not offering
+        # an address, rather than by raising from inside one.
+        return getattr(self._inner, "base_url", None)
+
+    def _pin(self, options_override: dict[str, Any] | None) -> dict[str, Any]:
+        merged = dict(options_override or {})
+        merged.update(self._pinned)
+        return merged
+
+    def _observe(self, system: str | None) -> None:
+        if self.observed_system is None and system is not None:
+            self.observed_system = system
+
+    async def generate(
+        self,
+        prompt: str,
+        system: str | None = None,
+        model: str | None = None,
+        options_override: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ):
+        self._observe(system)
+        return await self._inner.generate(
+            prompt=prompt,
+            system=system,
+            model=model,
+            options_override=self._pin(options_override),
+            **kwargs,
+        )
+
+    async def generate_stream(
+        self,
+        prompt: str,
+        system: str | None = None,
+        model: str | None = None,
+        options_override: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ):
+        self._observe(system)
+        async for chunk in self._inner.generate_stream(
+            prompt=prompt,
+            system=system,
+            model=model,
+            options_override=self._pin(options_override),
+            **kwargs,
+        ):
+            yield chunk
+
+
+def build_action_service(client: PinnedOptionsClient) -> ActionService:
+    """An `ActionService` with no store behind it.
+
+    `memory_store=None` and `self_knowledge=None` are load-bearing, not
+    laziness. Both collaborators are guarded (`action.py:1121`, `:1128`,
+    `_build_wondering_block`'s own `is None` return), so the turn runs without
+    Postgres, Qdrant or Neo4j -- keeping the harness's "no NATS, no databases,
+    no mesh" property, which is what lets it run anywhere the model does.
+
+    The consequence is stated rather than hidden: `_surface_fallback_memories`
+    never runs, so SHARED HISTORY is empty on this path. Retrieval is what
+    `run-conversation` measures; this path measures the prompt built around it.
+    """
+    return ActionService(llm_service=client, memory_store=None, self_knowledge=None)
+
+
+def build_plan(prompt: str, identity_prompt: str, model: str | None) -> ActionPlan:
+    """The minimal plan a `RESPOND_CHAT` turn needs.
+
+    Every affect field is pinned rather than omitted. Omitting the three
+    endocrine keys would make `_compute_endocrine_options` return `None`
+    (`action.py:637`), which reads as "no endocrine signal" and leaves the
+    model on `generate_stream`'s 40-token default -- so the omission that looks
+    like "don't simulate hormones" is really "truncate every answer". They are
+    supplied at rest instead, and `PinnedOptionsClient` overrides the sampling
+    they produce.
+    """
+    return ActionPlan(
+        action_type="RESPOND_CHAT",
+        goal=EVAL_GOAL,
+        payload={
+            "message": prompt,
+            "identity_prompt": identity_prompt,
+            "emotion_state": "neutral",
+            "model": model,
+            "valence": EVAL_VALENCE,
+            "arousal": EVAL_AROUSAL,
+            "dominance": EVAL_DOMINANCE,
+            "cortisol": 0.0,
+            "dopamine": 0.0,
+            "fatigue": 0.0,
+        },
+    )
+
+
+async def generate_through_action_service(
+    service: ActionService,
+    plan: ActionPlan,
+) -> str:
+    """Stream a turn and return what the user would actually have heard.
+
+    Only `content` chunks are collected. The other types are real parts of the
+    turn but are not speech: `self_correction` is the internal signal
+    `pipeline.py` intercepts and never forwards to transport, and `error`
+    reports a failed turn. Scoring the internal ones would measure text no
+    listener receives.
+
+    A self-correction retry is *not* filtered out, and should not be: its
+    replacement text arrives as ordinary `content`, which is exactly what the
+    user hears, and a change that starts triggering self-correction is a
+    behavior change the gate should catch.
+    """
+    parts: list[str] = []
+    async for chunk in service.execute(plan):
+        if chunk.get("type") == "content":
+            parts.append(str(chunk.get("data", "")))
+    return "".join(parts)

--- a/backend/evals/compare.py
+++ b/backend/evals/compare.py
@@ -15,6 +15,36 @@ regressions are unarguable, which is what a gate needs to be.
 from .schema import ComparisonReport, EvalReport, OptionDiff, ProbeDelta
 
 
+class PathMismatch(ValueError):
+    """Raised when the two reports were produced by different execution paths.
+
+    This is the one input disagreement `compare` refuses outright, and the
+    asymmetry is deliberate. Sampling options and persona edits are *inputs to
+    the same measurement*: the caller may have changed one on purpose, the
+    deltas still mean something, and `diff_options`'s own docstring argues that
+    a gate blocking a deliberate change would simply get bypassed. Both are
+    therefore surfaced loudly and left to the reader.
+
+    A path difference is not that. "llm" and "action" do not sample the same
+    quantity -- one is the model's answer to the persona prompt, the other is
+    what a full turn produced after `action.py` rebuilt the prompt around it,
+    stripped `<thought>`, sanitized markup and possibly ran a self-correction
+    retry. Every probe delta between them is attributable to the harness. There
+    is no reading of such a diff that says anything about the model, so there
+    is nothing for a reader to weigh and no deliberate case to preserve.
+    """
+
+
+def require_same_path(baseline: EvalReport, candidate: EvalReport) -> None:
+    if baseline.path != candidate.path:
+        raise PathMismatch(
+            f"baseline was run on the {baseline.path!r} path and candidate on "
+            f"the {candidate.path!r} path. These do not measure the same "
+            "thing: every probe difference between them is the harness, not "
+            "the model. Re-run both on one path before comparing."
+        )
+
+
 def diff_options(baseline: EvalReport, candidate: EvalReport) -> list[OptionDiff]:
     """Sampling options the two runs did not share.
 
@@ -52,6 +82,8 @@ def diff_options(baseline: EvalReport, candidate: EvalReport) -> list[OptionDiff
 def compare_reports(
     baseline: EvalReport, candidate: EvalReport
 ) -> ComparisonReport:
+    require_same_path(baseline, candidate)
+
     base_by_id = {result.probe_id: result for result in baseline.results}
     cand_by_id = {result.probe_id: result for result in candidate.results}
     shared = [pid for pid in base_by_id if pid in cand_by_id]
@@ -99,6 +131,7 @@ def compare_reports(
         candidate_model=candidate.model,
         baseline_provenance=baseline.provenance,
         candidate_provenance=candidate.provenance,
+        path=baseline.path,
         option_diffs=diff_options(baseline, candidate),
         persona_prompt_differs=bool(
             baseline.system_prompt_sha256
@@ -121,8 +154,16 @@ def render_comparison(comparison: ComparisonReport) -> str:
         f"[{comparison.baseline_provenance}]"),
         (f"candidate: {comparison.candidate_model} "
         f"[{comparison.candidate_provenance}]"),
+        f"path:      {comparison.path}",
         "",
     ]
+    if comparison.path == "action":
+        lines += [
+            "(action path: responses came through the real ActionService, so",
+            "this diff covers action.py's prompt construction, <thought>",
+            "stripping, sanitization and self-correction as well as the model.)",
+            "",
+        ]
     if "mock" in (comparison.baseline_provenance, comparison.candidate_provenance):
         lines += [
             "!! MOCK PROVENANCE — these responses came from the deterministic",

--- a/backend/evals/runner.py
+++ b/backend/evals/runner.py
@@ -20,9 +20,16 @@ from app import config as config_module
 from app.cognitive.identity import IdentityManager
 from app.llm.ollama_client import OllamaClient
 
+from .action_path import (
+    PinnedOptionsClient,
+    build_action_service,
+    build_plan,
+    generate_through_action_service,
+)
 from .schema import (
     DEFAULT_OPTIONS,
     CheckResult,
+    EvalPath,
     EvalReport,
     Probe,
     ProbeResult,
@@ -122,13 +129,27 @@ async def run_probe(
     system: str,
     model: str | None,
     options: RunOptions,
+    generate=None,
 ) -> ProbeResult:
-    response = await client.generate(
-        prompt=probe.prompt,
-        system=system,
-        model=model,
-        options_override=options.as_override(),
-    )
+    """Score one probe.
+
+    `generate` is how the response is produced: `None` keeps the original LLM
+    boundary (persona prompt straight into `OllamaClient.generate`). The action
+    path passes a callable that drives the same probe through the real
+    `ActionService` instead. Everything after the response -- the checks, the
+    boundary delegation to `IdentityManager.validate_response`, the scoring --
+    is deliberately shared and unchanged, so a verdict means the same thing on
+    either path and `compare` has one implementation to serve both.
+    """
+    if generate is None:
+        response = await client.generate(
+            prompt=probe.prompt,
+            system=system,
+            model=model,
+            options_override=options.as_override(),
+        )
+    else:
+        response = await generate(probe.prompt)
 
     views = response_views(response)
     checks: list[CheckResult] = []
@@ -159,15 +180,45 @@ async def run_eval(
     probes: list[Probe],
     model: str | None = None,
     options: RunOptions = DEFAULT_OPTIONS,
+    path: EvalPath = "llm",
 ) -> EvalReport:
-    system = manager.get_persona_prompt(current_mood_directive=EVAL_MOOD_DIRECTIVE)
-    await reset_model_state(client, system, model, options)
+    """Probe a model and write a report.
+
+    `path` chooses what is measured. "llm" is the original seam and stays the
+    default, because it is the one a fine-tuned adapter changes and every
+    existing baseline was taken there. "action" runs each probe through the
+    real `ActionService`, which is the only way to gate a change to
+    `action.py`'s own prompt construction -- see `action_path.py` for why that
+    gap existed and what it let through.
+    """
+    persona_prompt = manager.get_persona_prompt(
+        current_mood_directive=EVAL_MOOD_DIRECTIVE
+    )
+
+    generate = None
+    pinned: PinnedOptionsClient | None = None
+    if path == "action":
+        pinned = PinnedOptionsClient(client, options)
+        service = build_action_service(pinned)
+
+        async def generate(prompt: str) -> str:
+            return await generate_through_action_service(
+                service, build_plan(prompt, persona_prompt, model)
+            )
+
+    # Warm-up goes through the plain client either way: it is discarded text
+    # whose only job is to leave the runtime in a named state, and routing it
+    # through ActionService would add a turn's worth of failure modes to a call
+    # nobody scores.
+    await reset_model_state(client, persona_prompt, model, options)
 
     results: list[ProbeResult] = []
     # Sequential on purpose: one local model, and concurrent generations on a
     # CPU-only box would contend for the same cores and skew nothing useful.
     for probe in probes:
-        result = await run_probe(client, manager, probe, system, model, options)
+        result = await run_probe(
+            client, manager, probe, persona_prompt, model, options, generate
+        )
         logger.info(
             "[eval] %-32s %s (%.2f)",
             probe.id,
@@ -176,12 +227,20 @@ async def run_eval(
         )
         results.append(result)
 
+    # Fingerprint what the model was actually given. On the action path that is
+    # not the persona prompt: `_execute_respond_chat` appends `_CHAT_GUIDELINE`
+    # to it. Read back from the client that saw the call rather than rebuilt
+    # here, so this cannot drift out of step with `action.py` -- a local copy of
+    # that composition would keep producing a plausible digest after the
+    # composition changed, which is the failure mode a digest exists to catch.
+    observed = pinned.observed_system if pinned else None
     return EvalReport(
         model=model or client.model,
         persona_name=manager.persona.name,
         provenance=_provenance(),
+        path=path,
         options=options.as_override(),
-        system_prompt_sha256=fingerprint(system),
+        system_prompt_sha256=fingerprint(observed or persona_prompt),
         results=results,
         by_category=summarize_by_category(results),
     )

--- a/backend/evals/schema.py
+++ b/backend/evals/schema.py
@@ -34,6 +34,19 @@ def fingerprint(text: str) -> str:
 
 Category = Literal["identity", "boundary", "memory", "custom"]
 
+# Which code path produced a report's responses.
+#
+# "llm" is the original boundary: the persona prompt straight into
+# `OllamaClient.generate`. "action" drives the same probe through the real
+# `ActionService`, so the report also covers everything `action.py` adds to a
+# turn -- the chat guideline, the ToM block, the goal line, `<thought>`
+# stripping, sanitization, boundary validation and self-correction.
+#
+# This is not a sampling option or a persona edit; it is *which measurement was
+# taken*. Two reports from different paths are not two samples of one quantity,
+# so `compare` refuses to diff them rather than warning -- see `compare.py`.
+EvalPath = Literal["llm", "action"]
+
 CheckKind = Literal[
     "must_include",
     "must_include_any",
@@ -234,6 +247,10 @@ class EvalReport(BaseModel):
     model: str
     persona_name: str
     provenance: Literal["live", "mock"]
+    # Which execution path produced these responses. Defaults to "llm" so that
+    # reports written before this field existed read as what they actually
+    # were, rather than as an unknown that `compare` would have to guess at.
+    path: EvalPath = "llm"
     options: dict[str, Any]
     # Digest of the system prompt every probe in this run was generated under.
     # It is the largest single input to every response and the one most likely
@@ -283,6 +300,12 @@ class ComparisonReport(BaseModel):
     candidate_model: str
     baseline_provenance: Literal["live", "mock"]
     candidate_provenance: Literal["live", "mock"]
+    # Single-valued, not a pair: `compare_reports` refuses a cross-path diff
+    # outright, so by the time a comparison exists both sides agree. Carried so
+    # the rendered output says which measurement was compared -- an "action"
+    # gate and an "llm" gate answer different questions and a reader of the
+    # report months later has no other way to tell them apart.
+    path: EvalPath = "llm"
     # Sampling options the two runs disagreed on. Greedy decoding reproduces
     # only for a fixed load configuration, so a diff here means the comparison
     # is measuring the configuration as much as the model. Surfaced, never

--- a/backend/tests/test_eval_harness.py
+++ b/backend/tests/test_eval_harness.py
@@ -6,6 +6,7 @@ with a green gate saying it didn't. Every test here names the specific way the
 gate could lie.
 """
 
+import asyncio
 import json
 from unittest import mock
 
@@ -13,11 +14,17 @@ import pytest
 from pydantic import ValidationError
 
 from app import config as config_module
+from app.cognitive.action import _CHAT_GUIDELINE
 from app.cognitive.identity import IdentityManager
 from app.persona.profile import IMMUTABLE_CORE
 from evals import runner as runner_module
 from evals.__main__ import main as evals_main
-from evals.compare import compare_reports, render_comparison
+from evals.action_path import (
+    build_action_service,
+    build_plan,
+    generate_through_action_service,
+)
+from evals.compare import PathMismatch, compare_reports, render_comparison
 from evals.probes import collect_probes, load_pack, persona_probes, shipped_packs
 from evals.runner import run_eval
 from evals.schema import (
@@ -388,11 +395,12 @@ def _result(pid, category, passed, score):
     )
 
 
-def _report(model, results, provenance="live", options=None):
+def _report(model, results, provenance="live", options=None, path="llm"):
     return EvalReport(
         model=model,
         persona_name="Kavya",
         provenance=provenance,
+        path=path,
         options={} if options is None else options,
         results=results,
         by_category=summarize_by_category(results),
@@ -560,7 +568,214 @@ def test_an_unpinned_num_gpu_is_omitted_rather_than_sent_as_null():
     assert unpinned["temperature"] == 0.0 and unpinned["num_ctx"] == 8192
 
 
+# ------------------------------------------------- the ActionService path
+#
+# P2-4 proposed appending a classification instruction to `action.py`'s system
+# prompt, ran `evals run` before and after, and got identical reports -- the
+# harness never executed the code the change lived in. These cover the path
+# added to close that.
+
+
+class ScriptedStreamClient:
+    """Stands in for OllamaClient on the streaming path ActionService uses.
+
+    Records what it was actually handed, because that is the whole question:
+    the action path's claim is that the prompt reaching the model is the one
+    production builds, not the bare probe text.
+    """
+
+    def __init__(self, reply="I am Kavya, and I'm glad you asked."):
+        self.model = "scripted:test"
+        self.reply = reply
+        self.seen_systems = []
+        self.seen_prompts = []
+        self.seen_options = []
+        # Kept apart from `seen_options` on purpose. `reset_model_state`'s
+        # warm-up goes through `generate` with its own deliberate
+        # `num_predict: 8`, so a single combined list would make an assertion
+        # about the streamed sampling pass or fail on the warm-up instead.
+        self.seen_stream_options = []
+
+    async def generate(self, prompt, system=None, model=None, options_override=None):
+        self.seen_systems.append(system)
+        self.seen_prompts.append(prompt)
+        self.seen_options.append(options_override)
+        return self.reply
+
+    async def generate_stream(
+        self, prompt, system=None, model=None, options_override=None
+    ):
+        self.seen_systems.append(system)
+        self.seen_prompts.append(prompt)
+        self.seen_options.append(options_override)
+        self.seen_stream_options.append(options_override)
+        # Split so the incremental parsing in `_visible_segments` is genuinely
+        # exercised across chunk boundaries rather than handed one whole string.
+        for word in self.reply.split(" "):
+            yield word + " "
+
+
+@pytest.mark.asyncio
+async def test_the_action_path_prompts_the_model_the_way_production_does(kavya):
+    """The reason this path exists. On the llm path the model receives the
+    persona prompt and the bare probe; a change to `action.py`'s own prompt
+    construction is invisible to it, which is exactly how P2-4's classification
+    instruction passed an unchanged eval twice. Here the model must receive
+    what a real turn builds -- the chat guideline in the system prompt, and the
+    goal line and `User:`/`Assistant:` framing in the user prompt."""
+    client = ScriptedStreamClient()
+
+    report = await run_eval(
+        client, kavya, persona_probes(kavya), path="action"
+    )
+
+    # The system prompt is the persona *plus* what action.py appends.
+    system = client.seen_systems[-1]
+    assert "YOU ARE Kavya" in system
+    assert _CHAT_GUIDELINE in system
+
+    # The user prompt is production's, not the probe string on its own.
+    user_prompt = client.seen_prompts[-1]
+    assert "- Goal: ENGAGE" in user_prompt
+    assert "User: " in user_prompt and user_prompt.rstrip().endswith("Assistant:")
+
+    assert report.path == "action"
+    assert len(report.results) == len(persona_probes(kavya))
+
+
+@pytest.mark.asyncio
+async def test_the_action_path_pins_sampling_over_the_endocrine_layer(kavya):
+    """`_compute_endocrine_options` maps cortisol to temperature, dopamine to
+    top_p and fatigue to num_predict, and hands them to `generate_stream` as an
+    override. Unpinned, the eval's sampling would be silently replaced by
+    simulated hormones and every run would be free to differ -- the exact
+    variance `reset_model_state` exists to remove. Worse, with no override at
+    all `generate_stream` defaults to num_predict=40 and num_ctx=2048, which
+    truncates answers mid-sentence."""
+    client = ScriptedStreamClient()
+
+    await run_eval(client, kavya, persona_probes(kavya), path="action")
+
+    # The streaming calls are the ones ActionService makes.
+    streamed = client.seen_stream_options
+    assert streamed, "the action path never reached generate_stream"
+    for opts in streamed:
+        assert opts["temperature"] == 0.0
+        assert opts["seed"] == 42
+        assert opts["num_ctx"] == 8192
+        # 250 is what the endocrine layer computes at zero fatigue; the pinned
+        # value must win over it.
+        assert opts["num_predict"] == 192
+
+
+@pytest.mark.asyncio
+async def test_the_action_report_fingerprints_the_prompt_the_model_really_saw(kavya):
+    """The digest exists so a comparison across a prompt edit cannot read as a
+    model change. On the action path the persona prompt is not what the model
+    got -- action.py appends the chat guideline -- so fingerprinting the
+    persona prompt here would stamp every action-path report with a digest for
+    text no model ever received, and two runs whose guideline differed would
+    still fingerprint identically."""
+    client = ScriptedStreamClient()
+
+    llm_report = await run_eval(client, kavya, persona_probes(kavya))
+    action_report = await run_eval(
+        client, kavya, persona_probes(kavya), path="action"
+    )
+
+    assert llm_report.system_prompt_sha256
+    assert action_report.system_prompt_sha256
+    assert action_report.system_prompt_sha256 != llm_report.system_prompt_sha256
+    assert action_report.system_prompt_sha256 == fingerprint(
+        client.seen_systems[-1]
+    )
+
+
+def test_a_cross_path_comparison_is_refused_rather_than_diffed():
+    """Sampling and persona differences are surfaced and left to the reader,
+    because the caller may have changed one deliberately and the deltas still
+    mean something. A path difference is not that: "llm" and "action" do not
+    sample the same quantity, so every probe delta between them is the harness
+    rather than the model, and there is no reading of the diff worth
+    printing."""
+    baseline = _report("m", [_result("a", "identity", True, 1.0)], path="llm")
+    candidate = _report("m", [_result("a", "identity", False, 0.0)], path="action")
+
+    with pytest.raises(PathMismatch) as excinfo:
+        compare_reports(baseline, candidate)
+
+    # The message must name both sides; "incomparable" alone leaves the reader
+    # guessing which report to re-run.
+    assert "'llm'" in str(excinfo.value) and "'action'" in str(excinfo.value)
+
+
+def test_reports_predating_the_path_field_compare_as_the_path_they_were_run_on():
+    """Every report written before this field existed came from the llm path.
+    Defaulting to anything else -- or to an "unknown" that refuses -- would make
+    the existing baselines uncomparable overnight, retiring evidence that is
+    still valid."""
+    old = EvalReport.model_validate_json(
+        json.dumps(
+            {
+                "model": "m",
+                "persona_name": "Kavya",
+                "provenance": "live",
+                "options": {},
+                "results": [],
+                "by_category": {},
+            }
+        )
+    )
+    assert old.path == "llm"
+
+    fresh = _report("m", [], path="llm")
+    assert compare_reports(old, fresh).path == "llm"
+
+
+def test_the_action_path_scores_speech_not_the_internal_chunks(kavya):
+    """`execute()` yields more than speech: `self_correction` is the internal
+    signal `pipeline.py` intercepts and never forwards to transport. Scoring it
+    would measure text no listener receives, and would let a probe pass on the
+    strength of an error report."""
+    service = build_action_service(ScriptedStreamClient())
+
+    class _FakeService:
+        async def execute(self, plan):
+            yield {"type": "content", "data": "Hello "}
+            yield {"type": "self_correction", "data": "boundary violation"}
+            yield {"type": "content", "data": "there."}
+            yield {"type": "done", "data": ""}
+
+    heard = asyncio.run(
+        generate_through_action_service(_FakeService(), build_plan("hi", "p", None))
+    )
+
+    assert heard == "Hello there."
+    assert "boundary violation" not in heard
+    # The real service is constructed without stores, and that must stay true:
+    # the harness runs wherever the model does, with no Postgres/Qdrant/Neo4j.
+    assert service.memory is None and service.self_knowledge is None
+
+
 # ---------------------------------------------------------------- CLI gates
+
+
+def test_compare_cli_refuses_a_cross_path_compare_with_a_usage_exit(
+    tmp_path, capsys
+):
+    """The reports are individually fine; the pairing is not. Exiting 2 like
+    every other input error keeps a mistaken pairing distinguishable from a
+    genuine regression, which exits 1 -- a consolidation loop reading only the
+    exit code would otherwise treat "you compared the wrong things" as "the
+    adapter broke behavior"."""
+    llm = _report("base", [_result("a", "identity", True, 1.0)], path="llm")
+    action = _report("cand", [_result("a", "identity", True, 1.0)], path="action")
+    llm_path, action_path = tmp_path / "llm.json", tmp_path / "action.json"
+    save_report(llm, str(llm_path))
+    save_report(action, str(action_path))
+
+    assert evals_main(["compare", str(llm_path), str(action_path)]) == 2
+    assert "path" in capsys.readouterr().err.lower()
 
 
 def test_compare_cli_refuses_mock_reports_without_allow_mock(tmp_path, capsys):


### PR DESCRIPTION
`evals run`/`run-conversation` built their own prompt and called `OllamaClient.generate` directly, so everything `action.py` contributes to a turn was invisible to every report the harness ever wrote. P2-4 proved it: it changed that exact system prompt, ran the eval before and after, and got an identical report both times.

`--path action` drives each probe through a real `ActionService` turn. Checks, boundary delegation and scoring are shared and unchanged, so a verdict means the same thing either way.

Verified on qwen2.5:3b: same headline (6/9), zero of nine responses shared, five metacognitive violations fired that the LLM path could not have reported. Two action-path runs 9/9 byte-identical.

Suite 1044/1044 (1037 + 7 new), ruff clean, all seven new tests mutation-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)