### PR TITLE
fix: take the JetStream ack off the outbound PCM critical path (P2-2)

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -8700,3 +8700,75 @@ and the reseed leaving `speech_active` set (caught).
   whisper hang still blocks, and was never this item's gate.
 - Stage 5's remaining parts -- P2-2's outbound ack and the two documentation
   leftovers -- next.
+
+## 2026-08-23 -- Stage 5 Part 3 -- P2-2: the outbound PCM ack comes off the
+critical path, but *not* for the reason the roadmap gives
+
+`ROADMAP.md` P2-2 (M3-P3) says to apply the maintainer's own inbound fix in the
+other direction: `publish_pcm` does `.await?.await?`, the same `.await?.await?`
+already removed on the inbound side, so do the same thing. **The pattern
+matches; the payloads do not, and that changes the fix.**
+
+Inbound (`stt-agent/src/main.rs:712-724`) drops the ack on
+`user.voice_properties`, and its comment is explicit about why that is safe:
+*"ephemeral observability samples superseded by the next chunk"*. Losing one
+costs a metric. `publish_pcm` carries **the agent's actual speech**. Losing a
+chunk is an audible gap in what the user hears. Copying the inbound reasoning
+across would have been copying a justification that does not hold here.
+
+**Measured before deciding.** Against the live `nats_mesh` container, 500
+publishes each way on a memory stream: **0.286 ms/chunk awaiting the ack vs
+0.001 ms not** -- 439x -- and **all 1000 messages arrived either way**. The
+cost is not just per-chunk overhead, it *serializes*: chunk N+1 was not sent
+until chunk N was acknowledged, so at 20ms chunks a five-second utterance paid
+~71ms of pure round-trip on the speech path. On loopback. The
+robot-plus-server split the roadmap anticipates would make that far worse,
+which is the case for fixing it at all.
+
+**Fix.** The first `await?` is kept, so send-side failure (connection down, no
+responders) still reaches the caller exactly as before. The ack is **moved off
+the critical path rather than discarded**: awaited on a spawned task that
+`warn!`s if JetStream rejects the message. A stream that is full or erroring is
+still reported. The residual trade is stated rather than buried: a chunk the
+server never accepts is now noticed a moment *after* the fact, in a log line,
+instead of being returned to the caller at the point of publish. That is a real
+weakening of the error path, accepted deliberately for a payload where the
+alternative was 439x latency on the audio the trade exists to protect.
+
+**Files:** `crates/voice-agent/src/main.rs`.
+
+**Verified.** `publish_pcm_does_not_wait_for_the_jetstream_ack` is a real
+integration test against live NATS -- it calls the production `publish_pcm`,
+not a reimplementation. Two assertions, both necessary: the 200 chunks complete
+in well under the serialized ack time, **and all 200 arrive in the stream**,
+because "faster" is only a fix if nothing was lost to get there. The threshold
+is *calibrated in-test* from a real ack round-trip taken moments earlier rather
+than hardcoded, since the RTT is a fraction of a millisecond on loopback and
+much larger across a machine boundary; a fixed number would be meaningless on
+one of the two. Skips loudly without NATS, and skips rather than touching a
+provisioned `AI_AUDIO` -- same shape as stt-agent's
+`real_model_loads_and_perceives_audio` skipping an unprovisioned model.
+Mutation-tested by restoring the awaited ack: caught, with the message naming
+the numbers (`200 chunks took 63.855ms, one ack round-trip is 329.542µs`).
+`cargo test` 77 across the three crates (voice-agent 35 -> 36),
+`cargo check --workspace` clean, clippy clean on the change.
+
+**NOT done:**
+- No **bounded outstanding-ack window**, which the plan named as preferable if
+  cheap. It is not cheap here: `publish_pcm` is a free function called from
+  five sites with no shared context object to hold the window, so it would mean
+  restructuring all five. The spawned-watch approach gets the observability
+  without that, and is where this stops.
+- The end-to-end barge-in measurement (1.1, `tools/measure/m11_bargein.py`) was
+  **not** re-run. `local_voice` is crash-looping (`Restarting (255)`) and the
+  audio path needs it, so the number would not have been real. The per-chunk
+  measurement above is direct evidence for the change; 1.1 would have shown its
+  effect on the full path, and remains worth taking when that container is
+  healthy.
+- `AI_AUDIO` is not provisioned on the running mesh (only `AI_MESSAGES` exists),
+  noticed while measuring. That means `audio.stream` currently has no stream
+  bound to it at all, so **every** outbound publish there is unacked in
+  practice today -- worth knowing, unrelated to this change, and a separate
+  question about whether `setup_nats_streams.py` has been run against this
+  deployment.
+- Stage 5's last part -- the two documentation leftovers -- next.

