### PR TITLE
fix: take the state lock in handle_system_tick (P2-14/M2-A1)

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -8556,3 +8556,68 @@ stream options separately.
   `hardware-and-deployment-roadmap`).
 - Stage 5's remaining parts -- P2-14's tick lock, P2-8's noise-floor latch,
   P2-2's outbound ack, and the two documentation leftovers -- next.
+
+## 2026-08-23 -- Stage 5 Part 1 -- P2-14/M2-A1: the system tick was mutating
+affect outside `_state_lock`, one method below the docstring explaining why
+that is not allowed
+
+`CLAUDE.md` states the invariant without qualification: `StateService` owns
+**all** mutation behind `self._state_lock`, and bypassing it reintroduces
+finding A2. `handle_system_tick` did not hold it. It mutated `fatigue`,
+`mood`, `energy`, `dominance` and all three trust fields unlocked, on a NATS
+callback, i.e. genuinely concurrently with the paths that do take the lock.
+
+**The placement is the finding.** `release_cortisol` and `release_dopamine` sit
+*immediately above* this method and carry careful docstrings about exactly this
+hazard -- A2 by name, the non-reentrancy of `asyncio.Lock`, and the fact that a
+burst peak is measured relative to the tonic floor so an unlocked release "can
+measure its peak against a floor that no longer exists". `handle_system_tick`
+is the method that rewrites that floor: the tonic terms are pure functions of
+valence and arousal, which is what the ALMA decay here recomputes. So the
+unlocked path was not some distant corner -- it was the other half of the
+hazard the adjacent docstring describes. This is the audit's own root cause
+verbatim ("the lock discipline is genuinely careful everywhere it was thought
+about; the tick path was not thought about").
+
+**Fix.** Wrapped the body in `async with self._state_lock:`, matching every
+other mutation path. `await self.persist_state()` stays *inside* the lock,
+which is correct and not incidental: `persist_state` serializes on
+`_persist_lock`, deliberately a different lock, precisely because callers reach
+it already holding the state lock. Verified before wrapping that
+`_enforce_bounds` and `_update_fatigue_python` are synchronous and take no lock
+(0 references each), so there is no reentrancy path.
+
+**Tests, mutation-tested.**
+`test_a_system_tick_does_not_let_an_affect_write_land_mid_decay` asserts
+*ordering*, not "was the lock acquired": a competing `release_dopamine` fired
+while the tick is inside its persist await must complete strictly after the
+whole tick. Unlocked it completes in the middle, and the recorded order becomes
+`[persist-start, release-done, persist-end]`. Chosen over the
+`_state_lock.acquire` spy already in this file (used by
+`test_apply_external_state_holds_the_state_lock`) because that shape still
+passes if the lock is taken around only *part* of the body, which is the more
+likely future regression. Mutation: unwrapped the body, re-dedented, test
+failed; reverted. The second test pins the `_persist_lock`/`_state_lock`
+separation and carries an explicit `asyncio.wait_for` timeout, because
+collapsing the two would **hang** rather than fail -- a timeout names the
+defect where a wedged suite does not.
+
+**Files:** `app/state/agent_state.py`, `tests/test_state.py`.
+
+**Verified.** Full backend suite 1039/1039 (1037 baseline + 2 new), `ruff
+check .` clean.
+
+**NOT done -- P2-14's other three findings, all deliberately left filed:**
+- **M1-A5** (`state.update` published once per LLM chunk) **does not reproduce
+  as filed.** `pipeline.py:254` and `:287` yield it twice per *turn* -- once
+  after the stage-5 state update, once after post-decision ToM -- not per
+  chunk. Either it was fixed by earlier work or the finding was mis-read at
+  audit time; either way it needs re-sizing before it needs fixing, and
+  "amplification" is the wrong frame for two yields a turn.
+- **M1-A14** (brain_agent subscribes to `audio.stop` at `brain_agent.py:132`
+  and publishes it at `:290`) is real, but it overlaps #190's interruption
+  arbiter directly and should be re-read against that work rather than fixed
+  blind.
+- **M2-A3** (`update_from_event` unlocked) -- dead in production.
+- Stage 5's remaining parts -- P2-8's noise-floor latch, P2-2's outbound ack,
+  and the two documentation leftovers -- next.

--- a/backend/app/state/agent_state.py
+++ b/backend/app/state/agent_state.py
@@ -1214,56 +1214,89 @@ class StateService:
         """
         Idle evolution triggered by NATS system.tick.
         Implements ALMA exponential decay (§2.2) and Fatigue updates.
+
+        audit/ROADMAP.md P2-14 (M2-A1): this ran **outside `_state_lock`**,
+        mutating fatigue, mood, energy, dominance and all three trust fields
+        while every other mutation path in this class held it -- including
+        `release_cortisol` and `release_dopamine` directly above, whose
+        docstrings spell out why affect mutation must be serialized. That is
+        the audit's own stated root cause for this finding: the lock discipline
+        is careful everywhere it was thought about, and the tick path was not
+        thought about.
+
+        Concretely, the tick arrives on a NATS callback while a fire-and-forget
+        System-2 appraisal can be writing affect (finding A2), so an unlocked
+        decay could read `mood` before that write and store its result after,
+        discarding it. The endocrine layer makes it worse rather than merely
+        racy: burst peaks are measured relative to the tonic floor, and the
+        tonic floor is a pure function of the valence and arousal this method
+        rewrites -- so a release interleaving with an unlocked decay measures
+        its peak against a floor that never existed.
+
+        `persist_state` is called from inside the lock deliberately. It
+        serializes on `_persist_lock`, which is **not** `_state_lock` precisely
+        because callers reach it already holding the state lock (see its own
+        docstring); `asyncio.Lock` is not reentrant, so the separation is what
+        makes this safe. `_enforce_bounds` and `_update_fatigue_python` are
+        synchronous and take no lock.
         """
         now = tick_metadata.get("timestamp", time.time())
         dt_hours = tick_metadata.get("interval", 60) / 3600.0
 
-        # Evolve fatigue
-        hour = datetime.fromtimestamp(now).hour
-        is_night = hour >= 22 or hour < 6
-        try:
-            import cognitive_rust
+        async with self._state_lock:
+            # Evolve fatigue
+            hour = datetime.fromtimestamp(now).hour
+            is_night = hour >= 22 or hour < 6
+            try:
+                import cognitive_rust
 
-            rust_state = cognitive_rust.FatigueState(
-                self.current_state.fatigue, self.current_state.last_user_interaction
-            )
-            updated_rust = cognitive_rust.update_fatigue(
-                rust_state, now, dt_hours, is_night
-            )
-            self.current_state.fatigue = updated_rust.fatigue
-        except ImportError:
-            self._update_fatigue_python(now, dt_hours, is_night)
-        except Exception:
-            logger.exception(
-                "[State] Unexpected Rust fatigue update error; using Python fallback."
-            )
-            self._update_fatigue_python(now, dt_hours, is_night)
+                rust_state = cognitive_rust.FatigueState(
+                    self.current_state.fatigue,
+                    self.current_state.last_user_interaction,
+                )
+                updated_rust = cognitive_rust.update_fatigue(
+                    rust_state, now, dt_hours, is_night
+                )
+                self.current_state.fatigue = updated_rust.fatigue
+            except ImportError:
+                self._update_fatigue_python(now, dt_hours, is_night)
+            except Exception:
+                logger.exception(
+                    "[State] Unexpected Rust fatigue update error; using Python fallback."
+                )
+                self._update_fatigue_python(now, dt_hours, is_night)
 
-        # ALMA Decay (§2.2): short-term affect decays back to baseline
-        base_v = self.current_state.baseline_valence
-        base_ar = self.current_state.baseline_arousal
-        base_d = self.current_state.baseline_dominance
+            # ALMA Decay (§2.2): short-term affect decays back to baseline
+            base_v = self.current_state.baseline_valence
+            base_ar = self.current_state.baseline_arousal
+            base_d = self.current_state.baseline_dominance
 
-        self.current_state.mood = base_v + (
-            self.current_state.mood - base_v
-        ) * math.exp(-self.lambda_decay * dt_hours)
-        self.current_state.energy = base_ar + (
-            self.current_state.energy - base_ar
-        ) * math.exp(-self.lambda_decay * dt_hours)
-        self.current_state.dominance = base_d + (
-            self.current_state.dominance - base_d
-        ) * math.exp(-self.lambda_decay * dt_hours)
+            self.current_state.mood = base_v + (
+                self.current_state.mood - base_v
+            ) * math.exp(-self.lambda_decay * dt_hours)
+            self.current_state.energy = base_ar + (
+                self.current_state.energy - base_ar
+            ) * math.exp(-self.lambda_decay * dt_hours)
+            self.current_state.dominance = base_d + (
+                self.current_state.dominance - base_d
+            ) * math.exp(-self.lambda_decay * dt_hours)
 
-        tb_drift = (self.trust_baseline - self.current_state.trust_benevolence) * 0.01
-        tc_drift = (self.trust_baseline - self.current_state.trust_competence) * 0.01
-        ti_drift = (self.trust_baseline - self.current_state.trust_integrity) * 0.01
-        self.current_state.trust_benevolence += tb_drift
-        self.current_state.trust_competence += tc_drift
-        self.current_state.trust_integrity += ti_drift
+            tb_drift = (
+                self.trust_baseline - self.current_state.trust_benevolence
+            ) * 0.01
+            tc_drift = (
+                self.trust_baseline - self.current_state.trust_competence
+            ) * 0.01
+            ti_drift = (
+                self.trust_baseline - self.current_state.trust_integrity
+            ) * 0.01
+            self.current_state.trust_benevolence += tb_drift
+            self.current_state.trust_competence += tc_drift
+            self.current_state.trust_integrity += ti_drift
 
-        self.current_state.last_update = datetime.fromtimestamp(now)
-        self._enforce_bounds()
-        await self.persist_state()
+            self.current_state.last_update = datetime.fromtimestamp(now)
+            self._enforce_bounds()
+            await self.persist_state()
         logger.debug(
             "[State Heartbeat] V=%.3f Ar=%.3f D=%.3f F=%.3f",
             self.current_state.mood,

--- a/backend/tests/test_state.py
+++ b/backend/tests/test_state.py
@@ -290,3 +290,80 @@ async def test_apply_external_state_preserves_fields_missing_from_broadcast(
 
     assert state_service.current_state.dominance == 0.73
     assert state_service.current_state.attachment == 0.44
+
+
+@pytest.mark.asyncio
+async def test_a_system_tick_does_not_let_an_affect_write_land_mid_decay(
+    state_service,
+):
+    """P2-14 (M2-A1): `handle_system_tick` mutated fatigue, mood, energy,
+    dominance and all three trust fields outside `_state_lock`, while every
+    other mutation path in `StateService` held it.
+
+    The tick arrives on a NATS callback, so it genuinely runs concurrently with
+    the paths that do take the lock -- a fire-and-forget System-2 appraisal
+    (finding A2), or an endocrine release. Unlocked, a release can slip in
+    between the tick's decay of `mood`/`energy` and the end of the tick, and
+    the endocrine layer makes that worse than an ordinary race: a burst peak is
+    measured *relative to the tonic floor*, and the tonic floor is a pure
+    function of exactly the valence and arousal this method is rewriting. The
+    burst then records a peak above a floor that never existed.
+
+    Asserted as ordering rather than as "was the lock acquired", because the
+    invariant is that no other affect writer observes the tick half-applied --
+    a spy on `acquire` would still pass if the lock were taken around only part
+    of the body.
+    """
+    order: list[str] = []
+
+    async def slow_persist():
+        # Stands in for the real persist, which is `await`ed inside the tick
+        # and is therefore the point another task can interleave at.
+        order.append("tick-persist-start")
+        await asyncio.sleep(0.05)
+        order.append("tick-persist-end")
+
+    state_service.persist_state = slow_persist
+
+    async def competing_release():
+        # Late enough that the tick is already inside its persist await.
+        await asyncio.sleep(0.01)
+        await state_service.release_dopamine(0.5)
+        order.append("release-done")
+
+    await asyncio.gather(
+        state_service.handle_system_tick(
+            {"timestamp": 123456789.0, "interval": 36000}
+        ),
+        competing_release(),
+    )
+
+    # The release must be serialized *after* the whole tick. Unlocked, it
+    # completes during the tick's persist await and this reads
+    # ["tick-persist-start", "release-done", "tick-persist-end"].
+    assert order == ["tick-persist-start", "tick-persist-end", "release-done"]
+
+
+@pytest.mark.asyncio
+async def test_the_tick_can_still_persist_while_holding_the_state_lock(
+    state_service,
+):
+    """The fix wraps the tick body in `_state_lock` and keeps
+    `await self.persist_state()` inside it. That is only safe because
+    `persist_state` serializes on `_persist_lock`, which is deliberately a
+    different lock -- callers reach it already holding the state lock, and
+    `asyncio.Lock` is not reentrant, so collapsing the two would deadlock the
+    heartbeat rather than fail loudly.
+
+    This would hang, not fail, if that separation were ever undone, so it is
+    given an explicit timeout: a hung test that reports as a timeout names the
+    defect, where a hung suite just looks like CI wedged.
+    """
+    await asyncio.wait_for(
+        state_service.handle_system_tick(
+            {"timestamp": 123456789.0, "interval": 3600}
+        ),
+        timeout=5.0,
+    )
+
+    assert state_service._state_lock.locked() is False


### PR DESCRIPTION
The system tick mutated fatigue, mood, energy, dominance and all three trust fields outside `_state_lock`, on a NATS callback, while every other mutation path in `StateService` held it.

The placement is the finding: `release_cortisol` and `release_dopamine` sit immediately above and document this exact hazard, including that a burst peak is measured relative to the tonic floor. `handle_system_tick` is the method that rewrites that floor.

`persist_state` stays inside the lock deliberately -- it serializes on `_persist_lock`, a different lock, precisely because callers reach it holding the state lock.

The test asserts ordering rather than "was the lock acquired": an acquire spy still passes if the lock covers only part of the body.

Suite 1039/1039 (1037 + 2 new), ruff clean, both tests mutation-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)