### PR TITLE
Consolidate the audit into two standing documents, and fix the voice-sample path bug

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -10701,3 +10701,92 @@ by running the exact CI command:
 
 **NOT done.** Waiting on PR #203's CI to confirm the fix (all five jobs
 re-run green) before considering the branch done.
+
+---
+
+## 2026-08-24 -- Consolidated the audit into two standing documents, and fixed
+## a voice-sample path bug found while writing them
+
+**Why.** The `audit/` directory is thirteen files and ~7,100 lines, plus a
+1,784-line brief at the repo root. It closed as a *process* at nine of nine
+milestones, and most of what it describes is now implemented -- so as a
+**work queue** it had become actively misleading, while remaining valuable
+as an **evidentiary record**. Those are two different jobs and it was doing
+neither cleanly.
+
+**Two new tracked documents, both under `docs/`:**
+
+- **`docs/FUTURE_WORK.md`** -- everything still open, each item carrying
+  What / Why it matters / How / Alternatives rejected / Status. The
+  "alternatives rejected" field is the one that earns its place: it is what
+  stops an item being relitigated every six months. Status vocabulary is
+  five values (OPEN, BLOCKED, TRIGGERED, DECLINED, UNANSWERED), and
+  **TRIGGERED is the one worth noting** -- items that require nothing today
+  and become mandatory the day a named condition holds (TLS when the mesh
+  crosses a machine boundary; proxy-aware `is_loopback_client` if a
+  reverse proxy is ever introduced). Those are the ones a roadmap normally
+  loses.
+- **`docs/BRINGING_IT_TO_LIFE.md`** -- how to actually run the brain, voice
+  and eyes on this laptop, author a personality, and clone a voice. Written
+  against the real resource reality of a 16 GB unified-memory machine
+  rather than against the README's happy path, and explicit that
+  `README.md` overstates completeness (which `CLAUDE.md` already says).
+
+Both are linked from `docs/README.md`'s "Start Here".
+
+**`audit/` stays untracked and was NOT deleted.** Added `audit/INDEX.md`
+(also untracked) marking the directory superseded as a work queue,
+preserved as evidence, with a per-file status table and an explicit list of
+known-stale claims. Deleting ~9,000 lines of untracked analysis is
+unrecoverable -- there is no `git checkout` to undo it -- so consolidation
+here means "index and mark", not "remove". Two stale claims were corrected
+in place, visibly rather than silently:
+
+- `QUESTIONS.md` §2 still advertised three BLOCKING questions that §6 of
+  the same file records as answered on 2026-08-22. Marked stale, kept for
+  its "what the answer changes" analysis.
+- `SECURITY.md` still said rotation was "the one security step that remains
+  genuinely open". Superseded by Item 2's REPLACE finding; struck through
+  and corrected.
+
+**A real bug, found by writing the instructions down.** The voice-cloning
+path in the new operations doc is the system's single highest-return
+unstarted action, so it was walked rather than assumed -- and the two helper
+scripts on it pointed at directories the synthesiser cannot see:
+
+| Script | Wrote/read | Should be |
+| :--- | :--- | :--- |
+| `scripts/audio/record_voice.py` | `backend/scripts/audio/voice_samples/` | `backend/voice_samples/` |
+| `scripts/audio/process_voice_samples.py` | `backend/scripts/voice_samples/` | `backend/voice_samples/` |
+
+`docker-compose.infra.yml:175` bind-mounts **`backend/voice_samples/`** to
+`/workspace/GPT-SoVITS/output`, which is what `REF_AUDIO_PATH=output/...`
+resolves against. Three different paths, none of the wrong two existing on
+disk. `process_voice_samples.py` printed *"No voice samples found in
+`backend/voice_samples/`"* while listing somewhere else entirely -- **the
+message and the code disagreed and both halves ran without complaint**,
+which is this repository's own defining failure pattern in miniature.
+Anyone following the scripts to record a reference clip would have produced
+a file the container never sees, with nothing to indicate why. Both now
+resolve three levels up instead of one or two; verified by asserting the
+resolved path equals the mount source.
+
+**Files.** `docs/FUTURE_WORK.md` (new), `docs/BRINGING_IT_TO_LIFE.md`
+(new), `docs/README.md`, `backend/scripts/audio/record_voice.py`,
+`backend/scripts/audio/process_voice_samples.py`. Untracked and
+intentionally uncommitted: `audit/INDEX.md`, `audit/QUESTIONS.md`,
+`audit/SECURITY.md`.
+
+**Verified.** `ruff check` clean on both scripts; `process_voice_samples.py`
+run and its output now names the directory it actually reads; resolved
+paths asserted equal to the compose mount source; every internal
+cross-document link and anchor checked to resolve (one broken anchor found
+and fixed that way, which is also what the `linkChecker` CI job would have
+caught).
+
+**NOT done.** The `audit/` files themselves are not deleted -- that is the
+user's call, and they are unrecoverable once gone. `FUTURE_WORK.md`'s two
+blocked items (4a `pause_bias`, 4c `tempo_wpm`) are unchanged and still
+need real audio; the missing `sample_en_gold.wav` reference clip is still
+missing, and the script fix above only means that recording one now lands
+where the synthesiser can see it.

--- a/backend/scripts/audio/process_voice_samples.py
+++ b/backend/scripts/audio/process_voice_samples.py
@@ -5,8 +5,17 @@ Helps organize multiple voice files for GPT-SoVITS cloning.
 
 import os
 
-# Move to the project root for relative paths to work correctly
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# `backend/voice_samples/` -- three levels up from this file, not two.
+#
+# This walked up only two levels and landed on `backend/scripts/`, so it listed
+# a directory nothing else in the system uses while its own "no samples found"
+# message named `backend/voice_samples/`. That is the directory that matters:
+# `docker-compose.infra.yml` bind-mounts it to `/workspace/GPT-SoVITS/output`,
+# which is what `REF_AUDIO_PATH=output/...` in `.env` resolves against. A clip
+# anywhere else is invisible to the synthesiser.
+BASE_DIR = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
 SAMPLES_DIR = os.path.join(BASE_DIR, "voice_samples")
 
 

--- a/backend/scripts/audio/record_voice.py
+++ b/backend/scripts/audio/record_voice.py
@@ -40,8 +40,16 @@ def record_audio(duration: int = 120, filename: str = "voice_sample.wav"):
     sd.wait()
     print("⏹️ Recording complete!")
 
-    # Save file
-    output_dir = os.path.join(os.path.dirname(__file__), "voice_samples")
+    # `backend/voice_samples/`, which is the only location the synthesiser can
+    # see: `docker-compose.infra.yml` bind-mounts it to
+    # `/workspace/GPT-SoVITS/output`, and that is what `REF_AUDIO_PATH=output/...`
+    # in `.env` resolves against. This previously wrote to
+    # `backend/scripts/audio/voice_samples/`, so a clip recorded here never
+    # reached the container and the reference-clip setup silently could not work.
+    output_dir = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        "voice_samples",
+    )
     os.makedirs(output_dir, exist_ok=True)
     filepath = os.path.join(output_dir, filename)
 