--- a/backend/crates/voice-agent/src/main.rs
+++ b/backend/crates/voice-agent/src/main.rs
@@ -1319,10 +1319,44 @@ async fn publish_pcm(
         build_latency_metadata(event).to_string(),
     );
 
-    jetstream
+    // audit/ROADMAP.md P2-2 (M3-P3): this used to be `.await?.await?` -- the
+    // second await being JetStream's publish ack, i.e. a full server round-trip
+    // *per PCM chunk*, on the outbound speech path. Worse than the cost, it
+    // serialized: chunk N+1 was not even sent until chunk N had been
+    // acknowledged, so the ack latency was added to time-to-first-audio and to
+    // every gap after it.
+    //
+    // The roadmap frames the fix as applying the maintainer's own inbound fix
+    // in the other direction. **The pattern matches but the payloads do not**,
+    // and the difference matters. Inbound (`stt-agent`, `user.voice_properties`)
+    // drops the ack on "ephemeral observability samples superseded by the next
+    // chunk" -- losing one costs a metric. This is the agent's actual speech:
+    // losing a chunk is an audible gap in what the user hears. So the ack is
+    // not simply discarded here.
+    //
+    // The first `await?` is kept, and still surfaces send-side failure
+    // (connection down, no responders) to the caller as before. The ack is
+    // moved off the critical path rather than dropped: awaited on a spawned
+    // task, so a stream that is rejecting messages -- full, storage error --
+    // is still reported, just not waited for. The residual trade, stated
+    // plainly: a chunk that the server never accepts is now noticed a moment
+    // *after* the fact, in a log line, instead of being returned to the caller
+    // as an error at the point of publish.
+    let ack = jetstream
         .publish_with_headers(topics::AUDIO_STREAM, headers, Bytes::from(pcm))
-        .await?
         .await?;
+
+    tokio::spawn(async move {
+        if let Err(err) = ack.await {
+            warn!(
+                error = %err,
+                subject = topics::AUDIO_STREAM,
+                "JetStream did not acknowledge an outbound audio chunk; \
+                 the listener may hear a gap"
+            );
+        }
+    });
+
     Ok(())
 }
 
