### PR TITLE
fix: stop the endpointer noise floor latching onto room noise (P2-8)

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -8621,3 +8621,82 @@ check .` clean.
 - **M2-A3** (`update_from_event` unlocked) -- dead in production.
 - Stage 5's remaining parts -- P2-8's noise-floor latch, P2-2's outbound ack,
   and the two documentation leftovers -- next.
+
+## 2026-08-23 -- Stage 5 Part 2 -- P2-8: the endpointer noise floor does not
+"deafen", it *latches* -- and a second way into the latch needs no dropout at
+all
+
+`ROADMAP.md` P2-8 (M3-R2) says the floor "can latch near zero" and "one
+near-silent chunk can deafen detection for a long time". The latching is real;
+**"deafen" is the wrong direction**, and getting it right changed the fix.
+
+**The actual mechanism.** `Endpointer::push` adapts the floor *only on
+non-voiced chunks* -- deliberately, so sustained talking cannot drag it up
+mid-utterance. The descent was unbounded: `if chunk_rms < self.noise_floor {
+self.noise_floor = chunk_rms; }`, a straight assignment. So one anomalous frame
+(a dropout, a muted mic, a lost packet) put the floor at ~0. `threshold` then
+collapsed to the flat `min_speech_rms` (0.008), and **in any room whose ambient
+level is above 0.008, every subsequent chunk reads as voiced** -- so the
+adaptation branch never runs again and the floor can never recover. The
+detector is not deaf, it is permanently *triggered*: utterances stop
+endpointing (until the `max_utterance_secs` force-cut), and barge-in fires on
+room noise. Note the comment on `min_speech_rms` claims it exists "so a silent
+room cannot make noise_floor ~0 and trigger on hiss" -- it guards the
+*threshold*, not the floor, so it never could.
+
+**A second entry, found by a failing test rather than by reading.** While
+writing the "floor still follows a quiet room" test, the assertion failed with
+`0.01 -> 0.00104` and the floor had never risen at all. Cause: the floor is
+constructed at 0.01, so the opening threshold is 0.03, and at an ambient level
+of 0.05 the *very first chunk* reads as voiced. The non-speech branch never
+executes even once and the floor stays pinned at its default forever. **No
+dropout is needed** -- a moderately noisy room at startup is enough. This is
+not in M3-R2, and it is the clearest argument that bounding the descent alone
+is insufficient: here the floor never descends.
+
+**Fix, two parts, both required.**
+1. **Bounded descent** (`NOISE_FLOOR_DESCENT = 0.1`): one chunk may close a
+   tenth of the gap downward, instead of assigning outright. Still fast (a
+   genuine drop is mostly tracked within half a second at 20ms chunks) but no
+   single frame can latch it. Asymmetric with the 0.005 rise on purpose, and
+   the asymmetry is the existing design's, not a new one: a room getting
+   quieter should be tracked promptly; a room getting louder must not drag the
+   floor up mid-utterance.
+2. **An escape hatch** (`reseed_noise_floor`), called from
+   `handle_audio_inbound`'s forced-cut branch only. A forced cut means the
+   endpointer has claimed one continuous utterance for longer than
+   `max_utterance_secs` -- precisely the latch's symptom -- so the caller
+   already computes the signal; it just never acted on it. Re-seeds from the
+   current `chunk_rms`, a live sample of the room, and clears the speech run.
+   Deliberately *not* done on a normal endpoint: that path means the detector
+   is working, and resetting a correctly-adapted floor after every utterance
+   would throw the adaptation away. This does not weaken the "adapt only on
+   non-speech" rule, because a voiced run that long is by the caller's own
+   definition not speech.
+
+Part 2 is what covers the startup case, which part 1 structurally cannot.
+
+**Files:** `crates/stt-agent/src/audio.rs`, `crates/stt-agent/src/main.rs`.
+
+**Verified.** `cargo test --package stt-agent` 39/39 (35 + 4 new);
+`--package voice-agent --package contracts` also green (80 tests across the
+three); `cargo check --workspace` clean. No Python changed. All four new tests
+mutation-tested against the specific defect each exists to catch: the descent
+restored to an outright assignment (the original bug -- caught), the descent
+rate set to zero so it never moves (caught), the reseed made a no-op (caught),
+and the reseed leaving `speech_active` set (caught).
+
+**NOT done:**
+- `NOISE_FLOOR_DESCENT = 0.1` is a reasoned choice, not a measured optimum.
+  M3-R2's own note ("tune against recorded audio") still stands; no recorded
+  room audio exists in this repo, and the synthetic sequences here prove the
+  latch is gone and the descent still tracks, not that 0.1 is the best value.
+- The **initial** `noise_floor` of 0.01 is left as-is. The startup latch is now
+  *recoverable* (after one forced cut, i.e. up to `max_utterance_secs` of false
+  speech) rather than *fixed*; seeding the floor from the first few chunks of
+  real audio would prevent it outright and is the better fix, but it changes
+  startup behaviour and belongs with the tuning pass above.
+- Measurement 1.4 is not re-run; it profiles the final/accurate path, which the
+  whisper hang still blocks, and was never this item's gate.
+- Stage 5's remaining parts -- P2-2's outbound ack and the two documentation
+  leftovers -- next.

--- a/backend/crates/stt-agent/src/audio.rs
+++ b/backend/crates/stt-agent/src/audio.rs
@@ -102,6 +102,15 @@ pub struct Endpointer {
     min_speech_ms: f64,
 }
 
+/// Fraction of the gap to the new (lower) energy that one chunk may close.
+///
+/// P2-8: the descent used to be unbounded -- a single chunk assigned the floor
+/// outright. Asymmetric with the 0.005 rise on purpose, and by a wide margin:
+/// a room getting quieter should be tracked promptly, while a room getting
+/// louder must not be allowed to drag the floor up mid-utterance and deafen
+/// the detector, which is what the rise rate is slow to prevent.
+const NOISE_FLOOR_DESCENT: f64 = 0.1;
+
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum VadEvent {
     /// No speech in progress.
@@ -144,6 +153,30 @@ impl Endpointer {
         self.speech_active && self.speech_run_ms >= self.min_speech_ms
     }
 
+    /// Re-seed the noise floor from a known-current energy level.
+    ///
+    /// P2-8's escape hatch. The floor adapts *only* on non-voiced chunks
+    /// (deliberately -- see `push`), which means that if it ever ends up below
+    /// the room's actual noise level, every chunk reads as voiced, the
+    /// adaptation branch stops running, and nothing can lift it back. That is
+    /// a latch, not a transient: the detector reports speech forever and
+    /// utterances stop endpointing.
+    ///
+    /// Bounding the descent (in `push`) stops a single anomalous chunk from
+    /// causing it, but cannot stop a genuinely long quiet stretch followed by
+    /// the noise returning. So there has to be a way out, and the caller
+    /// already knows when to use it: a forced cut at `max_utterance_secs` means
+    /// the endpointer has claimed one continuous utterance for longer than any
+    /// plausible one, which is exactly the symptom. Re-seeding there does not
+    /// weaken the "adapt only on non-speech" rule, because a run that long is
+    /// by the caller's own definition not speech.
+    pub fn reseed_noise_floor(&mut self, chunk_rms: f64) {
+        self.noise_floor = chunk_rms.max(0.0);
+        self.speech_active = false;
+        self.speech_run_ms = 0.0;
+        self.silence_run_ms = 0.0;
+    }
+
     /// Feed one chunk's energy and duration; returns the resulting VAD event.
     pub fn push(&mut self, chunk_rms: f64, chunk_ms: f64) -> VadEvent {
         let threshold = (self.noise_floor * self.speech_factor).max(self.min_speech_rms);
@@ -153,7 +186,23 @@ impl Endpointer {
         // drag the floor up and deafen the detector mid-utterance.
         if !is_voiced {
             if chunk_rms < self.noise_floor {
-                self.noise_floor = chunk_rms;
+                // P2-8: this used to snap straight to `chunk_rms`. One
+                // anomalous near-silent chunk -- a dropout, a muted frame --
+                // therefore dropped the floor to ~0, after which `threshold`
+                // fell to the flat `min_speech_rms` (0.008). In any room whose
+                // ambient level exceeds that, every later chunk then read as
+                // voiced, this branch stopped running, and the floor could
+                // never recover: a permanently-triggered detector, not a deaf
+                // one. The comment on `min_speech_rms` claims it prevents
+                // exactly this, but it guards the *threshold*, not the floor,
+                // so it never could.
+                //
+                // Descent is bounded instead. Still fast -- at 20ms chunks
+                // this covers most of a genuine drop inside half a second --
+                // but no single chunk can move the floor more than a tenth of
+                // the way down.
+                self.noise_floor =
+                    self.noise_floor * (1.0 - NOISE_FLOOR_DESCENT) + chunk_rms * NOISE_FLOOR_DESCENT;
             } else {
                 self.noise_floor = self.noise_floor * 0.995 + chunk_rms * 0.005;
             }
@@ -234,6 +283,159 @@ mod tests {
         let input = tone(320, 0.25);
         let out = resample_to_16k(&input, 16_000).unwrap();
         assert_eq!(out, input);
+    }
+
+    /// P2-8: one anomalous near-silent chunk must not latch the detector into
+    /// reporting speech forever.
+    ///
+    /// The floor adapts only on non-voiced chunks. Before this fix the descent
+    /// was unbounded -- a single chunk assigned it outright -- so one dropout
+    /// dropped it to ~0, `threshold` collapsed to the flat `min_speech_rms`
+    /// (0.008), and in any room noisier than that every later chunk read as
+    /// voiced. The adaptation branch then never ran again and the floor could
+    /// not recover: not a deaf detector, a permanently triggered one, whose
+    /// utterances stop endpointing and whose barge-in fires on room noise.
+    #[test]
+    fn one_silent_chunk_does_not_latch_the_detector_onto_room_noise() {
+        let mut ep = Endpointer::new(500.0, 100.0);
+        // A room with real ambient noise, well above min_speech_rms (0.008).
+        let ambient = 0.02;
+        for _ in 0..2000 {
+            ep.push(ambient, 20.0);
+        }
+        assert!(
+            !ep.speech_confirmed(),
+            "ambient noise alone must not read as speech before the dropout"
+        );
+
+        // One anomalous frame: a dropout, a muted mic, a lost packet.
+        ep.push(0.0, 20.0);
+
+        // The room has not changed. It must still read as silence.
+        for _ in 0..50 {
+            assert_eq!(
+                ep.push(ambient, 20.0),
+                VadEvent::Silence,
+                "ambient noise read as speech after a single silent chunk -- \
+                 the noise floor latched below the room"
+            );
+        }
+        // And real speech must still be distinguishable from it.
+        assert_eq!(ep.push(0.2, 20.0), VadEvent::SpeechContinues);
+    }
+
+    /// The descent still has to be fast enough to be useful: a room that
+    /// genuinely goes quiet must be tracked, or the detector stays deaf to
+    /// speech that is quiet-but-real. Bounding the rate must not become
+    /// refusing to descend.
+    #[test]
+    fn the_floor_still_follows_a_room_that_genuinely_goes_quiet() {
+        let mut ep = Endpointer::new(500.0, 100.0);
+        // 0.02 is below the initial threshold (0.01 * 3), so it reaches the
+        // adaptation branch and the floor genuinely rises to meet it. Picking
+        // a level *above* that threshold would instead read as voiced from the
+        // first chunk and never adapt at all -- which is its own defect, and
+        // has its own test below.
+        let noisy = 0.02;
+        for _ in 0..2000 {
+            ep.push(noisy, 20.0);
+        }
+        let noisy_floor = ep.noise_floor();
+        assert!(noisy_floor > 0.015, "floor never rose to the room: {noisy_floor}");
+
+        // The room quietens and stays quiet for one second (50 x 20ms).
+        let quiet = 0.001;
+        for _ in 0..50 {
+            ep.push(quiet, 20.0);
+        }
+
+        // Bounding the descent must not become refusing to descend: a second
+        // of quiet has to land the floor near the new level, or the detector
+        // stays deaf to speech that is quiet but real.
+        assert!(
+            ep.noise_floor() < quiet * 2.0,
+            "floor did not follow the room down within a second: {} -> {}",
+            noisy_floor,
+            ep.noise_floor()
+        );
+    }
+
+    /// The same latch, reached without any dropout at all -- found while
+    /// writing the test above.
+    ///
+    /// The floor is constructed at 0.01, so the opening threshold is 0.03. In
+    /// a room whose ambient level is above that, the *very first* chunk reads
+    /// as voiced, the non-speech adaptation branch never runs even once, and
+    /// the floor stays pinned at its default forever. P2-8 describes the
+    /// dropout entry; this one needs nothing to go wrong at all, just a noisy
+    /// room at startup. Bounding the descent cannot help here (the floor never
+    /// descends), which is the clearest argument that the escape hatch is
+    /// required rather than belt-and-braces.
+    #[test]
+    fn a_noisy_room_at_startup_is_recovered_by_the_forced_cut_reseed() {
+        let mut ep = Endpointer::new(500.0, 100.0);
+        let ambient = 0.05; // above the opening threshold of 0.01 * 3
+
+        for _ in 0..200 {
+            assert_eq!(
+                ep.push(ambient, 20.0),
+                VadEvent::SpeechContinues,
+                "precondition: a room this noisy reads as speech from the start"
+            );
+        }
+        assert_eq!(
+            ep.noise_floor(),
+            0.01,
+            "precondition: the floor never adapted, because nothing was ever \
+             classified as non-speech"
+        );
+
+        // This is what `handle_audio_inbound` does once the utterance passes
+        // `max_utterance_secs` without endpointing -- the symptom of the latch.
+        ep.reseed_noise_floor(ambient);
+
+        for _ in 0..50 {
+            assert_eq!(ep.push(ambient, 20.0), VadEvent::Silence);
+        }
+        assert_eq!(ep.push(0.3, 20.0), VadEvent::SpeechContinues);
+    }
+
+    /// The escape hatch. Bounding the descent stops a *single* chunk from
+    /// latching the floor, but cannot stop a genuinely long quiet stretch
+    /// followed by the noise returning -- the floor legitimately follows the
+    /// room down, then the room comes back and every chunk reads as voiced.
+    /// `reseed_noise_floor` is what the forced cut calls to break that, and it
+    /// must restore a detector that can tell noise from speech again.
+    #[test]
+    fn reseeding_recovers_a_detector_that_latched_onto_the_room() {
+        let mut ep = Endpointer::new(500.0, 100.0);
+        // Drive it into the latch directly: a long true silence drops the
+        // floor far below the level the room returns to.
+        for _ in 0..2000 {
+            ep.push(0.0, 20.0);
+        }
+        let ambient = 0.05;
+        // The room comes back. Everything now reads as voiced, and the floor
+        // can never recover on its own.
+        for _ in 0..200 {
+            ep.push(ambient, 20.0);
+        }
+        assert_eq!(
+            ep.push(ambient, 20.0),
+            VadEvent::SpeechContinues,
+            "precondition: the detector is latched onto room noise"
+        );
+
+        ep.reseed_noise_floor(ambient);
+
+        for _ in 0..50 {
+            assert_eq!(
+                ep.push(ambient, 20.0),
+                VadEvent::Silence,
+                "reseeding did not restore the ability to hear the room as quiet"
+            );
+        }
+        assert_eq!(ep.push(0.3, 20.0), VadEvent::SpeechContinues);
     }
 
     #[test]

--- a/backend/crates/stt-agent/src/main.rs
+++ b/backend/crates/stt-agent/src/main.rs
@@ -775,6 +775,21 @@ async fn handle_audio_inbound(
         }
         _ => {
             // Endpoint (or forced cut): close the utterance and transcribe it.
+            if force_cut {
+                // P2-8: a forced cut means the endpointer has claimed one
+                // continuous utterance for longer than `max_utterance_secs`,
+                // which is the exact symptom of a latched noise floor -- a
+                // floor that fell below the room's ambient level, after which
+                // every chunk reads as voiced and the non-speech adaptation
+                // branch that would lift it never runs again. Re-seed from the
+                // current chunk, which is a live sample of whatever the room
+                // actually sounds like now.
+                //
+                // Deliberately not done on a normal endpoint: that path means
+                // the detector is working, and resetting a correctly-adapted
+                // floor after every utterance would throw away the adaptation.
+                guard.endpointer.reseed_noise_floor(chunk_rms);
+            }
             let pcm = std::mem::take(&mut guard.buffer);
             let utt = guard.utterance_id.clone();
             let latency = guard.utterance_latency.take();


### PR DESCRIPTION
M3-R2 describes this as "deafening"; it is the opposite. The floor adapts only on non-voiced chunks, and the descent was an outright assignment, so one near-silent frame dropped it to ~0. `threshold` then fell to the flat `min_speech_rms` (0.008), every chunk in a room noisier than that read as voiced, the adaptation branch stopped running, and the floor could never recover -- a permanently *triggered* detector whose utterances stop endpointing and whose barge-in fires on room noise.

A failing test then surfaced a second entry needing no dropout at all: the floor is constructed at 0.01, so the opening threshold is 0.03, and in any room above that the very first chunk reads as voiced and the floor never adapts even once. Bounding the descent cannot help there, because the floor never descends.

So both halves are required: a rate-limited descent, and `reseed_noise_floor` called from the forced-cut branch only -- a cut past `max_utterance_secs` is exactly the latch's symptom, and the caller already computes it.

stt-agent 39/39, 80 Rust tests green across the three crates, `cargo check --workspace` clean. All four new tests mutation-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)