--- a/docs/BRINGING_IT_TO_LIFE.md
+++ b/docs/BRINGING_IT_TO_LIFE.md
@@ -1,0 +1,535 @@
+# BRINGING IT TO LIFE
+
+**How to run the brain, voice and eyes of your humanoid on this laptop — and give
+it a personality and a voice that are actually its own.**
+
+Written 2026-08-24, against `main` at the merge of PR #203.
+
+This is the operational companion to [FUTURE_WORK.md](FUTURE_WORK.md). That file
+says what is left to build. This one says how to run what exists.
+
+> **A note on tone, deliberately.** `README.md` is the polished front door and it
+> overstates completeness relative to the engineering ledger. This document does
+> not. Where something does not work yet, it says so and names what would fix it,
+> because the fastest way to lose an evening here is to follow a confident
+> instruction for a path nobody has walked.
+
+---
+
+## 0. What you are actually starting
+
+Nine or so processes that talk to each other over a message bus, not one program.
+
+| Layer | What it is | Where it runs |
+| :--- | :--- | :--- |
+| **The brain** | `brain_agent` (the cognitive turn), `system_agent` (ticks, decay), `subconscious_agent` (background reflection, graph persistence), `surfacing_agent` | Python, containers |
+| **Memory** | Postgres (episodes), Qdrant (vectors), Neo4j (the entity graph), Redis (cache) | Containers |
+| **The voice** | `voice_agent` (Rust) → GPT-SoVITS synthesis | Rust container + `local_voice` |
+| **The ears** | `stt_agent` (Rust) — Whisper, plus SenseVoice for tone | Rust container |
+| **The eyes** | `vision_agent` — moondream VLM | Container, **opt-in** |
+| **The mouth/ears wire** | `transport_agent` + LiveKit (WebRTC) | Containers |
+| **Thinking** | Ollama | **Host-native, not a container** |
+
+They coordinate over **NATS JetStream**. Nothing here is a function call between
+components — if two halves disagree about a message shape, both keep running and
+one of them silently stops working. That failure mode is the single most common
+one in this system and §9 is mostly about recognising it.
+
+---
+
+## 1. The machine you are on, honestly
+
+This laptop is an **Apple M5 with 16 GB of unified memory**. That number governs
+almost every decision below, so it is worth being blunt about what it means.
+
+**Unified memory is shared.** The model, the vector store, the graph database, the
+Docker VM and the synthesiser all draw from the same 16 GB. There is no separate
+VRAM to spill into. Running "everything at once" is not a configuration choice
+here; it is the thing that makes the machine swap.
+
+What that implies in practice:
+
+- **Ollama runs on the host, not in Docker.** This is the default and it is
+  deliberate — a containerized Ollama exists behind the `docker-ollama` profile
+  but is not started by a plain `up`. Host-native Ollama gets direct access to the
+  Metal backend; containerized does not.
+- **A 3B model is the working ceiling** (`llama3.2:3b` is the configured
+  `LLM_FAST_MODEL`). This is temporary and acknowledged as such — the roadmap
+  expects a rented GPU for training and a server for the humanoid.
+- **GPT-SoVITS falls back to CPU/FP32 on this machine.** Its image is
+  CUDA-oriented; on Apple silicon it detects no GPU and runs on CPU in FP32, which
+  is memory-heavy and slow. This is why the voice container is the first thing to
+  stop when the machine gets tight.
+- **Do not run the vision profile and the voice stack simultaneously** while you
+  are still learning the system. Each is fine; together on 16 GB they contend.
+
+**Pick a mode rather than starting everything:**
+
+| Mode | What runs | Use it for |
+| :--- | :--- | :--- |
+| **Light** | Cognition, memory, text agents. No WebRTC, no STT, no synthesis. | Personality work, memory work, evals. **Start here.** |
+| **Heavy** | Light + local Whisper STT. | Talking *to* it. |
+| **Full** | Everything: real-time WebRTC voice in and out, voice cloning. | Actually living with it. |
+| **`--profile vision`** | Adds the eyes, on top of any of the above. | Opt-in, separately. |
+
+---
+
+## 2. One-time prerequisites
+
+```bash
+# 1. Ollama, host-native. Install from ollama.com, then:
+ollama serve                      # leave running
+ollama pull llama3.2:3b           # the cognitive model
+ollama pull nomic-embed-text      # embeddings for memory retrieval
+ollama pull moondream             # only if you want the eyes
+
+# 2. Python environment. The venv lives at the REPO ROOT; pytest runs from backend/.
+python3 -m venv .venv
+.venv/bin/pip install -r backend/requirements-dev.txt
+
+# 3. The shared Docker network the mesh attaches to.
+docker network create ai_mesh_network
+
+# 4. Your environment file.
+cp .env.example .env
+```
+
+**Then edit `.env` before you start anything.** A straight unedited copy is
+designed to fail loudly: `.env.example` ships `ENVIRONMENT=production`, which arms
+a guard that refuses to boot on placeholder secrets. That guard exists because a
+silent boot on default credentials is worse than a crash. At minimum set:
+
+- `POSTGRES_PASSWORD`, `NEO4J_PASSWORD` — real values, not the placeholders.
+- `LIVEKIT_KEYS` — format `"apikey: secret"`, and **the secret must be at least 32
+  characters** or LiveKit refuses to start. Note that this environment variable
+  *fully replaces* any keys in `livekit.yaml` rather than merging with them —
+  verified empirically against a real server, not assumed.
+- `NATS_*_PASSWORD` — only if you want the scoped mesh credentials. They are
+  opt-in on both sides; an unconfigured mesh connects exactly as it did before
+  `nats-accounts.conf` existed. Fine to leave unset on a single machine.
+
+---
+
+## 3. First boot
+
+### Step 1 — infrastructure
+
+```bash
+docker compose -f docker-compose.infra.yml -f docker-compose.prod.yml \
+  up -d postgres neo4j redis nats livekit
+```
+
+Container names are not the service names, which matters when you go looking:
+`postgres` → `postgres_db`, `neo4j` → `brain_graph`, `redis` → `brain_cache`,
+`nats` → `nats_mesh`, `livekit` → `local_sfu`, `qdrant` → `brain_vectors`,
+`gpt-sovits` → `local_voice`.
+
+Wait for health before continuing:
+
+```bash
+docker ps --format "table {{.Names}}\t{{.Status}}"
+```
+
+### Step 2 — hydrate the schema
+
+Postgres is mapped to host port **5433**, not 5432, to avoid colliding with a
+local install.
+
+```bash
+export DIRECT_URL="postgresql://ai_friend:YOUR_DB_PASSWORD@127.0.0.1:5433/ai_friend_db"
+cd frontend && npx prisma generate && npx prisma db push && cd ..
+```
+
+### Step 3 — write the personality *before* the first agent boot
+
+**This is the step with a one-way door in it.** See §4. Do it now, not later.
+
+### Step 4 — start the agents
+
+```bash
+# Light — recommended for a first run
+docker compose -f docker-compose.infra.yml -f docker-compose.prod.yml \
+  -f docker-compose.light.yml up -d --build
+
+# Heavy — adds local STT
+docker compose -f docker-compose.infra.yml -f docker-compose.prod.yml \
+  -f docker-compose.heavy.yml up -d --build
+
+# Full — everything
+docker compose -f docker-compose.infra.yml -f docker-compose.prod.yml up -d --build
+```
+
+If Apple-silicon builds time out compiling PyTorch, build the cached layers
+sequentially first:
+
+```bash
+docker build -t ai-friend/base:v1 -f backend/Dockerfile.base ./backend
+docker build -t ai-friend/full:v1 --build-arg BASE_IMAGE=ai-friend/base:v1 \
+  -f backend/Dockerfile.full ./backend
+```
+
+---
+
+## 4. Giving it a personality
+
+Two files, and they do genuinely different jobs. Getting this distinction right is
+most of what makes the result feel like a person rather than a chatbot with a
+system prompt.
+
+### `config/persona.toml` — temperament
+
+Who they *are*: name, tone, the few sentences that colour every reply, and the
+numeric temperament that drives affect.
+
+**It is read exactly once, on the very first boot, and then never again.** Editing
+it later changes nothing; the log will tell you it was skipped.
+
+That is not a limitation, it is the design. The reasoning, from the source itself:
+a file that keeps re-asserting who someone is means *they can never grow away from
+the document, and the document is always the least current description of them.*
+After first boot, everything lives in the durable store and evolves through
+reflection.
+
+Fields sort into three tiers, enforced by the schema rather than by convention:
+
+| Tier | Meaning | Editable? |
+| :--- | :--- | :--- |
+| **CONSTITUTIONAL** | Temperament — who they fundamentally are. Reflection does not rewrite these. | Seeded once |
+| **ADAPTIVE** | Where the *relationship* starts. Trust, attachment. These move on their own. | Seeded once, then owned by the agent |
+| **IMMUTABLE** | Safety invariants. **Not in the file and cannot be put in it** — naming one is rejected with a warning. | Never |
+
+Bounds are deliberately tighter than the maths permits, each guarding a specific
+failure mode. `mood_decay_rate` must be `> 0` because zero is a permanent mood
+lock. `baseline_valence` is capped at ±0.6 because *a friend pinned at maximum
+happiness can never be sad with you.* **The rule behind all of them: a personality
+may be shaped, but it must remain moveable.** A character who cannot be affected by
+what happens to them is a puppet.
+
+Two temperament fields worth understanding, because they are the ones people get
+wrong: `dopamine_halflife_s` (default 90 s) and `cortisol_halflife_s` (default
+600 s) are **CONSTITUTIONAL, not deployment settings.** How long a reward glows and
+a fright lingers *is* temperament. A friend whose cortisol half-life is an hour is
+a different person from one whose is a minute.
+
+### `config/biography.md` — history
+
+Everything that is only *sometimes* relevant. This file is **not** pasted into the
+prompt — each blank-line-separated paragraph becomes one episodic memory, tagged
+with the heading it sits under. Only passages relevant to what is being said come
+back. That is what lets it be long.
+
+How to write it well:
+
+- **Prose, not bullet-point facts.** "She goes quiet when she is angry rather than
+  loud, and it takes a day" recalls far better than `trait: reserved`, because
+  retrieval matches on meaning.
+- **One idea per paragraph** — it becomes one memory and surfaces cleanly alone.
+- **You can extend it later.** Only new passages are seeded; existing ones are left
+  alone, so adding to it never duplicates.
+
+### Starting over
+
+```bash
+cd backend && ../.venv/bin/python -m scripts.reset_persona
+```
+
+Clears the stored persona and every file-seeded memory so the next boot re-reads
+both files as if it were the first. **Memories from real conversations are kept.**
+It requires typing a confirmation phrase in full rather than a `y/n` — the
+destructive half is irreversible, and a reflexive "y" is the most likely way to
+lose a persona someone spent an evening writing.
+
+Inspect what is actually loaded at any point:
+
+```bash
+cd backend && ../.venv/bin/python -m scripts.show_persona
+```
+
+---
+
+## 5. Giving it a voice
+
+GPT-SoVITS clones **zero-shot from a reference clip**. There are two levels, and
+you almost certainly want the first.
+
+### Level 1 — a cloned voice from one clip (minutes)
+
+Whatever audio sits at the reference path *is what your humanoid sounds like*.
+
+```bash
+cd backend && ../.venv/bin/python scripts/audio/record_voice.py
+# It asks for a duration (default 120 s) and a filename.
+# For a REFERENCE clip, answer ~8, not 120. The 120 s default is sized for a
+# fine-tuning dataset (Level 3), not for zero-shot cloning.
+```
+
+It saves into `backend/voice_samples/`, which is the only directory the
+synthesiser can see — `docker-compose.infra.yml` bind-mounts it to
+`/workspace/GPT-SoVITS/output`, and that is what `output/...` resolves against.
+
+Then point `.env` at the clip:
+
+```bash
+REF_AUDIO_PATH=output/sample_en_gold.wav
+REF_TEXT=the exact transcript of that clip, word for word
+```
+
+The path is `output/...` because `backend/voice_samples/` is mounted into the
+container at `/workspace/GPT-SoVITS/output`. **`REF_TEXT` must match the audio
+exactly** — the model conditions on the pairing, and a wrong transcript degrades
+every utterance.
+
+For the reference clip itself: **5–10 seconds, clean, neutral tone, no background
+noise, no music, one speaker.** Longer is not better. Neutral matters because
+everything else is modulated *relative* to it.
+
+> ### ⚠️ Known gap, and the first thing you will hit
+>
+> `backend/voice_samples/` is **empty**, and nothing in the repository provisions
+> `sample_en_gold.wav` — but the bootstrap and healthcheck scripts both probe it.
+> Result: `local_voice` boots, loads weights, serves on 9871, and its healthcheck
+> returns **400 Bad Request** forever.
+>
+> **Recording your own clip and setting `REF_TEXT` is what fixes this**, and it is
+> the same action as choosing the voice. Tracked as
+> [FUTURE_WORK.md §1.3](FUTURE_WORK.md#13--the-missing-reference-clip).
+
+### Level 2 — four emotional reference clips (an evening)
+
+The agent selects a reference per turn from its own affect state. Record four more
+clips in the same voice — calm, warm, concerned, excited — and set both members of
+each pair:
+
+```bash
+REF_AUDIO_PATH_CALM=output/calm.wav
+REF_TEXT_CALM=transcript of the calm clip
+# ...WARM, CONCERNED, EXCITED likewise
+```
+
+**Both members of a pair must be set together**, or the whole pair is ignored — a
+lone audio path with no transcript is worse than falling back to neutral. Any
+unset pair silently falls back, so setting none behaves exactly like the
+single-clip setup. This is the single highest-return thing you can do for
+perceived humanness right now, because it makes affect *audible* rather than just
+modelled.
+
+### Level 3 — a fine-tuned voice (a day, plus a GPU)
+
+Train dedicated weights and point at them:
+
+```bash
+CUSTOM_GPT_PATH=GPT_weights/ai_friend_voice.ckpt
+CUSTOM_SOVITS_PATH=SoVITS_weights/ai_friend_voice.pth
+```
+
+See [GPT_SOVITS_INSTALL.md](GPT_SOVITS_INSTALL.md). Realistically this belongs on
+the rented GPU, not here. Use `scripts/audio/process_voice_samples.py` to organise
+a multi-file training set.
+
+### What is *not* wired yet
+
+`pause_bias` — arousal-driven pause length — is computed and then thrown away.
+Every other prosody dimension drifts across an utterance; pause length is frozen.
+See [FUTURE_WORK.md §1.1](FUTURE_WORK.md#11--pause_bias-arousal-driven-pause-length).
+`tempo_wpm` is worse: it is measured wrongly, and §1.2 explains why wiring it as-is
+would make the agent *less* human.
+
+**There is deliberately no fallback voice.** If synthesis fails, it stays silent
+rather than speaking in a different voice — a friend whose voice changes mid-
+conversation is not a friend. The circuit-breaker settings govern same-engine
+recovery only.
+
+---
+
+## 6. Giving it eyes
+
+Vision is **opt-in**, gated behind a profile, and not part of a default `up`:
+
+```bash
+docker compose -f docker-compose.infra.yml -f docker-compose.prod.yml \
+  --profile vision up -d vision_agent
+```
+
+It uses `moondream` through host Ollama for visual appraisal and spatial
+reasoning. On Linux, screen capture and camera passthrough need the X11 volume and
+`/dev/video0` device lines uncommented in `docker-compose.prod.yml`; on macOS,
+camera passthrough into Docker is not straightforward and this is one of the
+places the system is genuinely less capable on this host.
+
+**Privacy boundaries already in force**, worth knowing before you point a camera
+at your life:
+
+- Screen captures carry a hard TTL — `VISUAL_SCREEN_TRACE_TTL_H`, default **24
+  hours**.
+- Camera traces follow the normal memory lifecycle (ACT-R decay).
+- Dead-letter logging records a payload's length and SHA-256, **not** its content —
+  changed specifically because it had been putting user speech into log files.
+
+The open question nobody has answered: whether persisted *screen* content should
+be stored at all, as distinct from live capture. See
+[FUTURE_WORK.md](FUTURE_WORK.md#part-4--unanswered-questions), Q-M6-1′.
+
+---
+
+## 7. Verifying it is actually alive
+
+Container health is not aliveness. Everything in this system is built so that a
+broken half keeps running and logging normally, so check the seams.
+
+```bash
+# 1. Everything up?
+docker compose -f docker-compose.infra.yml -f docker-compose.prod.yml ps
+
+# 2. Do the message subjects actually connect at both ends?
+cd backend && ../.venv/bin/python scripts/check_subject_wiring.py
+```
+
+That second one is the important one. It is the CI gate for the defining failure
+mode of this architecture. Seven subjects are currently allowlisted with
+individual written justifications — that is expected. What you care about is
+anything *new*.
+
+```bash
+# 3. Does it still behave the way it did yesterday?
+cd backend
+../.venv/bin/python -m evals run --model llama3.2:3b --out evals/out/today.json
+../.venv/bin/python -m evals compare evals/out/baseline.json evals/out/today.json \
+    --fail-on-regression
+```
+
+**Pass `--model` explicitly.** The client's hardcoded default is `llama3.2:1b`,
+which is probably not pulled — and a run against a missing model returns "Error
+generating response." for *every* probe, scoring 0/48 while looking like a
+completed run. Matching totals on both sides of a comparison is not by itself
+evidence of anything.
+
+```bash
+# 4. Does a fact survive distance? (needs Postgres, Qdrant, Neo4j up)
+../.venv/bin/python -m evals run-conversation --model llama3.2:3b \
+    --retrieval bm25 --retrieval memory --num-ctx 8192 --out evals/out/recall.json
+```
+
+Two failure modes are surfaced rather than scored, because either makes the number
+meaningless rather than merely low: **`plant out`** (the strategy never showed the
+model the fact) and **`fits NO`** (context exceeded `num_ctx`, and truncation
+happens from the front, which is exactly where the planted fact sits).
+
+⚠️ **`--retrieval memory` writes every transcript turn into the live stores** and
+removes them at the end. Point it at a throwaway database unless you mean to write
+into your agent's actual memory.
+
+And the repo's own bar, before you consider any change done:
+
+```bash
+cd backend
+../.venv/bin/python -m pytest -q --junit-xml=/tmp/res.xml   # parse the XML
+../.venv/bin/python -m ruff check .
+cargo check --workspace && cargo test --package stt-agent --package voice-agent --package contracts
+```
+
+**Parse the XML.** Pytest's terminal summary is unreliable in this repo — the final
+`N passed` line and even whole `=== FAILURES ===` sections get swallowed, verified
+on both macOS and Windows and not a terminal-truncation artefact. Do not trust the
+dots.
+
+---
+
+## 8. Day to day
+
+```bash
+# Watch it think
+docker logs -f brain_agent
+
+# Stop the voice stack when the machine gets tight (this is normal on 16 GB)
+docker stop local_voice
+
+# After changing anything in backend/app/contracts.py
+cd backend && ../.venv/bin/python scripts/bootstrap/setup_nats_streams.py
+```
+
+That last one is not optional. `contracts.py` defines the models that cross agent
+boundaries; changing one without re-running the stream setup produces exactly the
+silent-mismatch failure this architecture is prone to.
+
+---
+
+## 9. When it breaks
+
+The failure modes that actually happen, in rough order of frequency.
+
+**A container crash-loops with `exec ... permission denied`.**
+`docker-compose.infra.yml` bind-mounts several bootstrap scripts directly over
+their in-container paths. A bind mount **completely replaces** the image's baked-in
+copy, so the Dockerfile's own `RUN chmod +x` never applies at runtime — the *host*
+file's permission bits are what the container executes. Fix with `chmod +x` on the
+host file. (This exact bug ran unnoticed as a standing crash-loop under
+`restart: always` until 2026-08-24.)
+
+**`local_voice` is healthy-ish but every synthesis returns 400.** The missing
+reference clip. See §5.
+
+**LiveKit refuses to start.** Either the secret is under 32 characters, or
+`LIVEKIT_KEYS` is set to an empty string — which is not a silent fallback to the
+config file, it is a hard refusal. Unset the variable entirely if you want
+`livekit.yaml`'s keys to apply.
+
+**An agent connects but hears nothing.** If you configured scoped NATS
+credentials, note that **a denied subscribe never raises on the caller.** It
+surfaces only through `error_cb` — a logged error and a quietly deaf subscription.
+A too-narrow grant does not crash; it silently stops working. Check
+`nats-accounts.conf` against what that agent actually subscribes to.
+
+**A cognitive turn gets redelivered / acked twice.** `BaseAgent.subscribe` acks
+only after the callback returns, and a turn can run to `LLM_STREAM_MAX_SECONDS`
+(120 s) — well past JetStream's default AckWait. Read finding **A1** in
+`.agents/CONTEXT.md` before touching long-running consumers.
+
+**Affect changes are lost or interleave strangely.** `StateService` owns *all*
+mutation behind `self._state_lock`, and a fire-and-forget System-2 appraisal task
+writes concurrently with the synchronous path. Route new affect changes through a
+`StateService` method; never touch `current_state` fields directly. Hormone bursts
+in particular must go through the wrappers — burst peaks are computed relative to
+the tonic floor, so an unlocked release interleaving with a valence write measures
+its peak against a floor that no longer exists.
+
+**Ollama "model not found" during evals.** Pass `--model` explicitly. See §7.
+
+---
+
+## 10. What "a person living in this system" honestly needs next
+
+The parts that make this feel like a person rather than a pipeline, ranked by
+return on effort *from where the system actually is today*:
+
+1. **Record the reference clip.** (§5, Level 1.) It is the single blocking gap
+   between "the voice stack runs" and "the voice stack works", and it is also how
+   you choose what your humanoid sounds like. Minutes of work.
+2. **Record the four emotional clips.** (§5, Level 2.) This is what makes affect
+   *audible*. The system already models emotion end to end and already selects a
+   clip per turn from its own state — it just currently has one clip to choose
+   from. An evening.
+3. **Write the biography properly.** (§4.) The retrieval layer is the most
+   developed part of this codebase — a learned mental lexicon built from the
+   agent's own conversation, ACT-R activation, graph boost, cue expansion. It has
+   very little to retrieve *from* until you write something worth retrieving.
+4. **Wire `pause_bias`, then fix and wire `tempo_wpm`.**
+   ([FUTURE_WORK.md §1.1–1.2](FUTURE_WORK.md#part-1--open-engineering-work).) The
+   last two frozen dimensions of delivery. Both need real audio to verify, which
+   is why they are the first things to do *after* you have a microphone set up for
+   step 1 anyway.
+5. **Run the nine pressure scenarios.**
+   ([FUTURE_WORK.md §5.2](FUTURE_WORK.md#52--the-nine-pressure-scenarios).) Nobody
+   has measured this system under simultaneous multimodal load. On 16 GB that is
+   the measurement that decides what is actually livable on this machine versus
+   what needs the server.
+6. **The consolidation loop / fine-tuned adapter.**
+   ([FUTURE_WORK.md §6.1](FUTURE_WORK.md#61--consolidation-and-the-fine-tuned-adapter-cvs-4).)
+   The long arc. The quality being chased is a post-training problem, not a scale
+   problem — which is exactly why this, and not a bigger model, is the item that
+   matters most in the end.
+
+**A closing caution that is load-bearing.** Documented benchmark figures in this
+repo are placeholders (`[TBP]`), and `MOCK_LLM_TEXT=true` returns hardcoded strings
+fitted to one demo corpus. No headline latency or Recall@K number has been measured
+against real infrastructure. When you are deciding whether this system is ready to
+live with, measure it yourself — and state targets as targets until you have.

--- a/docs/FUTURE_WORK.md
+++ b/docs/FUTURE_WORK.md
@@ -1,0 +1,514 @@
+# FUTURE_WORK.md — everything still open, and why
+
+**Standing as of 2026-08-24**, after the engineering roadmap (Stages 0–6, PR #202)
+and its leftovers pass (PR #203) both merged to `main`.
+
+This file replaces thirteen audit documents and a 1,784-line brief as the place to
+look for *what is left to do*. Those documents are still on disk under `audit/`
+(untracked, local only) and remain the evidentiary record — every finding ID cited
+below resolves there. What they are not is a work queue: they were written on
+2026-08-22, before any of it was implemented, and most of what they describe is now
+done.
+
+**The engineering ledger, `.agents/CONTEXT.md`, is still ground truth.** This file
+is a forward-looking index into it. Where the two disagree, the ledger is right.
+
+---
+
+## How to read this
+
+Every item carries the same five fields, because the thing that makes a roadmap
+rot is recording *what* without recording *why*:
+
+- **What** — the defect or gap, in one paragraph, with `file:line` where it exists.
+- **Why it matters** — what a user or the system actually loses. If this field is
+  weak, the item probably should not be done.
+- **How** — the approach that was chosen, concretely enough to start from.
+- **Alternatives rejected** — and the reason. This is the field that stops an item
+  from being relitigated every six months.
+- **Status** — one of:
+
+| Status | Meaning |
+| :--- | :--- |
+| **OPEN** | Should be done. Nothing blocks it but time. |
+| **BLOCKED** | Decided and specified, but waiting on something outside the code. |
+| **TRIGGERED** | Do nothing now. Becomes mandatory the day a named condition holds. |
+| **DECLINED** | Deliberately not doing. Recorded so it is not re-opened by accident. |
+| **UNANSWERED** | A question, not a task. Someone has to decide. |
+
+---
+
+# Part 1 — Open engineering work
+
+Two items, both from the same finding cluster (P4-10: "signals computed but never
+consumed"), both blocked on the same thing: **real audio**.
+
+Everything else P4-10 named is done. `turn_taking_probability` was verified over
+the reachable state space and wired into proactive-speech gating; the dead-code
+test was identified and fixed. These two are what is left, and they are left
+because verifying them needs a microphone and a running synthesiser, not because
+they are hard.
+
+## 1.1 — `pause_bias`: arousal-driven pause length
+
+**Status: BLOCKED** (needs `local_voice` / GPT-SoVITS running for real synthesis).
+Finding **M3-D1**, roadmap **P4-10**, plan Item 4a.
+
+### What
+
+`vad_to_prosody` derives `pause_bias` as `1.0 - arousal`
+(`backend/crates/contracts/src/lib.rs:345-346`). `clamp_prosody` re-clamps it
+(`backend/crates/voice-agent/src/main.rs:91`). `OlaCrossfadeFilter` includes it in
+the equality test that decides whether a crossfade fires. And **nothing applies it
+to any pause duration** — the modulation path hardcodes the multiplier to `1.0`
+(`:129`). Pause lengths come solely from the literal `<pause=Nms>` tags the LLM
+emits, identically whether the agent is calm or frightened.
+
+### Why it matters
+
+Humans compress pauses when aroused and stretch them when calm or tired. Pause
+length is the one temporal dimension of delivery still frozen. After P3-13
+(Stage 6 Part 6), every *other* prosody dimension already drifts across an
+utterance via `ProsodyTrajectory::prosody_now()`. This is a gap in a system that
+is otherwise finished: arousal-driven pacing is wired end to end except the end
+that makes it hearable.
+
+### How
+
+Keep `split_temporal_parts` (`voice-agent/src/main.rs:1251`) **pure** — it keeps
+parsing tags to `TemporalPart::Silence(ms)` / `Hesitation(350)`, so its existing
+test at `:1582` stays valid. Scale at the **consumption** site, where prosody is
+known, sampling `prosody_now()` at the moment the pause is emitted so pause length
+drifts with the trajectory exactly as rate, pitch and volume already do.
+
+Multiplier `0.6 + 0.8 × pause_bias`, giving a `[0.6, 1.4]` range. Re-apply the
+existing 5000 ms clamp **after** scaling, not before — scaling a pre-clamped value
+can exceed the cap.
+
+**Verify before wiring.** Synthesize one fixed utterance containing several
+`<pause=Nms>` tags through the real TTS path at a high-arousal and a low-arousal
+state, and measure the rendered PCM. Three criteria, all required:
+
+1. Total rendered silence differs between the two states by a margin matching the
+   multiplier (≈2.3× between extremes) — **measured on the PCM**, not asserted
+   from the code.
+2. Total utterance duration shifts accordingly, proving the change survives into
+   the audio rather than being absorbed by the synthesis loop.
+3. No artefact at the seams. This is the real risk: `pause_bias` is already part of
+   the crossfade equality test, so changing what it does changes *when a crossfade
+   fires*.
+
+If 1 or 2 fails, the value is being overwritten downstream — find where before
+wiring. If 3 fails, the multiplier range is wrong, not the idea; narrow it and
+re-measure.
+
+### Alternatives rejected
+
+- **Scaling inside `split_temporal_parts`.** Rejected: it would break that
+  function's purity and invalidate its existing test, and — decisively — a pure
+  parser cannot sample `prosody_now()`, so pause length would be constant across
+  an utterance instead of drifting with the trajectory. The drift is the point.
+- **Shipping it unverified because the code is obviously right.** Rejected on
+  principle: this repo has a standing rule that a signal is wired only after it is
+  shown to help. Pause scaling is audible on *every* utterance, which makes it the
+  worst candidate for an unverified change.
+
+### What unblocks it
+
+`local_voice` running (see [1.3](#13--the-missing-reference-clip) — its healthcheck
+is also broken) plus enough headroom to run CPU-mode GPT-SoVITS. On a 16 GB
+machine that realistically means not running the vision profile at the same time.
+
+---
+
+## 1.2 — `tempo_wpm`: fix the measurement, verify it, then entrain
+
+**Status: BLOCKED** (needs a real recording session).
+Finding **M3-A17**, roadmap **P4-10**, plan Item 4c.
+
+### What
+
+`estimate_tempo_wpm` (`backend/crates/stt-agent/src/main.rs:917`) computes a
+zero-crossing rate and maps it to `120 + min(zcr·200, 60)`. **ZCR measures spectral
+brightness — fricative content — not speaking rate**, and the output is
+structurally confined to `[120, 180]` wpm no matter how fast anyone talks. It is
+published on `user.voice.properties` under a name that asserts otherwise. Its only
+consumer today is a log line (`backend/app/agents/brain_agent.py:608`).
+
+### Why it matters
+
+Speech-rate entrainment — humans unconsciously converging toward an interlocutor's
+tempo — is a genuine humanoid feature and would be the largest human-likeness win
+of the three P4-10 signals.
+
+**But entraining to this number would make the agent less human, not more.** It
+would converge on a value that does not track the user at all and does not vary
+outside a 60-wpm band. Acting on a wrong signal is worse than acting on none. That
+is why "wire it up" is the wrong instruction for this one, and why it splits into
+three ordered pieces.
+
+### How
+
+**(i) Fix the measurement — correctness, do this regardless.** The problem is
+*where* it is computed: `estimate_tempo_wpm` runs per inbound audio chunk
+(`main.rs:746`), in the VAD loop, **where no transcript exists yet**. Real speaking
+rate needs words and duration, and the crate has both at the final-transcript
+point. Compute `words / duration_minutes` there, carry it in session state, and
+have the per-chunk `UserVoiceProperties` publish the last completed utterance's
+measured rate. Before the first completed utterance there is no rate — make the
+contract field `Option<f64>` in **both** `crates/contracts/src/lib.rs` and
+`backend/app/contracts.py`, and publish `None` rather than a fabricated default.
+Delete `estimate_tempo_wpm`.
+
+**(ii) Verify the corrected number before wiring anything to it.** Record three
+passes of the same scripted paragraph — slow, natural, fast — via
+`backend/scripts/audio/record_voice.py`, and compare measured WPM against
+hand-counted ground truth (`words ÷ stopwatch duration`). Criteria:
+
+1. **Rank order holds:** slow < natural < fast, every time. An estimator that
+   cannot order three deliberately different tempos is unusable however good its
+   absolute error.
+2. **Absolute error within ~15%** of hand-counted truth on the natural pass.
+3. **Range exceeds the old band.** The ZCR proxy was trapped in `[120, 180]`; if
+   the corrected number does not move outside that on the slow and fast passes,
+   nothing has actually been fixed.
+
+If it fails, the likely cause is duration accounting — whether the measured window
+includes leading/trailing silence the endpointer kept. Fix the window, re-measure.
+Do not proceed to (iii) on a number that failed here.
+
+**(iii) Wire it — partial entrainment.** Feed the verified rate into the agent's
+own prosody `rate` so delivery converges **partway** toward the user's tempo:
+`agent_rate = base_rate × (1 + k × (user_rate / reference_rate − 1))` with
+`k ≈ 0.3`, clamped to the existing prosody rate bounds. Verify the wiring on PCM,
+not just the signal: a fast-speaking user measurably shortens the agent's rendered
+utterance and a slow one lengthens it, and the clamp holds at both extremes.
+
+### Alternatives rejected
+
+- **Full convergence (`k = 1.0`).** Rejected: matching a speaker's tempo exactly
+  reads as mimicry rather than rapport. Partial convergence is what the phenomenon
+  actually looks like in humans.
+- **Keeping `estimate_tempo_wpm` and calibrating it.** Rejected: ZCR is not a noisy
+  proxy for speaking rate, it is a measurement of a different physical quantity.
+  No calibration constant fixes a category error.
+- **Publishing a default (e.g. 150 wpm) before the first utterance.** Rejected: a
+  fabricated default is indistinguishable downstream from a measured one. `Option`
+  makes "we do not know yet" representable, which is the honest state.
+
+### Risks specific to this item
+
+- **It changes a published contract field to `Option`.** The Rust mirror and
+  `contracts.py` must change **together** — a one-sided change is exactly the
+  silent-drop failure mode that produced the `char_offset` / `character_offset`
+  bug found in Stage 6 Part 9. Re-run
+  `backend/scripts/bootstrap/setup_nats_streams.py` after the contract change.
+- **It compounds with [1.1](#11--pause_bias-arousal-driven-pause-length).**
+  Entrainment moves prosody `rate` while pause scaling moves silence; both change
+  perceived tempo. **Verify them independently before enabling both**, or a
+  regression in one will be attributed to the other.
+
+---
+
+## 1.3 — The missing reference clip
+
+**Status: OPEN** (needs an audio asset, not code). Found 2026-08-24 while fixing an
+unrelated crash-loop; no finding ID — it predates the audit's coverage.
+
+### What
+
+`backend/scripts/bootstrap/sovits_bootstrap.sh:88` and `sovits_healthcheck.sh` both
+POST against a fixed reference clip, `output/sample_en_gold.wav`, mounted from the
+host's `backend/voice_samples/` (`docker-compose.infra.yml:175`). **The file does
+not exist**, `backend/voice_samples/` is empty, and nothing in the repository
+provisions it — not a bootstrap script, not a provisioning script, not the docs.
+Every call returns 400 Bad Request.
+
+`.env.example:157-158` describes this exact clip and its transcript as "the
+always-present neutral clip GPT-SoVITS conditions delivery on", implying it is
+expected to exist. It never did.
+
+### Why it matters
+
+It is the difference between the voice stack starting and the voice stack
+appearing to start. The container boots, loads weights, serves on 9871 — and its
+healthcheck fails forever, so `local_voice` never reports healthy and anything
+gated on that health never proceeds. It also **blocks [1.1](#11--pause_bias-arousal-driven-pause-length)**,
+which needs real synthesis to verify.
+
+More importantly: this clip *is* the voice. GPT-SoVITS clones zero-shot from a
+reference clip, so whatever audio lands at this path is what the agent sounds
+like. See
+[BRINGING_IT_TO_LIFE.md § Giving it a voice](BRINGING_IT_TO_LIFE.md#5-giving-it-a-voice).
+
+### How
+
+Record (or license) a clean 5–10 s neutral-tone clip, place it at
+`backend/voice_samples/sample_en_gold.wav`, and set `REF_TEXT` in `.env` to its
+**exact** transcript. Then decide whether the repo should ship a reference clip at
+all, or whether `voice_samples/` should stay empty-by-design with the bootstrap
+scripts made to skip the probe gracefully when no clip is present.
+
+### Alternatives rejected
+
+- **Generating a synthetic clip to satisfy the healthcheck.** Rejected: a
+  synthesised reference makes the cloned voice a copy of a copy, and a healthcheck
+  that passes against a fake asset is worse than one that fails honestly.
+- **Deleting the healthcheck probe.** Rejected as the *first* move — the probe is
+  the only thing that distinguishes "server up" from "server can actually
+  synthesise". If the decision is that no clip ships, the probe should be made
+  conditional, not removed.
+
+### Related bug, fixed 2026-08-24
+
+The two helper scripts on this exact path pointed at directories the synthesiser
+cannot see. `record_voice.py` saved to `backend/scripts/audio/voice_samples/` and
+`process_voice_samples.py` listed `backend/scripts/voice_samples/`, while the only
+directory that matters — the one `docker-compose.infra.yml:175` bind-mounts to
+`/workspace/GPT-SoVITS/output`, and therefore the one `REF_AUDIO_PATH=output/...`
+resolves against — is `backend/voice_samples/`. Three different paths.
+
+`process_voice_samples.py` printed *"No voice samples found in
+`backend/voice_samples/`"* while looking somewhere else entirely, which is this
+repo's own defining failure pattern in miniature: **the message and the code
+disagreed, and both halves ran without complaint.** Anyone recording a reference
+clip by following the scripts would have produced a file the container never sees
+and had no way to tell why. Both now resolve to `backend/voice_samples/`.
+
+---
+
+# Part 2 — Deferred by trigger
+
+Nothing to do now. Each becomes mandatory the day its condition holds, and each is
+recorded here because the condition is easy to meet without noticing.
+
+## 2.1 — TLS across the mesh
+
+**Trigger: the day the mesh crosses a machine boundary.**
+
+`nats-accounts.conf` ships per-agent users with per-subject permissions, verified
+against a real `nats-server` 2.14.5 (finding **M4-S1**, roadmap **P2-1**). The
+**accounts half is done; the TLS half was deliberately deferred**, because
+single-host with all ports bound to `127.0.0.1` (P0-2) means the mesh is not
+reachable off-box and TLS would buy nothing.
+
+That reasoning expires the moment the humanoid-plus-server split in
+[Part 6](#part-6--the-long-arc) happens, which is a stated goal. **Do not ship that
+split without TLS on the mesh.**
+
+**Known limitation, already recorded in the file itself:** a denied *subscribe*
+never raises on the caller. It surfaces only through `error_cb` — a logged error
+and a quietly deaf subscription. A grant that is wrong in the too-narrow direction
+does not crash; it silently stops working.
+
+## 2.2 — The loopback trust exemption
+
+**Trigger: the day a TLS-terminating reverse proxy is introduced.**
+
+`is_loopback_client` trusts the loopback host with no key — a deliberate decision
+for zero-config single-machine setups, and correct today (finding **M4-S4**, which
+M7 withdrew as a false positive on the confirmed no-proxy topology).
+
+**Behind a proxy, every request arrives from loopback, so every caller becomes
+trusted.** If a proxy is ever introduced, `is_loopback_client` must be made
+proxy-aware **in the same change**, or this becomes a live HIGH the same day.
+
+## 2.3 — Reducing the per-turn LLM call count
+
+**Trigger: moving to a larger model.**
+
+Roadmap **P2-4**. Attempted at Stage 4 and dropped, with two independent findings:
+
+- Measurement 1.5 settled the prefix-caching question definitively — the two
+  in-turn calls share **0** characters of prefix, so prefix caching was never a
+  lever here.
+- The stage-merge itself was built, mutation-tested, and dropped: a 3B model does
+  not reliably continue past a JSON classification block into prose.
+
+The second reason is a property of the model, not the design. Worth revisiting on
+a larger model — which the hardware roadmap expects.
+
+**Do not parallelise instead.** `HARDWARE.md` §5 measured aggregate throughput
+rising only 16% with two models loaded, so overlapping converts latency into
+memory contention. On 16 GB this is strictly worse.
+
+---
+
+# Part 3 — Declined, deliberately
+
+Recorded so they are not re-opened by accident. Each was argued once, in the
+ledger, and re-opening a decision the ledger already made is not completing the
+roadmap — it is contradicting it.
+
+| Item | Decision | Reasoning |
+| :--- | :--- | :--- |
+| **P4-3** — three dead PyO3 exports; `_split_thought` superseded; `evolved_learnings` loader with no saver | **KEEP** | "A loader without a saver is a worse asymmetry than an unused pair." Deleting the loader removes the only evidence of intended shape. |
+| **P4-11** — import cycle broken with deferred imports; `app.config` process-global with fan-in 24 | **KEEP** | Both are load-bearing workarounds with no better local fix. Prefer `@computed_field` over adding logic to `ConfigMeta.__getattr__` (finding **F4**). |
+| **Migrating off NATS, off Ollama, or to full-duplex speech-to-speech** | **DECLINED** | All three analysed at M6 against the brief's seven-field template and declined. Reasoning in `audit/REAL_WORLD_COMPARISON.md` §13. |
+| **Bi-temporal memory edges** | **DECLINED** | A second time axis before reinforcement works (P2-13) builds on a broken base. |
+| **An Isaac-style real-time control layer** | **DECLINED** | There are no actuators. What transfers is the *discipline* — no blocking call on a bus-serving loop, a stated latency budget for audio, perception off the cognition loop — carried as review criteria, not a build item. |
+| **Horizontal scaling / multi-tenancy** | **DECLINED, do not resurrect** | Issues #151 and #164 were rejected as contradicting the single-family deployment; the maintainer's own answer confirmed it. |
+| **Corpus-specific constants in production retrieval** | **DECLINED** | Finding **B1**. `MOCK_LLM_TEXT=true` returns strings fitted to one demo corpus; that fitting must never migrate into real retrieval paths. |
+
+---
+
+# Part 4 — Unanswered questions
+
+These are decisions, not tasks. None blocks work today; each would sharpen it.
+
+**All previously-BLOCKING questions are closed.** `audit/QUESTIONS.md` §2 still
+lists three as blocking (Q-M4-1(b), Q-M2-2, Q-M1-2) — **that section is stale**;
+§6 of the same file records all three as answered on 2026-08-22, and Q-M3-2 and
+Q-M4-2 were closed during the leftovers pass. Read §6, not §2.
+
+What remains is the "IMPORTANT" tier — worth answering, none urgent:
+
+| ID | Question | What it would settle |
+| :--- | :--- | :--- |
+| **Q-M1-1** | The Rust agents subscribe over core NATS and publish over JetStream. Is restart-time loss on the subscribe side accepted? | Whether M1-A7 is a defect or a documented trade-off. P1-2's sensor tier already resolved it in the right *direction*; the intent is still unstated. |
+| **Q-M1-3** | Is `system.tick` meant to be durable, or a transient heartbeat? | Sizes part of M1-A2. A heartbeat persisted forever suggests nobody chose. |
+| **Q-M2-1** | Is `IdentityCoreStore` / `cache.sync` intended to be wired, or abandoned? | Its CHANGELOG advertises it as shipped. Wire-or-delete. |
+| **Q-M2-3** | Should repeated facts reinforce graph edges? | The comment says "optionally"; the decay model implies yes. |
+| **Q-M2-4** | Is tick-driven consolidation expected to finish within one 60 s tick? | Measured at 7.48 s idle / 10.08 s under VLM contention vs a 30 s AckWait — so the answer is currently "yes, comfortably", but the intent is unrecorded. |
+| **Q-M3-3** | Of the subjects wired at one end only, is any a deliberate extension point? | The allowlist for the P1-8 CI check. Seven are currently allowlisted with individual justifications. |
+| **Q-M3-4** | Is `user_distance` a calibrated metre measurement or a relative proximity signal? | Finding M3-A10. Four absolute-metre thresholds consume it; nothing calibrates it. |
+| **Q-M3-5** | Should `agent.voice.modulation` drive prosody *across* an utterance or set one value per turn? | Largely settled by P3-13 shipping trajectories, but the contract still permits both readings. |
+| **Q-M4-3** | Is the mesh trusted-by-construction on a private segment, or was auth never added? | Now partly moot — accounts shipped — but decides whether the opt-in default is right. |
+| **Q-M5-1** | Is `pytest-benchmark` a regression gate or illustrative timing? | `test_vision_frame_encode_benchmark` asserts `len(x) > 100` under either reading, so today it is neither. |
+| **Q-M5-2** | Must `stt-agent` run natively on macOS, or only in its container? | Changes what "runs on laptop hardware" means. |
+| **Q-M6-1′** | Should visual episodic memory store traces when the source is **screen**? | The privacy boundary for *live capture* is closed; the boundary for *persisted screen content* is a different question and has not been asked. Currently: screen traces carry a hard 24 h TTL (`VISUAL_SCREEN_TRACE_TTL_H`). |
+
+Three further questions (Q-M0-5, Q-M0-6, Q-M1-4) are classed OPTIONAL and are
+effectively answered by what shipped.
+
+---
+
+# Part 5 — The unfinished audit surface
+
+The audit closed as a *process* at nine of nine milestones. It did not close as
+*coverage*, and the distinction is the single most important thing to carry
+forward.
+
+## 5.1 — Coverage is 17.8%
+
+**58 of 325 applicable files were read end to end** (76 of 325 = 23.4% counting
+partial reads). **249 applicable files were never opened.** Skipped files are
+excluded from the denominator and individually justified in
+`audit/REPOSITORY_INVENTORY.md` §3 — none were silently dropped.
+
+**This is a second audit, not a leftover**, and it should be scoped as one. The
+existing audit's own defining finding is the reason it matters: *the parts one
+engineer could reason about alone are done well; the parts requiring two components
+to agree fail silently, because the failing half still compiles, still passes its
+own tests, and still logs as though it were working.* That pattern was confirmed
+repeatedly **in places the audit never reached** — `char_offset` vs
+`character_offset` across the Python/Rust boundary, `audio.playback.progress`
+published by nothing, `cache.sync` subscribed by an agent no one constructed, a
+`.dockerignore` silently excluding a module imported at startup, a `requests`
+import that was never a declared dependency. Every one was found by making two
+halves actually run against each other.
+
+**The method that works, therefore: run the halves against each other.** Not more
+reading.
+
+## 5.2 — The nine pressure scenarios
+
+`AUDIT.md` §17 asks for resource-pressure analysis of the **complete system running
+simultaneously** across nine states: idle; voice-only; voice + cognition;
+vision-only; vision + cognition; voice + vision + cognition; full multimodal; full
++ background cognition; and sustained long-running operation — determining RAM,
+VRAM, CPU, GPU, disk and storage growth for each.
+
+**None of the nine has been run.** What exists instead:
+
+- A boot-and-connect path exercised on real infrastructure.
+- Two sustained-behaviour measurements: consolidation wall-clock (7.48 s idle,
+  10.08 s under real VLM contention, vs a 30 s AckWait) and `AI_AUDIO` growth
+  (68,571 B/s measured, roughly **half** the ~130 KB/s that was estimated — so the
+  audio tier has more headroom than assumed).
+- Six Stage-3 measurement harnesses under `backend/tools/measure/` (`m11`–`m16`,
+  plus `m4b`), all with a `MEASURED` / `ESTIMATED` / `UNKNOWN` provenance label.
+
+**This is a separate measurement campaign.** It is also the one that decides
+whether the humanoid is feasible on the hardware it is meant to live on, so it
+should probably come before the second audit.
+
+## 5.3 — Benchmark figures are still placeholders
+
+Documented benchmark results are **`[TBP]`** placeholders. `MOCK_LLM_TEXT=true`
+returns hardcoded strings fitted to a specific demo corpus. **No headline latency
+or Recall@K figure has been measured against real infrastructure.** State targets
+as targets until measured — this is a standing integrity constraint, not a to-do.
+
+One number now exists that did not before: the eval recall gate was run against the
+Stage 6 retrieval rewrite on 2026-08-24 and found **no regression** (27/48 probes
+on both a pre-Stage-6 baseline and current `main`, identical probe-for-probe,
+`mean score delta +0.000`). Read it precisely: it shows the rewrite did **not make
+recall worse**. It does *not* show the memory layer beats its own BM25 control at
+long distance — on the two hardest probe families both fail identically. That is a
+finding about the eval pack's discriminating power, and it is worth fixing before
+the pack is used to justify anything.
+
+---
+
+# Part 6 — The long arc
+
+Not roadmap items. The direction the above is in service of.
+
+## 6.1 — Consolidation and the fine-tuned adapter (CVS-4)
+
+`docs/cvs4_architecture_roadmap.md` describes a consolidation loop in which the
+agent's own conversation history trains a LoRA/QLoRA adapter that is then adopted
+as its voice. **This has been discussed across sessions and never built.** Parts of
+the same document *are* implemented, which makes the document itself a trap — read
+it as a roadmap, not a description, and note that its §F.6 now contradicts the
+prosody code that actually shipped.
+
+The gate it needs already exists: `backend/evals/` answers "did this model +
+persona change behaviour between two runs?" at the LLM boundary, with
+deterministic scoring, provenance-carrying reports, and a `run-conversation` suite
+for multi-turn recall. **No fine-tuned adapter should be adopted without passing
+it.** A regression is pass→fail on a probe, not a score threshold.
+
+Note the reproducibility lesson embedded in that harness: deterministic scoring is
+not enough on its own — the *response* has to be reproducible too, and on a 3B
+model it was not until the runner started unloading the model, reloading it and
+burning one throwaway generation before the first scored probe.
+
+## 6.2 — The hardware split
+
+The current machine (Apple M5, 16 GB unified memory) is a development host, not
+the target. The stated direction is a rented GPU for training and a server for the
+humanoid, with the 3B model ceiling explicitly temporary.
+
+Two things follow that are already written down above and are easy to miss:
+
+1. **The mesh crosses a machine boundary in that topology** → [2.1](#21--tls-across-the-mesh) becomes mandatory.
+2. **The model gets bigger** → [2.3](#23--reducing-the-per-turn-llm-call-count) becomes worth revisiting.
+
+## 6.3 — What "human-likeness" is being measured against
+
+The quality target is a cheap-tier frontier model's conversational quality, which
+means **the thing being chased is post-training, not scale.** That is what makes
+6.1 the central item of the long arc rather than a nice-to-have, and it is why the
+eval harness probes the LLM boundary specifically — that is the seam an adapter
+changes.
+
+---
+
+## Appendix — where the evidence lives
+
+| Source | What it is | Tracked? |
+| :--- | :--- | :--- |
+| `.agents/CONTEXT.md` | **Engineering ledger. Ground truth.** What was built, measured, and deliberately left undone. | Yes |
+| `audit/ISSUES.md` | All 101 findings with `file:line` evidence, as written 2026-08-22. Point-in-time; status lives in `ROADMAP.md`. | No — local only |
+| `audit/ROADMAP.md` | P0–P4 disposition per finding, with dated implementation-status markers. | No — local only |
+| `audit/QUESTIONS.md` | The question register. **Read §6, not §2** — §2 is stale. | No — local only |
+| `audit/SECURITY.md`, `HARDWARE.md`, `PERFORMANCE.md`, `ARCHITECTURE.md`, and 6 more | Milestone reports. Evidentiary, superseded as a work queue by this file. | No — local only |
+| `AUDIT.md` (repo root) | The original 1,784-line audit brief. | No — local only |
+| `backend/tools/measure/out/` | Measurement artefacts with provenance labels. **Check here before claiming something was never measured.** | Yes |
+| `backend/evals/` | The behavioural eval harness and its probe packs. | Yes |
+
+**`audit/` and `AUDIT.md` are deliberately untracked and must stay that way.**
+Stage every commit by explicit path; never `git add -A`. A prior sweep published
+the security audit and required a force-push to undo.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,12 @@ organic memory, and future robotics compatibility.
 
 ## Start Here
 
+- **[BRINGING_IT_TO_LIFE.md](./BRINGING_IT_TO_LIFE.md)** — how to actually run the
+  brain, voice and eyes on one laptop, and how to give the agent a personality and
+  a cloned voice of its own. Start here if you want it *running*.
+- **[FUTURE_WORK.md](./FUTURE_WORK.md)** — everything still open, with the
+  decision, the reasoning, and the alternatives that were rejected. Start here if
+  you want to *build on it*. Supersedes the `audit/` documents as a work queue.
 - [ARCHITECTURE.md](./ARCHITECTURE.md) gives the system-level map: NATS mesh,
   agents, cognition, state, memory, voice, and feedback loops.
 - [API_SPEC.md](./API_SPEC.md) defines the REST endpoints and NATS subjects used


### PR DESCRIPTION
## Summary

The `audit/` directory is thirteen files and ~7,100 lines, plus a 1,784-line brief at the repo root. It closed as a *process* at nine of nine milestones, and most of what it describes is now implemented — so as a **work queue** it had become actively misleading, while remaining genuinely valuable as an **evidentiary record**. Those are two different jobs; this splits them.

### Two new standing documents

**[`docs/FUTURE_WORK.md`](docs/FUTURE_WORK.md)** — everything still open, each item carrying **What / Why it matters / How / Alternatives rejected / Status**. The "alternatives rejected" field is the one that earns its place: it's what stops an item being relitigated every six months.

Five-value status vocabulary, of which **TRIGGERED** is the one a roadmap normally loses — items requiring nothing today that become mandatory the day a named condition holds (TLS when the mesh crosses a machine boundary; proxy-aware `is_loopback_client` if a reverse proxy is ever introduced).

**[`docs/BRINGING_IT_TO_LIFE.md`](docs/BRINGING_IT_TO_LIFE.md)** — how to actually run the brain, voice and eyes on one laptop, author a personality, and clone a voice. Written against the real resource ceiling of a 16 GB unified-memory machine rather than the README's happy path, and explicit that `README.md` overstates completeness (which `CLAUDE.md` already says).

Both linked from `docs/README.md`'s "Start Here".

### `audit/` stays untracked and was not deleted

Deleting ~9,000 lines of untracked analysis is unrecoverable — there is no `git checkout` to undo it — so consolidation here means *index and mark*, not *remove*. An untracked `audit/INDEX.md` marks the directory superseded-as-a-work-queue, preserved-as-evidence, with a per-file status table and an explicit list of known-stale claims. Two of those were corrected in place, visibly rather than silently (`QUESTIONS.md` §2 advertising three BLOCKING questions its own §6 records as answered; `SECURITY.md` still calling rotation the one open security step).

### A real bug, found by walking the path instead of assuming it

Voice cloning is the system's highest-return unstarted action, so the instructions were walked rather than written from the code's intent. Both helper scripts on that path pointed at directories the synthesiser cannot see:

| Script | Resolved to | Should be |
| :--- | :--- | :--- |
| `record_voice.py` | `backend/scripts/audio/voice_samples/` | `backend/voice_samples/` |
| `process_voice_samples.py` | `backend/scripts/voice_samples/` | `backend/voice_samples/` |

`docker-compose.infra.yml:175` bind-mounts **`backend/voice_samples/`** to `/workspace/GPT-SoVITS/output`, which is what `REF_AUDIO_PATH=output/...` resolves against. Three different paths; neither wrong one existed on disk.

`process_voice_samples.py` printed *"No voice samples found in `backend/voice_samples/`"* while listing somewhere else entirely — **the message and the code disagreed, and both halves ran without complaint.** That is this repository's own defining failure pattern in miniature. Anyone following the scripts to record a reference clip would have produced a file the container never sees, with nothing to indicate why.

## Test plan

- [x] `ruff check` clean on both scripts
- [x] `process_voice_samples.py` run — its output now names the directory it actually reads
- [x] Resolved paths asserted equal to the compose mount source for both scripts
- [x] Every internal cross-document link and anchor checked to resolve (one broken anchor found and fixed this way — the same class `linkChecker` gates)
- [x] No personal names in the new tracked documents
- [x] `audit/` and `AUDIT.md` confirmed absent from the staged set

🤖 Generated with [Claude Code](https://claude.com/claude-code)