@@ -1937,5 +1971,110 @@ mod tests {
         let config = test_voice_config(server.uri());
         let http = Client::new();
         assert!(probe_synthesis(&config, &http).await.is_ok());
+    }
+
+    const STREAM: &str = "P2_2_PUBLISH_PCM_TEST";
+
+    /// P2-2: `publish_pcm` must not wait for JetStream's publish ack.
+    ///
+    /// Needs a live NATS, and skips loudly without one -- same shape as
+    /// stt-agent's `real_model_loads_and_perceives_audio`, which skips when the
+    /// model is unprovisioned. Also skips if a stream already covers
+    /// `audio.stream`, so it can never disturb a provisioned `AI_AUDIO`.
+    ///
+    /// The threshold is measured in-test rather than hardcoded, because the ack
+    /// round-trip depends entirely on where NATS is: on loopback it is a
+    /// fraction of a millisecond, and across the machine boundary the
+    /// robot-plus-server split implies, far more. Calibrating against a real
+    /// round-trip taken moments earlier keeps the assertion meaningful on both.
+    #[tokio::test]
+    async fn publish_pcm_does_not_wait_for_the_jetstream_ack() {
+        let url = std::env::var("NATS_URL")
+            .unwrap_or_else(|_| "nats://127.0.0.1:4222".to_string());
+        let Ok(client) = async_nats::connect(&url).await else {
+            eprintln!("SKIP: no NATS at {url}");
+            return;
+        };
+        let js = async_nats::jetstream::new(client);
+
+        if js.get_stream(STREAM).await.is_ok()
+            || js
+                .get_stream("AI_AUDIO")
+                .await
+                .is_ok()
+        {
+            eprintln!("SKIP: a stream already covers audio.stream; refusing to touch it");
+            return;
+        }
+
+        js.create_stream(async_nats::jetstream::stream::Config {
+            name: STREAM.to_string(),
+            subjects: vec![topics::AUDIO_STREAM.to_string()],
+            storage: async_nats::jetstream::stream::StorageType::Memory,
+            ..Default::default()
+        })
+        .await
+        .expect("create the test stream");
+
+        let event = ChatOutput {
+            content: None,
+            done: false,
+            turn_id: Some("p2-2-test".to_string()),
+            affect: None,
+            timestamp: 0.0,
+            full_response: None,
+            generation_error: None,
+            proactive: false,
+            latency_metadata: None,
+        };
+        let chunk = || vec![0u8; 640]; // ~20ms of 16-bit PCM at 16 kHz
+
+        // Calibrate: one publish whose ack we *do* wait for.
+        let started = std::time::Instant::now();
+        js.publish(topics::AUDIO_STREAM, Bytes::from(chunk()))
+            .await
+            .expect("publish")
+            .await
+            .expect("ack");
+        let ack_rtt = started.elapsed();
+
+        const N: usize = 200;
+        let started = std::time::Instant::now();
+        for _ in 0..N {
+            publish_pcm(&js, chunk(), &event, 1.0)
+                .await
+                .expect("publish_pcm must succeed");
+        }
+        let elapsed = started.elapsed();
+
+        // Awaiting the ack per chunk costs at least N round-trips. A quarter of
+        // that is a wide margin: the point is the difference in kind, not a
+        // tuned number.
+        let serialized = ack_rtt * (N as u32);
+        assert!(
+            elapsed < serialized / 4,
+            "publish_pcm looks like it is still waiting for acks: {N} chunks took \
+             {elapsed:?}, and one ack round-trip alone is {ack_rtt:?} \
+             (serialized would be ~{serialized:?})"
+        );
+
+        // Not waiting must not mean not delivering. This is the half that
+        // matters: outbound PCM is the agent's actual speech, not the ephemeral
+        // observability sample the inbound side drops acks on.
+        let info = js
+            .get_stream(STREAM)
+            .await
+            .expect("stream")
+            .info()
+            .await
+            .expect("stream info")
+            .state
+            .messages;
+        let _ = js.delete_stream(STREAM).await;
+        assert_eq!(
+            info,
+            (N + 1) as u64,
+            "chunks went missing once the ack stopped being awaited"
+        );
     }
 }


### PR DESCRIPTION
`publish_pcm` did `.await?.await?` -- the second await being a full server round-trip per PCM chunk, which also serialized: chunk N+1 was not sent until chunk N was acked.

The roadmap frames this as applying the inbound fix in the other direction. The pattern matches but the payloads do not. Inbound drops acks on "ephemeral observability samples superseded by the next chunk"; this is the agent's actual speech, where a lost chunk is an audible gap. So the ack is moved off the critical path, not discarded: the first `await?` still surfaces send failure, and the ack is watched on a spawned task that warns if JetStream rejects it.

Measured against live NATS before deciding: 0.286 ms/chunk awaiting the ack vs 0.001 ms not (439x), with all 1000 messages arriving either way. At 20ms chunks that is ~71ms of round-trip on a five-second utterance, on loopback.

The test calls the real `publish_pcm` against live NATS and asserts both halves -- fast enough not to be serializing, and all chunks actually delivered. Its threshold is calibrated in-test from a real ack RTT, since a hardcoded number would be meaningless across a machine boundary.

77 Rust tests green, `cargo check --workspace` clean, mutation-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)