### PR TITLE
Phase 7: code quality hardening (7.1, 7.2, partial 7.4, 7.5)

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -12743,3 +12743,202 @@ lint/build, Rust `cargo check --workspace`, and Rust contracts/STT/voice tests
   must be checked after these changes are pushed.
 - Roadmap Phase 3--8 measurement/eval gates and browser visual QA remain
   outside this repair pass; no placeholder benchmark was promoted to a result.
+
+## 2026-08-28 — Community roadmap Phase 7: code quality hardening (7.1, 7.2,
+## partial 7.4, 7.5) -- the report-only tools from Phase 0.7 fixed and the CI
+## gates flipped to blocking
+
+Landed on its own branch/PR (`phase-7/code-quality-hardening`), off `main`
+after PR #205 merged -- the community roadmap's "one branch total" rule
+applied only to Phases 1-8's original scope, and that PR already shipped, so
+Phase 7 is a fresh cycle per this repo's normal branch-per-change convention.
+
+**7.2 (type errors) -- complete: 75 -> 0 mypy errors, 12 -> 0 files.**
+`agent_state.py`'s 24 errors -- the ones Phase 7.3's entry deliberately
+deferred as highest-risk, given `CLAUDE.md`'s own warning about the state
+lock and concurrent System-2 writes -- turned out to be entirely
+type-annotation fixes with zero logic changes: `persona: PersonaProfile |
+None`, named (not `**`-unpacked) `dopamine_halflife_s`/`cortisol_halflife_s`
+kwargs to `AgentState()` (a generic `dict[str, float]` spread makes mypy
+check every field for float-compatibility, not just the two real ones), an
+explicit `redis.Redis | None` annotation, and a `cast()` around
+`asyncio.to_thread(self.redis_client.hgetall, ...)` (same redis-py
+sync/async stub-sharing issue `working_memory_store.py` already worked around
+in Phase 7.3). Nothing in the state-mutation path itself changed.
+
+Also added `plugins = ["pydantic.mypy"]` to `[tool.mypy]` -- a real fix, not
+a suppression, for `config.py`'s two `@computed_field @property` errors
+(though the plugin turned out not to fully suppress the `prop-decorator`
+diagnostic on this mypy/pydantic version pairing either; those two still
+carry a `# type: ignore[prop-decorator]`, correctly placed on the decorator
+line, not the `def` line -- bandit-style trial and error found that mypy
+attributes the error to the decorator, not the signature). One incidental
+real fix along the way: `learning.py`'s two `except Exception as e:` blocks
+both later reused the name `f` as an unrelated loop variable in the same
+function scope -- Python's automatic `del e` on except-block exit plus
+mypy's redefinition tracking flagged this correctly; renamed the loop
+variable rather than suppressing.
+
+**7.1 (cyclomatic complexity) -- the named worst-offender tier eliminated:
+1 F + 3 E + 8 D (12 findings) -> 0. Baseline's 46 C findings not pursued (now
+54, net after extraction created some new low-C helpers) -- 7.1's own text
+says "let the tool name the actual worst offenders," and the worst tier is
+now clean.** All done by pure extraction -- pulling a self-contained block
+into a named helper with the same logic, never rewriting behavior -- per the
+roadmap's explicit instruction and this session's own added constraint (the
+user asked for "fix first, test later": all extractions landed before a
+single test run, verified only at the end).
+
+- `cognitive/pipeline.py::execute` (F, 42 -> C, 20), the worst single
+  function in the codebase and the file `CLAUDE.md` names as the master
+  cognitive loop. The hard part: it's an async generator (`yield`-bearing),
+  so a naive extraction into a plain helper can't hand back a computed value
+  the way a normal function return would. Followed the pattern already
+  established in this same file for exactly this problem
+  (`_stream_action_pass`'s own docstring: "this is an async generator, so it
+  cannot both yield chunks and hand back the assembled response") --
+  extracted stages 2, 5, 6, and 9 as their own async-generator methods that
+  `yield` their events and write results into a caller-supplied mutable
+  dict, with `execute` doing `async for chunk in self._stage(...): yield
+  chunk` then reading the dict. Stages 7 and 10 (no `yield`, pure
+  computation) became plain method calls. One near-miss caught before it
+  shipped: the stage-9 extraction's first draft reset `done_chunk` to `None`
+  at the top of the validation stage, silently discarding stage 8's chunk
+  whenever validation passed without a retry -- caught by re-reading the
+  original control flow line-by-line before running tests, not by the tests
+  themselves, since no existing test exercises `execute` as a whole
+  generator closely enough to have caught a `None` where a real chunk
+  belonged.
+- `state/memory_store.py`, six of eight D/E findings in one file:
+  `apply_actr_decay` (E 39 -> gone; split into `_compute_actr_decay`, a pure
+  per-row decision function, plus three dual-backend I/O helpers -- the
+  compute half is what carried almost all the complexity), `search_memories`
+  (E 32 -> C 16, four extraction passes: cache-key builder, entity-context
+  resolution, candidate-fetch dual-backend dispatch, and finally the L1
+  cache-hit-or-miss check itself), `_resolve_identity_nodes` (D 26 -> gone;
+  split agent-name vs. user-name discovery, previously one function doing
+  both), `add_memory` (D 25 -> gone; entity pre-linking and the Qdrant
+  upsert payload each became their own method), `_score_qdrant_candidates`
+  (D 25 -> gone; the per-candidate scoring loop body became
+  `_score_one_qdrant_candidate`, then a second pass replaced four
+  near-identical "DB overrides Qdrant payload" ternaries with one
+  `_db_or_meta()` helper), `_promote_archived_rows` (D 24 -> gone; same
+  per-row-loop-body pattern as the Qdrant scorer).
+- `cognitive/learning.py::_consolidate` (E 36 -> gone): the function's own
+  comments already named four parts ("PART 1: Fact Resolution", "PART 2:
+  Persona Evolution", "PART 3: Episodic Memory Consolidation", "PART 4:
+  Hebbian Graph Decay") -- each became its own method, plus the saliency
+  ranking and summary-text building that preceded them.
+- `llm/ollama_client.py::generate` (D 25 -> gone): the ~60-line
+  `MOCK_LLM_TEXT` if/elif chain was unrelated to the real generation path
+  below it: extracted whole as `_mock_generate_response`.
+- `agents/brain_agent.py`, two D findings: `_process_chat_input_flow` (D 24
+  -> C 13) and `_stream_to_speech` (D 24 -> C 12, the second needing a
+  closure rather than a method since its state -- `current_chunk_words`,
+  `segment_started_at`, `full_response` -- is mutated across the whole
+  `async for output in generator:` loop; used a nested `async def` with
+  `nonlocal`, same technique the function's own pre-existing
+  `_publish_tracked` closure already used one scope up).
+- `cognitive/appraisal.py::appraise_semantic_drift` (D 22 -> gone): split
+  the JSON-parse-with-three-fallback-strategies chain from the
+  PAD-drift-computation math that follows it -- unrelated concerns that
+  happened to share one function.
+
+**Verified per extraction, not just at the end:** `ast.parse()` after every
+edit (catches a syntax slip immediately, before it could compound across
+dozens of sequential edits to the same files) and a fresh `radon cc
+<file>.py` after every function to confirm the specific score actually
+dropped, rather than trusting the edit "looked" like it reduced branching.
+Full verification bar only at the very end, per the user's "fix first, test
+later" instruction: 1408 tests (+7 from Phase 7.4's addition below), 0
+failures, 0 errors (`--junit-xml`, parsed); `ruff check .` clean; fresh
+`mypy app` 0 errors; fresh `bandit -r app` 0 findings; fresh `radon cc app
+--min D` empty; `cargo check --workspace` clean; `check_subject_wiring.py`
+OK.
+
+**Two real regressions caught by that final full run, both from the same
+root cause and both fixed rather than routed around.** `test_f1_
+decomposed_stages.py`'s `_GatingSpy` is a deliberately minimal, hand-written
+`self`-double for `search_memories` (its own docstring explains why: a
+`MagicMock(spec=MemoryStore)` answers every attribute including the one
+under test, which is how an earlier version of this same test came to pass
+while asserting on an empty list). Every new `self.<staticmethod>(...)` call
+`search_memories` reaches before the point that test stops at needs to exist
+on the spy too, or attribute lookup fails -- happened twice, once for
+`_build_search_cache_key` and again (after that same file's later `search_
+memories` extraction pass) for `_l1_cache_hit`/`_refresh_stop_words_if_
+stale`. Fixed by delegating the spy's attributes to the real static/instance
+methods (`_build_search_cache_key = staticmethod(MemoryStore._build_search_
+cache_key)`, etc.) rather than reimplementing them a third time or loosening
+the test's own stated design -- consistent with the docstring's philosophy
+("the few attributes search_memories touches before it picks a tier"), now
+grown by two entries because the real function grew two new pre-gating call
+sites. Also a real, if minor, bandit regression: the `_parse_qdrant_created_
+at` extraction introduced a bare `except: pass` (B110) that the pre-
+extraction inline code didn't trip on, since bandit's check is structural,
+not semantic -- fixed with the same targeted `# nosec B110` + reason pattern
+Phase 7.3 established for the same true-false-positive shape elsewhere in
+this file.
+
+**7.4 (coverage gaps), partial and scoped, not exhaustive.** No coverage
+baseline was ever actually saved under `backend/tools/quality/baseline/`
+despite Phase 0.7's own stated plan to add one (`pytest-cov` is installed,
+but nothing ran it and committed the output) -- so this pass is a fresh
+read of current coverage, not a diff against a Phase 0.7 snapshot; that gap
+in the roadmap's own execution is recorded here rather than silently
+worked around by fabricating a baseline. Surveyed per-file coverage across
+`app/`, sorted by percentage, and picked the clearest Phase-1-6-scoped gap
+rather than chasing every low number repo-wide (7.1's own instruction:
+"not a repo-wide push"): `runtime_bootstrap.py` at 27% -- Phase 1.6's
+one-command-start bootstrap module. The sentinel-file SQLite-fallback logic
+(`_enter_sqlite_fallback`/`_clear_sqlite_fallback`) already had a full test
+file; the gap was `_normalized_required_models`/`_model_exists`, two pure
+functions with real edge-case logic (CSV dedup/whitespace-stripping, and a
+bidirectional `"model"` <-> `"model:latest"` tag-compatibility check so the
+bootstrap doesn't re-pull an Ollama model already present under a different
+spelling of the same tag) that had zero tests. Added 7, mutation-verified by
+hand: removing the dedup guard broke 2 of 2 dedup-specific tests; removing
+the `:latest`-compatibility branch broke exactly the 2 tests that exercise
+it and left the other 3 (exact match, genuinely-absent, different-tag)
+passing, confirming those three don't accidentally depend on the removed
+code. `state/proactive_queue.py` (Phase 3, 84.4%, 5 missing lines) was
+surveyed but not touched -- a small exception-path tail, lower priority
+than `runtime_bootstrap.py`'s real gap. The rest of Phase 1-6's modules
+were not audited line-by-line; this is one representative fix, not
+coverage-complete.
+
+**7.5 (flip the gates), scoped to what 7.1-7.3 actually cleaned.** `ci.yml`'s
+`code-quality` job: removed job-level `continue-on-error: true`, so mypy and
+bandit (both already exit non-zero on any finding) now block for real. radon
+`cc` has no native pass/fail exit code, so added an explicit gate: `radon cc
+app --min D -s`, written to a file, and the step fails if that file is
+non-empty -- verified locally (empty output on a clean D/E/F tier, confirmed
+non-empty and failing against a deliberately reintroduced D-rank function
+before being reverted). Deliberately does NOT gate on radon's C tier (54
+remaining) or the maintainability-index job -- neither has had a real fix
+pass, so blocking on either now would gate against noise nobody has earned
+the right to call a regression yet. All three real steps
+(`mypy app`, `radon cc app --min D -s` + emptiness check, `bandit -r app -f
+txt`) run-tested locally against the exact commands in the workflow file,
+not just inferred from the diff, before considering the flip verified.
+
+**NOT done:**
+- 7.1's remaining 54 C-rank findings (up from the Phase 0.7 baseline's 46 --
+  extraction moved complexity into new, smaller, lower-rank helper functions
+  rather than eliminating it, so some net-new C entries are expected and
+  correct, not a regression). No attempt was made to reduce these; the
+  roadmap's own text scopes 7.1 to "the actual worst offenders."
+- 7.4 covered one file deeply, not every Phase 1-6 module shallowly. No
+  Phase 0.7 coverage baseline exists to diff against -- creating one (a real
+  `pytest --cov` run committed to `backend/tools/quality/baseline/`,
+  matching the mypy/radon/bandit baseline files already there) is unstarted
+  and would make a future coverage pass diff-able the way this one could
+  not.
+- radon's maintainability-index job stays report-only, as does the C-rank
+  complexity tier -- both explicitly deferred above, not overlooked.
+- No mutation-testing tool run against the newly-extracted functions
+  themselves (only the two new `runtime_bootstrap.py` tests got hand-rolled
+  mutation verification) -- the extractions are behavior-preserving by
+  construction (moved code, not rewritten logic) and covered by whatever
+  test already exercised the original function, but no one specifically
+  broke each new helper and confirmed a test catches it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,13 +204,18 @@ jobs:
         retention-days: 14
 
   code-quality:
-    # Roadmap Phase 0.7: report-only. mypy/radon/bandit findings are recorded
-    # as artifacts here and fixed in Phase 7, as a dedicated PR, once every
-    # functional phase is done -- see backend/tools/quality/baseline/ and the
-    # standing rule in the roadmap plan. continue-on-error keeps this from
-    # blocking merges before that point.
+    # Roadmap Phase 7.5: blocking. mypy and bandit ran clean (0 findings)
+    # against the Phase 0.7 baseline (93 mypy errors, 33 bandit findings)
+    # after Phase 7.2/7.3's fix passes, so both now gate for real. radon's
+    # cyclomatic-complexity D/E/F tier (the "worst offenders" the roadmap
+    # named as 7.1's target) also ran clean after that phase's extraction
+    # pass, from a baseline of 1 F + 3 E + 8 D -- that tier gates too. The
+    # 54 remaining C-rank findings do not: 7.1 fixed what radon named as
+    # worst, not a repo-wide push to zero, so C stays report-only until a
+    # dedicated pass earns it a real baseline to gate against. Maintainability
+    # index remains report-only for the same reason -- no fix pass has run
+    # against it yet.
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
@@ -224,20 +229,26 @@ jobs:
         cd backend
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
-    - name: mypy (report only)
+    - name: mypy
       run: |
         cd backend
         mypy app | tee /tmp/mypy_report.txt
-    - name: radon cyclomatic complexity (report only)
+    - name: radon cyclomatic complexity (D/E/F blocking, C report-only)
       run: |
         cd backend
         radon cc app -s | tee /tmp/radon_cc_report.txt
         radon cc app -s -a
+        echo "--- D/E/F tier (blocking) ---"
+        radon cc app --min D -s | tee /tmp/radon_cc_def.txt
+        if [ -s /tmp/radon_cc_def.txt ]; then
+          echo "New D/E/F-rank complexity found -- Phase 7.1 brought this to zero; extract before adding more."
+          exit 1
+        fi
     - name: radon maintainability index (report only)
       run: |
         cd backend
         radon mi app | tee /tmp/radon_mi_report.txt
-    - name: bandit (report only)
+    - name: bandit
       run: |
         cd backend
         bandit -r app -f txt | tee /tmp/bandit_report.txt
@@ -249,6 +260,7 @@ jobs:
         path: |
           /tmp/mypy_report.txt
           /tmp/radon_cc_report.txt
+          /tmp/radon_cc_def.txt
           /tmp/radon_mi_report.txt
           /tmp/bandit_report.txt
         retention-days: 14

--- a/backend/app/agents/base.py
+++ b/backend/app/agents/base.py
@@ -93,8 +93,10 @@ class BaseAgent:
         # operator actually turns this on.
         self.nats_user = os.getenv("NATS_USER")
         self.nats_password = os.getenv("NATS_PASSWORD")
-        self.nc = None
-        self.js = None
+        # Any, not a nats-py type: self.js._jsm is accessed directly below,
+        # which isn't in JetStreamContext's public stub either.
+        self.nc: Any = None
+        self.js: Any = None
         tracked_subjects_raw = os.getenv(
             "MESH_OBSERVED_SUBJECTS",
             "system.tick,memory.surfaced,audio.stop,audio.resume,chat.output",

--- a/backend/app/agents/brain_agent.py
+++ b/backend/app/agents/brain_agent.py
@@ -60,9 +60,9 @@ class BrainAgent(BaseAgent):
     def __init__(
         self,
         ollama_url: str = Config.OLLAMA_URL,
-        graph_db: GraphDB = None,
-        memory_store: MemoryStore = None,
-        conversation_store: ConversationHistoryStore = None,
+        graph_db: GraphDB | None = None,
+        memory_store: MemoryStore | None = None,
+        conversation_store: ConversationHistoryStore | None = None,
     ):
         super().__init__(name="brain_agent")
         self.ollama = build_llm_client(base_url=ollama_url, model=Config.LLM_CHAT_MODEL)
@@ -89,17 +89,17 @@ class BrainAgent(BaseAgent):
         self.last_interaction_time = datetime.now()
         self.last_visual_context = "No visual data available."
         self.last_user_distance = 1.0
-        self.last_user_voice_properties = None
+        self.last_user_voice_properties: UserVoiceProperties | None = None
 
         # CVS-3.5 Segmentation Config
         self.coordinator = SpeechCoordinator(
             segmenter=HybridSegmenter(target_size=7), formation_buffer_ms=0.030
         )
         self.conversational_runtime = ConversationalRuntime(publish_cb=self.publish)
-        self._active_generation_task = None
+        self._active_generation_task: asyncio.Task[Any] | None = None
         self._generation_lock = asyncio.Lock()
-        self.last_audio_progress = None
-        self.last_assistant_response = None
+        self.last_audio_progress: AudioPlaybackProgress | None = None
+        self.last_assistant_response: str | None = None
         self._active_response_turn_id: str | None = None
         # P2-14/M1-A14: `last_audio_progress` and `last_assistant_response`
         # are written from three independent NATS subscription tasks --
@@ -210,9 +210,8 @@ class BrainAgent(BaseAgent):
             logger.debug("[Brain] Visual context updated: %s", description[:60])
         else:
             self.last_visual_context = f"I am seeing the user's {source}."
-        self.last_user_distance = (
-            data.get("user_distance") if data.get("user_distance") is not None else 1.0
-        )
+        distance = data.get("user_distance")
+        self.last_user_distance = float(distance) if distance is not None else 1.0
 
         await self._appraise_somatic(description)
 
@@ -406,35 +405,28 @@ class BrainAgent(BaseAgent):
                 if self._active_generation_task == task:
                     self._active_generation_task = None
 
-    async def _process_chat_input_flow(
-        self, chat_input: ChatInput, is_subconscious: bool, message: dict[str, Any]
-    ):
-        flow_start_time = time.time()
-        user_text = chat_input.text
-        turn_id = chat_input.turn_id or chat_input.utterance_id or str(uuid.uuid4())
+    @staticmethod
+    def _resolve_chat_input_metadata(
+        chat_input: ChatInput, message: dict[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Normalize the loosely-typed metadata/latency_metadata the message
+        may or may not carry into plain dicts, falling back to the
+        ChatInput's own metadata."""
         metadata = message.get("metadata")
         if not isinstance(metadata, dict):
             metadata = chat_input.metadata.model_dump() if chat_input.metadata else {}
         latency_metadata = message.get("latency_metadata")
         if not isinstance(latency_metadata, dict):
             latency_metadata = {}
-        utterance_id = chat_input.utterance_id
+        return metadata, latency_metadata
 
-        if not user_text:
-            return
-
-        async with self._turn_state_lock:
-            self._active_response_turn_id = turn_id
-
-        # Pacing Conversational Turn: calculate silence duration and pause
-        state_snap = self.cognitive_core.state.get_context_snapshot()
+    async def _apply_conversational_pacing(
+        self, metadata: dict[str, Any], state_snap: dict[str, Any]
+    ) -> None:
+        """Sleep for the calculated pre-response silence, skipped entirely
+        for a latency benchmark pulse."""
         pacing = self.conversational_runtime.calculate_pacing_parameters(state_snap)
-
-        is_benchmark = (
-            metadata.get("benchmark_id") == "bench_pulse"
-            if isinstance(metadata, dict)
-            else False
-        )
+        is_benchmark = metadata.get("benchmark_id") == "bench_pulse"
         if is_benchmark:
             silence_s = 0.0
             logger.info(
@@ -447,6 +439,43 @@ class BrainAgent(BaseAgent):
             )
         await asyncio.sleep(silence_s)
 
+    @staticmethod
+    def _resolve_chat_user_id(
+        message: dict[str, Any], chat_input: ChatInput, metadata: dict[str, Any]
+    ) -> str:
+        return (
+            message.get("user_id")
+            or metadata.get("user_id")
+            or getattr(chat_input, "user_id", None)
+            or (
+                chat_input.metadata.model_dump().get("user_id")
+                if chat_input.metadata
+                else None
+            )
+            or "User"
+        )
+
+    async def _process_chat_input_flow(
+        self, chat_input: ChatInput, is_subconscious: bool, message: dict[str, Any]
+    ):
+        flow_start_time = time.time()
+        user_text = chat_input.text
+        turn_id = chat_input.turn_id or chat_input.utterance_id or str(uuid.uuid4())
+        metadata, latency_metadata = self._resolve_chat_input_metadata(
+            chat_input, message
+        )
+        utterance_id = chat_input.utterance_id
+
+        if not user_text:
+            return
+
+        async with self._turn_state_lock:
+            self._active_response_turn_id = turn_id
+
+        # Pacing Conversational Turn: calculate silence duration and pause
+        state_snap = self.cognitive_core.state.get_context_snapshot()
+        await self._apply_conversational_pacing(metadata, state_snap)
+
         # Only update human interaction tracking if it's an actual user message
         if not is_subconscious:
             self.cognitive_core.state.record_user_interaction()
@@ -457,17 +486,7 @@ class BrainAgent(BaseAgent):
             user_voice_properties = self.last_user_voice_properties.model_dump()
             self.last_user_voice_properties = None
 
-        user_id = (
-            message.get("user_id")
-            or (metadata.get("user_id") if isinstance(metadata, dict) else None)
-            or getattr(chat_input, "user_id", None)
-            or (
-                chat_input.metadata.model_dump().get("user_id")
-                if chat_input.metadata
-                else None
-            )
-            or "User"
-        )
+        user_id = self._resolve_chat_user_id(message, chat_input, metadata)
 
         raw_event = {
             "id": str(uuid.uuid4()),
@@ -615,6 +634,75 @@ class BrainAgent(BaseAgent):
         except Exception as e:
             logger.error(f"Error parsing user voice properties: {e}")
 
+    async def _publish_final_chunk_payload(
+        self,
+        *,
+        full_response: str,
+        turn_id: str,
+        generation_errors: list[str],
+        is_proactive: bool,
+        incoming_metadata: dict[str, Any] | None,
+        incoming_latency_metadata: dict[str, Any] | None,
+    ) -> None:
+        """Publish the turn's terminal chat.output chunk, if there's
+        anything worth sending (a proactive turn with nothing generated
+        stays silent rather than publishing an empty message)."""
+        if not (full_response.strip() or not is_proactive):
+            return
+        state_snap = self.cognitive_core.state.get_context_snapshot()
+        output_msg = self.coordinator.create_chunk_payload(
+            state_snap=state_snap,
+            turn_id=turn_id,
+            done=True,
+            full_response=full_response,
+            generation_error=generation_errors[-1] if generation_errors else None,
+            proactive=is_proactive,
+            user_distance=self.last_user_distance,
+        )
+        output_msg.metadata = incoming_metadata
+        output_msg.latency_metadata = incoming_latency_metadata
+        await self.publish(Topics.CHAT_OUTPUT, output_msg.model_dump())
+
+    async def _publish_stream_error_fallback(
+        self,
+        error: Exception,
+        *,
+        turn_id: str,
+        incoming_metadata: dict[str, Any] | None,
+        incoming_latency_metadata: dict[str, Any] | None,
+    ) -> None:
+        """Recovery path for `_stream_to_speech`'s outer exception handler,
+        for a non-proactive turn only (the caller checks `is_proactive`).
+
+        P4-2: deliberately untracked (no character_offset/word_index) --
+        unlike the empty-generation fallback, the caller's `full_response`
+        is NOT reassigned to `fallback_text` here, and it will set
+        `last_assistant_response` to whatever partial `full_response`
+        `_stream_to_speech` returns, not to `fallback_text`. Stamping this
+        chunk's audio against `fallback_text` would produce an offset that
+        indexes into a string `last_assistant_response` never actually holds
+        -- a pre-existing gap (that mismatch exists whether or not this
+        chunk carries progress metadata), not one to paper over with a
+        fabricated-looking offset.
+        """
+        fallback_text = "I'm having trouble thinking right now..."
+        await self._publish_speech_chunk(
+            fallback_text.split(),
+            turn_id,
+            incoming_metadata=incoming_metadata,
+            incoming_latency_metadata=incoming_latency_metadata,
+        )
+        output_msg = self.coordinator.create_chunk_payload(
+            done=True,
+            full_response=fallback_text,
+            turn_id=turn_id,
+            generation_error=str(error),
+            user_distance=self.last_user_distance,
+        )
+        output_msg.metadata = incoming_metadata
+        output_msg.latency_metadata = incoming_latency_metadata
+        await self.publish(Topics.CHAT_OUTPUT, output_msg.model_dump())
+
     async def _stream_to_speech(
         self,
         generator,
@@ -625,7 +713,7 @@ class BrainAgent(BaseAgent):
     ) -> str:
         """Helper method to process text generation streams and segment them into speech chunks."""
         full_response = ""
-        current_chunk_words = []
+        current_chunk_words: list[str] = []
         segment_started_at = None
         generation_errors: list[str] = []
         fallback_text = "I'm having trouble thinking right now..."
@@ -653,48 +741,50 @@ class BrainAgent(BaseAgent):
             )
             published_word_count = new_word_count
 
+        async def _handle_content_output(chunk_text: str) -> None:
+            nonlocal full_response, current_chunk_words, segment_started_at
+            await self.set_state("speaking")
+            full_response += chunk_text
+            if not is_proactive:
+                # P2-14/M1-A14: this fires once per streamed chunk, so
+                # contention is rare, but an uncontended asyncio.Lock
+                # acquire/release is cheap and correctness here matters
+                # more than the microscopic saving from skipping it.
+                async with self._turn_state_lock:
+                    self.last_assistant_response = full_response
+
+            now_monotonic = time.perf_counter()
+            if (
+                current_chunk_words
+                and segment_started_at is not None
+                and (now_monotonic - segment_started_at)
+                >= self.coordinator.formation_buffer_ms
+                and len(current_chunk_words) >= 3
+            ):
+                await _publish_tracked(current_chunk_words, full_response)
+                current_chunk_words = []
+                segment_started_at = None
+
+            words = chunk_text.split()
+            for word in words:
+                if not current_chunk_words:
+                    segment_started_at = time.perf_counter()
+                current_chunk_words.append(word)
+
+                score = self.coordinator.segmenter.score_split_point(
+                    word, len(current_chunk_words)
+                )
+                if score > 0.7 or len(current_chunk_words) > 12:
+                    await _publish_tracked(current_chunk_words, full_response)
+                    current_chunk_words = []
+                    segment_started_at = None
+
         await self.set_state("thinking")
 
         try:
             async for output in generator:
                 if output["type"] == "content":
-                    await self.set_state("speaking")
-                    chunk_text = output["data"]
-                    full_response += chunk_text
-                    if not is_proactive:
-                        # P2-14/M1-A14: this fires once per streamed chunk,
-                        # so contention is rare, but an uncontended
-                        # asyncio.Lock acquire/release is cheap and
-                        # correctness here matters more than the microscopic
-                        # saving from skipping it.
-                        async with self._turn_state_lock:
-                            self.last_assistant_response = full_response
-
-                    now_monotonic = time.perf_counter()
-                    if (
-                        current_chunk_words
-                        and segment_started_at is not None
-                        and (now_monotonic - segment_started_at)
-                        >= self.coordinator.formation_buffer_ms
-                        and len(current_chunk_words) >= 3
-                    ):
-                        await _publish_tracked(current_chunk_words, full_response)
-                        current_chunk_words = []
-                        segment_started_at = None
-
-                    words = chunk_text.split()
-                    for word in words:
-                        if not current_chunk_words:
-                            segment_started_at = time.perf_counter()
-                        current_chunk_words.append(word)
-
-                        score = self.coordinator.segmenter.score_split_point(
-                            word, len(current_chunk_words)
-                        )
-                        if score > 0.7 or len(current_chunk_words) > 12:
-                            await _publish_tracked(current_chunk_words, full_response)
-                            current_chunk_words = []
-                            segment_started_at = None
+                    await _handle_content_output(output["data"])
 
                 elif output["type"] == "error":
                     error_msg = str(
@@ -726,54 +816,24 @@ class BrainAgent(BaseAgent):
                         full_response = fallback_text
                         await _publish_tracked(fallback_text.split(), full_response)
 
-                    if full_response.strip() or not is_proactive:
-                        state_snap = self.cognitive_core.state.get_context_snapshot()
-                        output_msg = self.coordinator.create_chunk_payload(
-                            state_snap=state_snap,
-                            turn_id=turn_id,
-                            done=True,
-                            full_response=full_response,
-                            generation_error=generation_errors[-1]
-                            if generation_errors
-                            else None,
-                            proactive=is_proactive,
-                            user_distance=self.last_user_distance,
-                        )
-                        output_msg.metadata = incoming_metadata
-                        output_msg.latency_metadata = incoming_latency_metadata
-                        await self.publish(Topics.CHAT_OUTPUT, output_msg.model_dump())
+                    await self._publish_final_chunk_payload(
+                        full_response=full_response,
+                        turn_id=turn_id,
+                        generation_errors=generation_errors,
+                        is_proactive=is_proactive,
+                        incoming_metadata=incoming_metadata,
+                        incoming_latency_metadata=incoming_latency_metadata,
+                    )
 
         except Exception as e:
             logger.error("Cognitive Loop error on turn_id=%s: %s", turn_id, e)
             if not is_proactive:
-                error_msg = str(e)
-                # P4-2: deliberately untracked (no character_offset/word_index)
-                # -- unlike the empty-generation fallback above, `full_response`
-                # is NOT reassigned to `fallback_text` here, and the caller
-                # will set `last_assistant_response` to whatever partial
-                # `full_response` this method returns below, not to
-                # `fallback_text`. Stamping this chunk's audio against
-                # `fallback_text` would produce an offset that indexes into a
-                # string `last_assistant_response` never actually holds -- a
-                # pre-existing gap (that mismatch exists whether or not this
-                # chunk carries progress metadata), not one to paper over with
-                # a fabricated-looking offset.
-                await self._publish_speech_chunk(
-                    fallback_text.split(),
-                    turn_id,
+                await self._publish_stream_error_fallback(
+                    e,
+                    turn_id=turn_id,
                     incoming_metadata=incoming_metadata,
                     incoming_latency_metadata=incoming_latency_metadata,
                 )
-                output_msg = self.coordinator.create_chunk_payload(
-                    done=True,
-                    full_response=fallback_text,
-                    turn_id=turn_id,
-                    generation_error=error_msg,
-                    user_distance=self.last_user_distance,
-                )
-                output_msg.metadata = incoming_metadata
-                output_msg.latency_metadata = incoming_latency_metadata
-                await self.publish(Topics.CHAT_OUTPUT, output_msg.model_dump())
 
         await self.set_state("idle")
         return full_response

--- a/backend/app/agents/transport_agent.py
+++ b/backend/app/agents/transport_agent.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import logging
 import time
+from typing import Any
 
 from livekit import rtc
 from livekit.api import AccessToken, VideoGrants
@@ -44,14 +45,16 @@ class TransportAgent(BaseAgent):
         self.audio_track = rtc.LocalAudioTrack.create_audio_track(
             "ai-voice", self.audio_source
         )
-        self.audio_queue = asyncio.Queue(
+        self.audio_queue: asyncio.Queue[
+            tuple[bytes, int, int, str | None, int | None, int | None]
+        ] = asyncio.Queue(
             maxsize=max(32, int(getattr(Config, "TRANSPORT_AUDIO_QUEUE_SIZE", 256)))
         )
         self.audio_worker_task = None
         self.dropped_audio_frames = 0
         # Set for real once `start()` publishes the initial track; needed to
         # unpublish it by sid when P1-3's flush rotates to a fresh one.
-        self.audio_publication = None
+        self.audio_publication: rtc.LocalTrackPublication | None = None
         # P1-3: which turn's PCM is currently flowing through audio.stream,
         # read off the X-Latency-Meta header voice-agent now stamps with
         # `event.turn_id` (see `build_latency_metadata` in voice-agent). Mirrors
@@ -83,7 +86,7 @@ class TransportAgent(BaseAgent):
         # over. Decoupling capture from publish with a bounded queue and a
         # dedicated worker means a slow NATS publish drops frames instead of
         # stalling audio capture.
-        self.inbound_audio_queue = asyncio.Queue(
+        self.inbound_audio_queue: asyncio.Queue[tuple[bytes, dict[str, Any]]] = asyncio.Queue(
             maxsize=max(32, int(getattr(Config, "TRANSPORT_AUDIO_QUEUE_SIZE", 256)))
         )
         self.inbound_audio_worker_task = None
@@ -224,7 +227,7 @@ class TransportAgent(BaseAgent):
         publication: rtc.TrackPublication,
         participant: rtc.RemoteParticipant,
     ):
-        if track.kind == rtc.TrackKind.KIND_AUDIO:
+        if track.kind == rtc.TrackKind.KIND_AUDIO and isinstance(track, rtc.RemoteAudioTrack):
             logger.info(
                 f"Subscribed to remote audio track: {track.sid} from {participant.identity}"
             )
@@ -467,7 +470,9 @@ class TransportAgent(BaseAgent):
             return
         payload = viseme.model_dump_json().encode("utf-8")
         try:
-            self.room.local_participant.publish_data(
+            # publish_data is a coroutine in this livekit-rtc version; an
+            # unawaited call here silently never sends anything.
+            await self.room.local_participant.publish_data(
                 payload, reliable=False, topic="visemes"
             )
         except Exception as exc:

--- a/backend/app/cognitive/appraisal.py
+++ b/backend/app/cognitive/appraisal.py
@@ -235,6 +235,99 @@ class AppraisalEngine:
         )
         return vector
 
+    def _parse_semantic_drift_json(self, json_str: str, response: str) -> dict | None:
+        """Parse the appraisal JSON block, falling back through increasingly
+        lenient strategies for a model that didn't emit valid JSON."""
+        data = None
+        try:
+            data = json.loads(json_str)
+        except Exception:
+            try:
+                import ast
+
+                data = ast.literal_eval(json_str)
+            except Exception:
+                cleaned = json_str
+                cleaned = re.sub(r"'\s*([a-zA-Z_0-9]+)\s*'\s*:", r'"\1":', cleaned)
+                cleaned = re.sub(r":\s*'\s*([^']*)\s*'", r': "\1"', cleaned)
+                cleaned = re.sub(r",\s*}", "}", cleaned)
+                try:
+                    data = json.loads(cleaned)
+                except Exception as e2:
+                    logger.error(
+                        f"[System 2 Appraisal] Failed to sanitize and parse LLM response: {json_str}. Error: {e2}"
+                    )
+
+        # Sequential/float extraction fallback if dict structure was not successfully parsed
+        if not data:
+            try:
+                blocks = re.findall(r"\{([^\}]+)\}", response) + re.findall(
+                    r"\[([^\]]+)\]", response
+                )
+                for block in blocks:
+                    floats = [
+                        float(x) for x in re.findall(r"-?\d+(?:\.\d+)?", block)
+                    ]
+                    if len(floats) == 3:
+                        data = {
+                            "goal_congruence": floats[0],
+                            "norm_alignment": floats[1],
+                            "expectedness": floats[2],
+                        }
+                        logger.info(
+                            f"[System 2 Appraisal] Extracted 3-float tuple from block: {data}"
+                        )
+                        break
+
+                if not data:
+                    all_floats = [
+                        float(x) for x in re.findall(r"-?\d+(?:\.\d+)?", response)
+                    ]
+                    if len(all_floats) >= 3:
+                        floats_to_use = (
+                            all_floats[-3:] if len(all_floats) > 3 else all_floats
+                        )
+                        data = {
+                            "goal_congruence": floats_to_use[0],
+                            "norm_alignment": floats_to_use[1],
+                            "expectedness": floats_to_use[2],
+                        }
+                        logger.info(
+                            f"[System 2 Appraisal] Extracted sequential floats from response: {data}"
+                        )
+            except Exception as seq_err:
+                logger.error(
+                    f"[System 2 Appraisal] Sequence extraction fallback failed: {seq_err}"
+                )
+        return data
+
+    def _drift_pad_toward(
+        self, data: dict, current_pad: dict[str, float]
+    ) -> dict[str, float]:
+        """Blend current PAD toward the target implied by one appraisal reading."""
+        gc = float(data.get("goal_congruence", 0.0))
+        na = float(data.get("norm_alignment", 1.0))
+        exp = float(data.get("expectedness", 0.5))
+
+        target_p = max(-1.0, min(1.0, gc))
+        target_a = max(-1.0, min(1.0, -exp))
+        target_d = max(-1.0, min(1.0, na))
+
+        drift_factor = 0.2
+        val = current_pad.get("valence", 0.0)
+        aro = current_pad.get("arousal", 0.5)
+        dom = current_pad.get("dominance", 0.5)
+
+        new_p = val + drift_factor * (target_p - val)
+        new_a = aro + drift_factor * (target_a - aro)
+        new_d = dom + drift_factor * (target_d - dom)
+
+        return {
+            "valence": max(-1.0, min(1.0, new_p)),
+            "arousal": max(0.0, min(1.0, new_a)),
+            "dominance": max(0.0, min(1.0, new_d)),
+        }
+
     async def appraise_semantic_drift(
         self, user_utterance: str, llm_client, current_pad: dict[str, float]
     ) -> dict[str, float]:
@@ -285,96 +378,9 @@ class AppraisalEngine:
                 json_str = candidate_blocks[0]
 
             if json_str:
-                data = None
-                try:
-                    data = json.loads(json_str)
-                except Exception:
-                    try:
-                        import ast
-
-                        data = ast.literal_eval(json_str)
-                    except Exception:
-                        cleaned = json_str
-                        cleaned = re.sub(
-                            r"'\s*([a-zA-Z_0-9]+)\s*'\s*:", r'"\1":', cleaned
-                        )
-                        cleaned = re.sub(r":\s*'\s*([^']*)\s*'", r': "\1"', cleaned)
-                        cleaned = re.sub(r",\s*}", "}", cleaned)
-                        try:
-                            data = json.loads(cleaned)
-                        except Exception as e2:
-                            logger.error(
-                                f"[System 2 Appraisal] Failed to sanitize and parse LLM response: {json_str}. Error: {e2}"
-                            )
-
-                # Sequential/float extraction fallback if dict structure was not successfully parsed
-                if not data:
-                    try:
-                        blocks = re.findall(r"\{([^\}]+)\}", response) + re.findall(
-                            r"\[([^\]]+)\]", response
-                        )
-                        for block in blocks:
-                            floats = [
-                                float(x) for x in re.findall(r"-?\d+(?:\.\d+)?", block)
-                            ]
-                            if len(floats) == 3:
-                                data = {
-                                    "goal_congruence": floats[0],
-                                    "norm_alignment": floats[1],
-                                    "expectedness": floats[2],
-                                }
-                                logger.info(
-                                    f"[System 2 Appraisal] Extracted 3-float tuple from block: {data}"
-                                )
-                                break
-
-                        if not data:
-                            all_floats = [
-                                float(x)
-                                for x in re.findall(r"-?\d+(?:\.\d+)?", response)
-                            ]
-                            if len(all_floats) >= 3:
-                                floats_to_use = (
-                                    all_floats[-3:]
-                                    if len(all_floats) > 3
-                                    else all_floats
-                                )
-                                data = {
-                                    "goal_congruence": floats_to_use[0],
-                                    "norm_alignment": floats_to_use[1],
-                                    "expectedness": floats_to_use[2],
-                                }
-                                logger.info(
-                                    f"[System 2 Appraisal] Extracted sequential floats from response: {data}"
-                                )
-                    except Exception as seq_err:
-                        logger.error(
-                            f"[System 2 Appraisal] Sequence extraction fallback failed: {seq_err}"
-                        )
-
+                data = self._parse_semantic_drift_json(json_str, response)
                 if data and isinstance(data, dict):
-                    gc = float(data.get("goal_congruence", 0.0))
-                    na = float(data.get("norm_alignment", 1.0))
-                    exp = float(data.get("expectedness", 0.5))
-
-                    target_p = max(-1.0, min(1.0, gc))
-                    target_a = max(-1.0, min(1.0, -exp))
-                    target_d = max(-1.0, min(1.0, na))
-
-                    drift_factor = 0.2
-                    val = current_pad.get("valence", 0.0)
-                    aro = current_pad.get("arousal", 0.5)
-                    dom = current_pad.get("dominance", 0.5)
-
-                    new_p = val + drift_factor * (target_p - val)
-                    new_a = aro + drift_factor * (target_a - aro)
-                    new_d = dom + drift_factor * (target_d - dom)
-
-                    return {
-                        "valence": max(-1.0, min(1.0, new_p)),
-                        "arousal": max(0.0, min(1.0, new_a)),
-                        "dominance": max(0.0, min(1.0, new_d)),
-                    }
+                    return self._drift_pad_toward(data, current_pad)
         except Exception as e:
             logger.error(f"[System 2 Appraisal] Semantic drift evaluation failed: {e}")
         return current_pad

--- a/backend/app/cognitive/decision.py
+++ b/backend/app/cognitive/decision.py
@@ -164,7 +164,7 @@ class DecisionService:
             )
 
         # 3. Tick BT
-        blackboard = {"event": event, "state": state_snapshot, "plan": None}
+        blackboard: dict[str, Any] = {"event": event, "state": state_snapshot, "plan": None}
         status = await self.root.tick(blackboard)
 
         if status == NodeStatus.SUCCESS and blackboard["plan"]:
@@ -222,7 +222,7 @@ class DecisionService:
                 reward - prev_u
             )
 
-        scores = {}
+        scores: dict[str, float] = {}
 
         # ENGAGE: Best for neutral/positive states, high energy, novel topics
         scores["ENGAGE"] = (
@@ -270,7 +270,7 @@ class DecisionService:
         )
 
         # §3.2: Intent Persistence with Context Gating
-        new_goal = max(scores, key=scores.get)
+        new_goal = max(scores, key=lambda g: scores[g])
         context_shift = N  # Novelty serves as a proxy for context shift
 
         if self._previous_goal is not None and context_shift < self.shift_threshold:
@@ -279,7 +279,7 @@ class DecisionService:
             for g in GOALS:
                 prev_score = self._goal_scores.get(g, 0.0)
                 scores[g] = (1 - rho) * prev_score + rho * scores[g]
-            new_goal = max(scores, key=scores.get)
+            new_goal = max(scores, key=lambda g: scores[g])
             logger.debug(
                 "[Decision] Persistence applied (shift=%.2f < θ=%.2f): %s → %s",
                 context_shift,

--- a/backend/app/cognitive/learning.py
+++ b/backend/app/cognitive/learning.py
@@ -44,7 +44,7 @@ class ReflectionService:
 
         if self.is_reflecting or not recent_episodes:
             # CVS-3.5: Always return awaitable to support deterministic testing
-            f = asyncio.Future()
+            f: asyncio.Future = asyncio.Future()
             f.set_result(None)
             return f
 
@@ -70,6 +70,288 @@ class ReflectionService:
         )
         return asyncio.create_task(self._consolidate(recent_episodes))
 
+    @staticmethod
+    def _rank_episodes_by_saliency(
+        episodes: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """ESI = 0.6*arousal + 0.4*cortisol, sorted descending, then filtered
+        to the salient tail (threshold, or top half if nothing clears it)."""
+        for e in episodes:
+            emotion_vec = e.get("emotion_vector", {})
+            arousal = emotion_vec.get("Ar", emotion_vec.get("arousal", 0.5))
+            # Cortisol may be stored in emotion_vector or metadata
+            cortisol = emotion_vec.get(
+                "cortisol", e.get("metadata", {}).get("cortisol", 0.5)
+            )
+            e["saliency_index"] = 0.6 * arousal + 0.4 * cortisol
+
+        episodes = sorted(episodes, key=lambda x: x["saliency_index"], reverse=True)
+
+        threshold = 0.4
+        filtered = [e for e in episodes if e["saliency_index"] >= threshold]
+        if not filtered:
+            filtered = episodes[: max(1, len(episodes) // 2)]
+        return filtered
+
+    @staticmethod
+    def _build_episode_summary(episodes: list[dict[str, Any]]) -> str:
+        """Render episodes into the shared narrative text every consolidation
+        prompt below is built from."""
+        summary_parts = []
+        for e in episodes:
+            emotion_vec = e.get("emotion_vector", {})
+            V = emotion_vec.get("V", 0.0)
+            Ar = emotion_vec.get("Ar", 0.5)
+            D = emotion_vec.get("D", 0.5)
+            ctx = e.get("context", "")
+            ri = e.get("relationship_delta", 0.0)
+            speaker_name = e.get("speaker") or "User"
+            summary_parts.append(
+                f"Context: {ctx}\n"
+                f"{speaker_name}: {e.get('content', e.get('event', ''))}\n"
+                f"AI: {e.get('response', '')}\n"
+                f"[Emotion V={V:.2f} Ar={Ar:.2f} D={D:.2f} | RelDelta={ri:.2f}]"
+            )
+        return "\n---\n".join(summary_parts)
+
+    async def _consolidate_facts(self, summary_text: str) -> None:
+        """PART 1: extract entities/relationships/ToM observations and write
+        confidently-resolved ones into Neo4j."""
+        fact_prompt = f"""
+        Extract new entities, relationships, and "Theory of Mind" observations from these interactions.
+        Interactions:
+        {summary_text}
+
+        Focus on:
+        1. People, Preferences, and Facts about the User.
+        2. THEORY OF MIND: Observations about the User's mental/physical state (e.g., "User seems stressed", "User is tired from work").
+
+        REQUIREMENT: Provide a confidence score (0.0 - 1.0), the appropriate category (one of: social, vocational, somatic, spiritual, crisis, milestone), and a brief reasoning for each fact.
+        Output JSON List ONLY: [{{"subject", "subject_type", "relation", "object", "object_type", "category", "confidence", "reason"}}]
+        """
+
+        try:
+            _t0 = time.monotonic()
+            fact_res = await self.llm.generate(
+                fact_prompt,
+                model=Config.LLM_REFLECTION_MODEL,
+                options_override={"num_predict": 256},
+            )
+            _measure_trace(
+                "reflection", "llm_call_facts", duration_s=time.monotonic() - _t0
+            )
+            facts = self._extract_json(fact_res)
+
+            # CVS-3.5: Defensive parsing for LLM output variability
+            if isinstance(facts, dict):
+                facts = [facts]
+            elif not isinstance(facts, list):
+                facts = []
+
+            for f in facts:
+                await self._resolve_one_fact(f)
+        except Exception as e:
+            logger.error(f"Fact consolidation failure: {e}")
+
+    async def _resolve_one_fact(self, f: Any) -> None:
+        """Gate and write a single extracted fact. Split out of
+        `_consolidate_facts` purely to keep that loop body flat."""
+        if not isinstance(f, dict):
+            return
+
+        # 1. CONFIDENCE GATING: Only store facts with > 0.8 certainty
+        confidence = f.get("confidence", 0.0)
+        if confidence < 0.8:
+            logger.debug(
+                f"Fact REJECTED (Low Confidence: {confidence}): {f.get('subject')} - {f.get('relation')}"
+            )
+            return
+
+        # 2. FACT RESOLUTION: Check for existing duplication in GraphDB
+        subject = f.get("subject")
+        object_val = f.get("object")
+        relation = f.get("relation")
+        subject_type = f.get("subject_type", "Entity")
+        object_type = f.get("object_type", "Entity")
+        category = f.get("category", "social").lower()
+
+        if not subject or not object_val or not relation:
+            return
+
+        # Neo4j must NOT have distractors
+        if category == "distractor":
+            logger.debug("Fact REJECTED (Distractors are excluded from Neo4j)")
+            return
+
+        if category not in [
+            "social",
+            "vocational",
+            "somatic",
+            "spiritual",
+            "crisis",
+            "milestone",
+        ]:
+            category = "social"
+
+        try:
+            # P3-11: canonicalization (LIKES/ENJOYS/LOVES -> one type) now
+            # lives in GraphDB.consolidate_relationship itself, applied to
+            # every write regardless of caller -- this is just the
+            # pre-flight safety check so an unsafe relation string is
+            # skipped-and-logged here rather than raising from deep inside
+            # the DB call below.
+            rel_type = GraphDB._safe_relation(relation)
+            GraphDB._safe_label(subject_type)
+            GraphDB._safe_label(object_type)
+            GraphDB._safe_label(category.capitalize())
+        except ValueError:
+            logger.warning("Skipping unsafe graph fact from reflection: %r", f)
+            return
+
+        # P2-13: this used to MATCH for an existing relationship first and
+        # `continue` on a hit, logging "Fact RESOLVED" and never writing
+        # anything -- so a restated fact never reinforced, while
+        # decay_relationships still pushed every edge toward the prune
+        # threshold regardless of repetition. create_triplet ->
+        # consolidate_relationship already does the right thing on a repeat
+        # (`ON MATCH SET r.weight = coalesce(r.weight, 1) + 1`); the guard
+        # above was preventing that path from ever being reached.
+        await self.graph.create_triplet(
+            subject,
+            rel_type,
+            object_val,
+            properties={
+                "confidence": confidence,
+                "extracted_at": str(time.time()),
+                "category": category,
+            },
+            subject_label=subject_type,
+            target_label=object_type,
+        )
+
+    async def _consolidate_persona(self, summary_text: str) -> None:
+        """PART 2: decide whether the persona itself should evolve."""
+        identity_prompt = f"""
+        Determine if {self.identity.personality.get("name")}'s personality or relationship should evolve.
+        Interactions:
+        {summary_text}
+        Current Role: {self.identity.history.get("relationship")}
+
+        Output JSON ONLY: {{"new_traits": ["..."], "relationship": "...", "confidence": 0.0}}
+        """
+        try:
+            _t0 = time.monotonic()
+            ident_res = await self.llm.generate(
+                identity_prompt,
+                model=Config.LLM_REFLECTION_MODEL,
+                options_override={"num_predict": 256},
+            )
+            _measure_trace(
+                "reflection", "llm_call_identity", duration_s=time.monotonic() - _t0
+            )
+            suggestions = self._extract_json(ident_res)
+
+            # CVS-3.5: Defensive parsing for identity suggestions (Ensures
+            # .get() availability). The list branch used to stop at "is this
+            # a list", not "is the element inside a dict" -- `_extract_json`
+            # returning e.g. ["some string"] unwrapped to a bare str that
+            # .get() below then crashed on. The sibling fact-parsing block
+            # above already re-validates each unwrapped element; this one
+            # didn't. Found via a real concurrent-load run (roadmap Phase
+            # 6.2) where contention made the reflection LLM call more likely
+            # to return a malformed shape.
+            if isinstance(suggestions, list) and len(suggestions) > 0:
+                suggestions = suggestions[0]
+            if not isinstance(suggestions, dict):
+                suggestions = {}
+
+            if suggestions and suggestions.get("confidence", 0.0) >= 0.8:
+                await self.identity.evolve_persona(suggestions)
+            else:
+                logger.debug(
+                    "Persona evolution REJECTED: Low confidence or no growth detected."
+                )
+        except Exception as e:
+            logger.error(f"Identity evolution failure: {e}")
+
+    async def _consolidate_episodic_memory(
+        self, episodes: list[dict[str, Any]], summary_text: str
+    ) -> None:
+        """PART 3: fold the episode batch into one long-term vector memory."""
+        try:
+            # Calculate composite affective vectors
+            total_valence = 0.0
+            total_arousal = 0.0
+            total_dominance = 0.0
+            count = len(episodes)
+            for episode in episodes:
+                emotion_vec = episode.get("emotion_vector", {})
+                total_valence += emotion_vec.get("V", 0.0)
+                total_arousal += emotion_vec.get("Ar", 0.5)
+                total_dominance += emotion_vec.get("D", 0.5)
+
+            avg_valence = total_valence / count if count > 0 else 0.0
+            avg_arousal = total_arousal / count if count > 0 else 0.5
+            avg_dominance = total_dominance / count if count > 0 else 0.5
+
+            consolidation_prompt = f"""
+            Consolidate the following recent interaction episodes into a single, cohesive episodic memory summary.
+            This summary should capture the essence of what was discussed, the emotional tone of both the user and the AI, and any key takeaways or relationship progression.
+            Interactions:
+            {summary_text}
+
+            Format: A brief, single-paragraph narrative from the AI's perspective (e.g. "We discussed...").
+            """
+
+            _t0 = time.monotonic()
+            consolidation_res = await self.llm.generate(
+                consolidation_prompt,
+                model=Config.LLM_REFLECTION_MODEL,
+                options_override={"num_predict": 256},
+            )
+            _measure_trace(
+                "reflection",
+                "llm_call_consolidation",
+                duration_s=time.monotonic() - _t0,
+            )
+            consolidated_summary = consolidation_res.strip()
+            if "<think>" in consolidated_summary:
+                consolidated_summary = consolidated_summary.split("</think>")[
+                    -1
+                ].strip()
+
+            if consolidated_summary and self.vector:
+                await self.vector.add_memory(
+                    content=consolidated_summary,
+                    raw_content=summary_text,
+                    wing="personal",
+                    importance=0.6,
+                    emotion=avg_arousal,
+                    valence=avg_valence,
+                    source="subconscious_consolidation",
+                    metadata={
+                        "composite_valence": avg_valence,
+                        "composite_arousal": avg_arousal,
+                        "composite_dominance": avg_dominance,
+                        "episode_count": len(episodes),
+                    },
+                )
+                logger.info(
+                    "[Reflection] Long-term episodic memory successfully consolidated and stored."
+                )
+        except Exception as e:
+            logger.error(f"Episodic memory consolidation failure: {e}")
+
+    async def _decay_relationship_graph(self) -> None:
+        """PART 4: Hebbian decay -- unrelated facts fade unless reinforced."""
+        if self.graph:
+            try:
+                await self.graph.decay_relationships(
+                    decay_factor=0.95, prune_threshold=0.25
+                )
+            except Exception as e:
+                logger.error(f"[Reflection] Graph decay failed: {e}")
+
     async def _consolidate(self, episodes: list[dict[str, Any]]):
         """
         Background Solid State Consolidation (§7):
@@ -81,278 +363,13 @@ class ReflectionService:
         """
         self.is_reflecting = True
         try:
-            # Calculate Episodic Saliency Index (ESI = 0.6 * arousal + 0.4 * cortisol)
-            for e in episodes:
-                emotion_vec = e.get("emotion_vector", {})
-                arousal = emotion_vec.get("Ar", emotion_vec.get("arousal", 0.5))
-                # Cortisol may be stored in emotion_vector or metadata
-                cortisol = emotion_vec.get(
-                    "cortisol", e.get("metadata", {}).get("cortisol", 0.5)
-                )
-                saliency = 0.6 * arousal + 0.4 * cortisol
-                e["saliency_index"] = saliency
+            episodes = self._rank_episodes_by_saliency(episodes)
+            summary_text = self._build_episode_summary(episodes)
 
-            # Sort episodes by saliency in descending order
-            episodes = sorted(episodes, key=lambda x: x["saliency_index"], reverse=True)
-
-            # Filter unconsolidated episodes to prioritize high-saliency events (threshold >= 0.4 or top 50%)
-            threshold = 0.4
-            filtered = [e for e in episodes if e["saliency_index"] >= threshold]
-            if not filtered:
-                filtered = episodes[: max(1, len(episodes) // 2)]
-            episodes = filtered
-
-            # Build enriched summary from episodic schema
-            summary_parts = []
-            for e in episodes:
-                emotion_vec = e.get("emotion_vector", {})
-                V = emotion_vec.get("V", 0.0)
-                Ar = emotion_vec.get("Ar", 0.5)
-                D = emotion_vec.get("D", 0.5)
-                ctx = e.get("context", "")
-                ri = e.get("relationship_delta", 0.0)
-                speaker_name = e.get("speaker") or "User"
-                summary_parts.append(
-                    f"Context: {ctx}\n"
-                    f"{speaker_name}: {e.get('content', e.get('event', ''))}\n"
-                    f"AI: {e.get('response', '')}\n"
-                    f"[Emotion V={V:.2f} Ar={Ar:.2f} D={D:.2f} | RelDelta={ri:.2f}]"
-                )
-            summary_text = "\n---\n".join(summary_parts)
-
-            # --- PART 1: Fact Resolution (Neo4j) ---
-            fact_prompt = f"""
-            Extract new entities, relationships, and "Theory of Mind" observations from these interactions.
-            Interactions:
-            {summary_text}
-
-            Focus on:
-            1. People, Preferences, and Facts about the User.
-            2. THEORY OF MIND: Observations about the User's mental/physical state (e.g., "User seems stressed", "User is tired from work").
-
-            REQUIREMENT: Provide a confidence score (0.0 - 1.0), the appropriate category (one of: social, vocational, somatic, spiritual, crisis, milestone), and a brief reasoning for each fact.
-            Output JSON List ONLY: [{{"subject", "subject_type", "relation", "object", "object_type", "category", "confidence", "reason"}}]
-            """
-
-            try:
-                _t0 = time.monotonic()
-                fact_res = await self.llm.generate(
-                    fact_prompt,
-                    model=Config.LLM_REFLECTION_MODEL,
-                    options_override={"num_predict": 256},
-                )
-                _measure_trace(
-                    "reflection", "llm_call_facts", duration_s=time.monotonic() - _t0
-                )
-                facts = self._extract_json(fact_res)
-
-                # CVS-3.5: Defensive parsing for LLM output variability
-                if isinstance(facts, dict):
-                    facts = [facts]
-                elif not isinstance(facts, list):
-                    facts = []
-
-                for f in facts:
-                    if not isinstance(f, dict):
-                        continue
-
-                    # 1. CONFIDENCE GATING: Only store facts with > 0.8 certainty
-                    confidence = f.get("confidence", 0.0)
-                    if confidence < 0.8:
-                        logger.debug(
-                            f"Fact REJECTED (Low Confidence: {confidence}): {f.get('subject')} - {f.get('relation')}"
-                        )
-                        continue
-
-                    # 2. FACT RESOLUTION: Check for existing duplication in GraphDB
-                    subject = f.get("subject")
-                    object_val = f.get("object")
-                    relation = f.get("relation")
-                    subject_type = f.get("subject_type", "Entity")
-                    object_type = f.get("object_type", "Entity")
-                    category = f.get("category", "social").lower()
-
-                    if not subject or not object_val or not relation:
-                        continue
-
-                    # Neo4j must NOT have distractors
-                    if category == "distractor":
-                        logger.debug(
-                            "Fact REJECTED (Distractors are excluded from Neo4j)"
-                        )
-                        continue
-
-                    if category not in [
-                        "social",
-                        "vocational",
-                        "somatic",
-                        "spiritual",
-                        "crisis",
-                        "milestone",
-                    ]:
-                        category = "social"
-
-                    try:
-                        # P3-11: canonicalization (LIKES/ENJOYS/LOVES -> one
-                        # type) now lives in GraphDB.consolidate_relationship
-                        # itself, applied to every write regardless of
-                        # caller -- this is just the pre-flight safety check
-                        # so an unsafe relation string is skipped-and-logged
-                        # here rather than raising from deep inside the DB
-                        # call below.
-                        rel_type = GraphDB._safe_relation(relation)
-                        GraphDB._safe_label(subject_type)
-                        GraphDB._safe_label(object_type)
-                        GraphDB._safe_label(category.capitalize())
-                    except ValueError:
-                        logger.warning(
-                            "Skipping unsafe graph fact from reflection: %r", f
-                        )
-                        continue
-
-                    # P2-13: this used to MATCH for an existing relationship
-                    # first and `continue` on a hit, logging "Fact RESOLVED"
-                    # and never writing anything -- so a restated fact never
-                    # reinforced, while decay_relationships still pushed
-                    # every edge toward the prune threshold regardless of
-                    # repetition. create_triplet -> consolidate_relationship
-                    # already does the right thing on a repeat (`ON MATCH SET
-                    # r.weight = coalesce(r.weight, 1) + 1`); the guard above
-                    # was preventing that path from ever being reached.
-                    await self.graph.create_triplet(
-                        subject,
-                        rel_type,
-                        object_val,
-                        properties={
-                            "confidence": confidence,
-                            "extracted_at": str(time.time()),
-                            "category": category,
-                        },
-                        subject_label=subject_type,
-                        target_label=object_type,
-                    )
-            except Exception as e:
-                logger.error(f"Fact consolidation failure: {e}")
-
-            # --- PART 2: Persona Evolution ---
-            # Identical pattern for Persona stability
-            identity_prompt = f"""
-            Determine if {self.identity.personality.get("name")}'s personality or relationship should evolve.
-            Interactions:
-            {summary_text}
-            Current Role: {self.identity.history.get("relationship")}
-
-            Output JSON ONLY: {{"new_traits": ["..."], "relationship": "...", "confidence": 0.0}}
-            """
-            try:
-                _t0 = time.monotonic()
-                ident_res = await self.llm.generate(
-                    identity_prompt,
-                    model=Config.LLM_REFLECTION_MODEL,
-                    options_override={"num_predict": 256},
-                )
-                _measure_trace(
-                    "reflection", "llm_call_identity", duration_s=time.monotonic() - _t0
-                )
-                suggestions = self._extract_json(ident_res)
-
-                # CVS-3.5: Defensive parsing for identity suggestions (Ensures
-                # .get() availability). The list branch used to stop at
-                # "is this a list", not "is the element inside a dict" --
-                # `_extract_json` returning e.g. ["some string"] unwrapped to
-                # a bare str that .get() below then crashed on. The sibling
-                # fact-parsing block above (line ~156) already re-validates
-                # each unwrapped element; this one didn't. Found via a real
-                # concurrent-load run (roadmap Phase 6.2) where contention
-                # made the reflection LLM call more likely to return a
-                # malformed shape.
-                if isinstance(suggestions, list) and len(suggestions) > 0:
-                    suggestions = suggestions[0]
-                if not isinstance(suggestions, dict):
-                    suggestions = {}
-
-                if suggestions and suggestions.get("confidence", 0.0) >= 0.8:
-                    await self.identity.evolve_persona(suggestions)
-                else:
-                    logger.debug(
-                        "Persona evolution REJECTED: Low confidence or no growth detected."
-                    )
-            except Exception as e:
-                logger.error(f"Identity evolution failure: {e}")
-
-            # --- PART 3: Long-Term Episodic Memory Consolidation ---
-            try:
-                # Calculate composite affective vectors
-                total_valence = 0.0
-                total_arousal = 0.0
-                total_dominance = 0.0
-                count = len(episodes)
-                for e in episodes:
-                    emotion_vec = e.get("emotion_vector", {})
-                    total_valence += emotion_vec.get("V", 0.0)
-                    total_arousal += emotion_vec.get("Ar", 0.5)
-                    total_dominance += emotion_vec.get("D", 0.5)
-
-                avg_valence = total_valence / count if count > 0 else 0.0
-                avg_arousal = total_arousal / count if count > 0 else 0.5
-                avg_dominance = total_dominance / count if count > 0 else 0.5
-
-                consolidation_prompt = f"""
-                Consolidate the following recent interaction episodes into a single, cohesive episodic memory summary.
-                This summary should capture the essence of what was discussed, the emotional tone of both the user and the AI, and any key takeaways or relationship progression.
-                Interactions:
-                {summary_text}
-
-                Format: A brief, single-paragraph narrative from the AI's perspective (e.g. "We discussed...").
-                """
-
-                _t0 = time.monotonic()
-                consolidation_res = await self.llm.generate(
-                    consolidation_prompt,
-                    model=Config.LLM_REFLECTION_MODEL,
-                    options_override={"num_predict": 256},
-                )
-                _measure_trace(
-                    "reflection",
-                    "llm_call_consolidation",
-                    duration_s=time.monotonic() - _t0,
-                )
-                consolidated_summary = consolidation_res.strip()
-                if "<think>" in consolidated_summary:
-                    consolidated_summary = consolidated_summary.split("</think>")[
-                        -1
-                    ].strip()
-
-                if consolidated_summary and self.vector:
-                    await self.vector.add_memory(
-                        content=consolidated_summary,
-                        raw_content=summary_text,
-                        wing="personal",
-                        importance=0.6,
-                        emotion=avg_arousal,
-                        valence=avg_valence,
-                        source="subconscious_consolidation",
-                        metadata={
-                            "composite_valence": avg_valence,
-                            "composite_arousal": avg_arousal,
-                            "composite_dominance": avg_dominance,
-                            "episode_count": len(episodes),
-                        },
-                    )
-                    logger.info(
-                        "[Reflection] Long-term episodic memory successfully consolidated and stored."
-                    )
-            except Exception as e:
-                logger.error(f"Episodic memory consolidation failure: {e}")
-
-            # --- PART 4: Hebbian Graph Decay ---
-            if self.graph:
-                try:
-                    await self.graph.decay_relationships(
-                        decay_factor=0.95, prune_threshold=0.25
-                    )
-                except Exception as e:
-                    logger.error(f"[Reflection] Graph decay failed: {e}")
+            await self._consolidate_facts(summary_text)
+            await self._consolidate_persona(summary_text)
+            await self._consolidate_episodic_memory(episodes, summary_text)
+            await self._decay_relationship_graph()
 
             logger.info("[Reflection] Semantic Mesh Consolidation Complete.")
 

--- a/backend/app/cognitive/pipeline.py
+++ b/backend/app/cognitive/pipeline.py
@@ -72,6 +72,282 @@ class CognitivePipeline:
         self.reappraisal = reappraisal
         self._system2_task = None
 
+    async def _resolve_turn_conflict(
+        self,
+        raw_event: dict[str, Any],
+        raw_event_type,
+        event_metadata: dict[str, Any],
+        stage_times: dict[str, Any],
+        result: dict[str, Any],
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        """Stage 2: turn-taking conflict resolution against a pending
+        speculative intent. Yields the resume/stop mesh_signal, if any.
+
+        `result["stop"]` is set True when a confirmed interruption means the
+        whole pipeline must stop here -- an async generator can't both yield
+        chunks and return a value (see `_stream_action_pass`), so the
+        stop signal goes through this mutable dict instead.
+        """
+        import time
+
+        result["stop"] = False
+        t_start = time.perf_counter()
+        if raw_event_type == "USER_MESSAGE" and not raw_event.get("is_partial"):
+            final_text = raw_event.get("content", "")
+            speculative_intent = self.state.last_speculative_intent
+
+            if speculative_intent:
+                confirmed = self.decision.is_speculative_stop_confirmed(
+                    final_text,
+                    speculative_intent.get("keywords"),
+                )
+                self.state.last_speculative_intent = None
+
+                if not confirmed:
+                    logger.info(
+                        "[Pipeline] Interruption REJECTED. Resuming playback..."
+                    )
+                    stage_times["stage_2_conflict_resolution_ms"] = (
+                        time.perf_counter() - t_start
+                    ) * 1000.0
+                    yield {
+                        "type": "mesh_signal",
+                        "subject": "audio.resume",
+                        "data": {
+                            "reason": "conflict_rejected",
+                            "perception_text": speculative_intent.get("text", ""),
+                            "utterance_id": speculative_intent.get("utterance_id"),
+                        },
+                    }
+                    return
+                else:
+                    logger.info("[Pipeline] Interruption CONFIRMED. Stopping playback.")
+                    stage_times["stage_2_conflict_resolution_ms"] = (
+                        time.perf_counter() - t_start
+                    ) * 1000.0
+                    yield {
+                        "type": "mesh_signal",
+                        "subject": "audio.stop",
+                        "data": {
+                            "interrupt": True,
+                            "speculative": False,
+                            "reason": "confirmed_command",
+                            "command_text": final_text,
+                            "keywords": speculative_intent.get("keywords", []),
+                            "utterance_id": speculative_intent.get("utterance_id"),
+                            "turn_id": event_metadata.get("turn_id"),
+                        },
+                    }
+                    result["stop"] = True
+                    return
+        stage_times["stage_2_conflict_resolution_ms"] = (
+            time.perf_counter() - t_start
+        ) * 1000.0
+
+    async def _update_state_from_appraisal(
+        self,
+        event,
+        event_metadata: dict[str, Any],
+        raw_event: dict[str, Any],
+        appraisal_vector,
+        state_snapshot,
+        stage_times: dict[str, Any],
+        result: dict[str, Any],
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        """Stage 5: reappraisal outcome eval, ToM update, apply appraisal to
+        state, kick off System 2. Yields the state.update mesh_signal for a
+        USER_MESSAGE turn. `result["state_snapshot"]` carries the (possibly
+        refreshed) snapshot back out -- an async generator can't both yield
+        chunks and return a value (see `_stream_action_pass`)."""
+        import time
+
+        t_start = time.perf_counter()
+        if event.event_type == "USER_MESSAGE":
+            # Reappraisal outcome evaluation
+            if self.reappraisal:
+                acoustic_delta = self._resolve_acoustic_delta(event_metadata, raw_event)
+                actual_text_valence = self._resolve_actual_text_valence(
+                    appraisal_vector, event
+                )
+
+                prediction_error = await self.reappraisal.evaluate_outcome(
+                    actual_text_valence=actual_text_valence,
+                    acoustic_delta=acoustic_delta,
+                    behavioral_signal=0.5,
+                )
+                await self._apply_reward_prediction_error(prediction_error)
+
+            # Pre-Decision Vocabulary Update (zero LLM overhead concepts indexing)
+            await self.state.update_theory_of_mind(event.raw_content)
+
+            weights = self.reappraisal.get_weights() if self.reappraisal else None
+            await self.state.update_from_appraisal(appraisal_vector, weights=weights)
+
+            # Trigger System 2 deep appraisal in background (non-blocking).
+            # A2: cancel any still-running prior appraisal so overlapping
+            # tasks cannot clobber each other's writes to short-term affect.
+            if self.llm:
+                if self._system2_task and not self._system2_task.done():
+                    self._system2_task.cancel()
+                self._system2_task = asyncio.create_task(
+                    self._async_system2_appraisal(event.raw_content)
+                )
+
+            state_snapshot = self.state.get_context_snapshot()
+            stage_times["stage_5_state_update_ms"] = (
+                time.perf_counter() - t_start
+            ) * 1000.0
+            yield {
+                "type": "mesh_signal",
+                "subject": "state.update",
+                "data": StateUpdate.from_snapshot(state_snapshot).model_dump(),
+            }
+        else:
+            stage_times["stage_5_state_update_ms"] = (
+                time.perf_counter() - t_start
+            ) * 1000.0
+        result["state_snapshot"] = state_snapshot
+
+    @staticmethod
+    def _resolve_acoustic_delta(event_metadata: dict[str, Any], raw_event: dict[str, Any]) -> float:
+        if isinstance(event_metadata, dict) and "acoustic_metadata" in event_metadata:
+            return event_metadata["acoustic_metadata"].get("emotion_bias", 0.0)
+        if "acoustic_metadata" in raw_event:
+            return raw_event["acoustic_metadata"].get("emotion_bias", 0.0)
+        return 0.0
+
+    @staticmethod
+    def _resolve_actual_text_valence(appraisal_vector, event) -> float:
+        actual_text_valence = appraisal_vector.goal_congruence
+        tom = event.metadata.get("tom_inferences", {}) if event.metadata else {}
+        if isinstance(tom, dict) and "inferred_valence" in tom:
+            return tom["inferred_valence"]
+        return actual_text_valence
+
+    async def _apply_post_decision_tom(
+        self, event, state_snapshot, result: dict[str, Any]
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        """Stage 6's ToM tail: a USER_MESSAGE turn with fresh tom_inferences
+        re-applies them to state and yields the refreshed state.update.
+        `result["state_snapshot"]` carries the (possibly refreshed) snapshot
+        back out, same reasoning as `_update_state_from_appraisal`."""
+        if event.event_type == "USER_MESSAGE":
+            tom_inferences = event.metadata.get("tom_inferences")
+            if tom_inferences:
+                await self.state.update_theory_of_mind(
+                    event.raw_content, tom_inferences
+                )
+                state_snapshot = self.state.get_context_snapshot()
+                yield {
+                    "type": "mesh_signal",
+                    "subject": "state.update",
+                    "data": StateUpdate.from_snapshot(state_snapshot).model_dump(),
+                }
+        result["state_snapshot"] = state_snapshot
+
+    async def _validate_and_self_correct(
+        self,
+        plan,
+        is_spec: bool,
+        full_response: str,
+        done_chunk: dict[str, Any] | None,
+        result: dict[str, Any],
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        """Stage 9: identity-boundary validation, with one self-correction
+        retry pass on failure. `result["full_response"]`/`result["done_chunk"]`
+        carry the (possibly corrected) output back out; `done_chunk` passes
+        stage 8's value through unchanged when validation doesn't retry."""
+        if full_response:
+            is_valid, reason = await self.identity.validate_response(
+                full_response, plan.goal
+            )
+            if not is_valid:
+                logger.warning(
+                    f"[Identity] Validation failed: {reason}. SELF-CORRECTION."
+                )
+                plan.payload["identity_prompt"] += (
+                    f"\n\nCRITICAL FIX: Your previous response was rejected for: {reason}. Correct this immediately."
+                )
+                retry_result: dict[str, Any] = {"response": "", "done": None}
+                async for chunk in self._stream_action_pass(
+                    plan, is_spec, retry_result
+                ):
+                    yield chunk
+                full_response = retry_result["response"]
+                done_chunk = retry_result["done"]
+        result["full_response"] = full_response
+        result["done_chunk"] = done_chunk
+
+    def _prepare_action_payload(self, plan, state_snapshot, event, state_directive) -> None:
+        """Stage 7: populate `plan.payload` with everything action.py's
+        endocrine-to-sampling mapping and prompt assembly need. Pure -- no
+        yields, so it's a plain call from `execute` rather than a
+        sub-generator."""
+        plan.payload["identity_prompt"] = self.identity.get_persona_prompt(
+            state_directive
+        )
+        plan.payload["cortisol"] = state_snapshot.get("cortisol", 0.5)
+        plan.payload["dopamine"] = state_snapshot.get("dopamine", 0.0)
+        plan.payload["fatigue"] = state_snapshot.get("fatigue", 0.0)
+        plan.payload["user_mental_model"] = state_snapshot.get("user_mental_model")
+        plan.payload["valence"] = state_snapshot.get("mood", 0.0)
+        plan.payload["arousal"] = state_snapshot.get("energy", 0.5)
+        plan.payload["dominance"] = state_snapshot.get("dominance", 0.5)
+        plan.payload["speculative"] = (
+            event.metadata.get("speculative", False) if event.metadata else False
+        )
+        plan.payload["visual_context"] = (
+            event.metadata.get("visuals") if event.metadata else None
+        )
+
+    @staticmethod
+    def _compute_pre_llm_telemetry(stage_times: dict[str, Any], event) -> None:
+        """Fold stages 1-7's timings into a pre-LLM total, plus the
+        intent/ToM fields the telemetry payload reports."""
+        pre_llm_total = sum(
+            [
+                stage_times["stage_1_extraction_ms"],
+                stage_times["stage_2_conflict_resolution_ms"],
+                stage_times["stage_3_perception_ms"],
+                stage_times["stage_4_appraisal_ms"],
+                stage_times["stage_5_state_update_ms"],
+                stage_times["stage_6_decision_ms"],
+                stage_times["stage_7_action_prep_ms"],
+            ]
+        )
+        stage_times["pre_llm_total_ms"] = pre_llm_total
+        stage_times["heuristic_intent"] = (
+            event.metadata.get("heuristic_intent") or event.intent
+        )
+        stage_times["llm_intent"] = event.intent
+        tom_inferences = event.metadata.get("tom_inferences") or {}
+        stage_times["inferred_valence"] = tom_inferences.get("inferred_valence")
+        stage_times["inferred_arousal"] = tom_inferences.get("inferred_arousal")
+
+    @staticmethod
+    def _build_consolidation_episode(
+        event, raw_event, state_directive, appraisal_vector, state, state_snapshot, full_response
+    ) -> dict[str, Any]:
+        """Stage 10: shape one turn into the schema `learning._consolidate`
+        expects."""
+        return {
+            "id": event.event_id,
+            "event": event.raw_content,
+            "speaker": raw_event.get("user_id") or "User",
+            "context": state_directive,
+            "emotion_vector": {
+                "V": state.current_state.valence,
+                "Ar": state.current_state.arousal,
+                "D": state.current_state.dominance,
+            },
+            "appraisal": appraisal_vector.to_dict(),
+            "relationship_delta": appraisal_vector.relationship_impact,
+            "intent": event.intent,
+            "content": event.raw_content,
+            "state": state_snapshot,
+            "response": full_response,
+        }
+
     async def execute(
         self, raw_event: dict[str, Any], surfaced_memories: list[dict[str, Any]] | None = None
     ) -> AsyncGenerator[dict[str, Any], None]:
@@ -81,7 +357,7 @@ class CognitivePipeline:
         """
         import time
 
-        stage_times = {}
+        stage_times: dict[str, Any] = {}
 
         # 1. Extraction & Metadata
         t_start = time.perf_counter()
@@ -120,61 +396,14 @@ class CognitivePipeline:
                 }
 
         # 2. Conflict Resolution (Turn-Taking Stability)
-        t_start = time.perf_counter()
-        conflict_resolved = False
-        if raw_event_type == "USER_MESSAGE" and not raw_event.get("is_partial"):
-            final_text = raw_event.get("content", "")
-            speculative_intent = self.state.last_speculative_intent
-
-            if speculative_intent:
-                confirmed = self.decision.is_speculative_stop_confirmed(
-                    final_text,
-                    speculative_intent.get("keywords"),
-                )
-                self.state.last_speculative_intent = None
-
-                if not confirmed:
-                    logger.info(
-                        "[Pipeline] Interruption REJECTED. Resuming playback..."
-                    )
-                    stage_times["stage_2_conflict_resolution_ms"] = (
-                        time.perf_counter() - t_start
-                    ) * 1000.0
-                    yield {
-                        "type": "mesh_signal",
-                        "subject": "audio.resume",
-                        "data": {
-                            "reason": "conflict_rejected",
-                            "perception_text": speculative_intent.get("text", ""),
-                            "utterance_id": speculative_intent.get("utterance_id"),
-                        },
-                    }
-                    conflict_resolved = True
-                else:
-                    logger.info("[Pipeline] Interruption CONFIRMED. Stopping playback.")
-                    stage_times["stage_2_conflict_resolution_ms"] = (
-                        time.perf_counter() - t_start
-                    ) * 1000.0
-                    yield {
-                        "type": "mesh_signal",
-                        "subject": "audio.stop",
-                        "data": {
-                            "interrupt": True,
-                            "speculative": False,
-                            "reason": "confirmed_command",
-                            "command_text": final_text,
-                            "keywords": speculative_intent.get("keywords", []),
-                            "utterance_id": speculative_intent.get("utterance_id"),
-                            "turn_id": event_metadata.get("turn_id"),
-                        },
-                    }
-                    conflict_resolved = True
-                    yield {"type": "pipeline_telemetry", "data": stage_times}
-                    return
-        if not conflict_resolved:
-            stage_times["stage_2_conflict_resolution_ms"] = (
-                time.perf_counter() - t_start
-            ) * 1000.0
+        conflict_result: dict[str, Any] = {}
+        async for chunk in self._resolve_turn_conflict(
+            raw_event, raw_event_type, event_metadata, stage_times, conflict_result
+        ):
+            yield chunk
+        if conflict_result["stop"]:
+            yield {"type": "pipeline_telemetry", "data": stage_times}
+            return
 
         # 3. Sequential Perception
         t_start = time.perf_counter()
@@ -203,64 +432,18 @@ class CognitivePipeline:
         yield {"type": "appraisal", "data": appraisal_vector}
 
         # 5. State Update via Appraisal (§2.3 — ALMA mood-pull)
-        t_start = time.perf_counter()
-        if event.event_type == "USER_MESSAGE":
-            # Reappraisal outcome evaluation
-            if self.reappraisal:
-                acoustic_delta = 0.0
-                if (
-                    isinstance(event_metadata, dict)
-                    and "acoustic_metadata" in event_metadata
-                ):
-                    acoustic_delta = event_metadata["acoustic_metadata"].get(
-                        "emotion_bias", 0.0
-                    )
-                elif "acoustic_metadata" in raw_event:
-                    acoustic_delta = raw_event["acoustic_metadata"].get(
-                        "emotion_bias", 0.0
-                    )
-
-                actual_text_valence = appraisal_vector.goal_congruence
-                tom = event.metadata.get("tom_inferences", {}) if event.metadata else {}
-                if isinstance(tom, dict) and "inferred_valence" in tom:
-                    actual_text_valence = tom["inferred_valence"]
-
-                prediction_error = await self.reappraisal.evaluate_outcome(
-                    actual_text_valence=actual_text_valence,
-                    acoustic_delta=acoustic_delta,
-                    behavioral_signal=0.5,
-                )
-                await self._apply_reward_prediction_error(prediction_error)
-
-            # Pre-Decision Vocabulary Update (zero LLM overhead concepts indexing)
-            await self.state.update_theory_of_mind(event.raw_content)
-
-            weights = self.reappraisal.get_weights() if self.reappraisal else None
-            await self.state.update_from_appraisal(appraisal_vector, weights=weights)
-
-            # Trigger System 2 deep appraisal in background (non-blocking).
-            # A2: cancel any still-running prior appraisal so overlapping tasks
-            # cannot clobber each other's writes to short-term affect.
-            if self.llm:
-                if self._system2_task and not self._system2_task.done():
-                    self._system2_task.cancel()
-                self._system2_task = asyncio.create_task(
-                    self._async_system2_appraisal(event.raw_content)
-                )
-
-            state_snapshot = self.state.get_context_snapshot()
-            stage_times["stage_5_state_update_ms"] = (
-                time.perf_counter() - t_start
-            ) * 1000.0
-            yield {
-                "type": "mesh_signal",
-                "subject": "state.update",
-                "data": StateUpdate.from_snapshot(state_snapshot).model_dump(),
-            }
-        else:
-            stage_times["stage_5_state_update_ms"] = (
-                time.perf_counter() - t_start
-            ) * 1000.0
+        state_update_result: dict[str, Any] = {}
+        async for chunk in self._update_state_from_appraisal(
+            event,
+            event_metadata,
+            raw_event,
+            appraisal_vector,
+            state_snapshot,
+            stage_times,
+            state_update_result,
+        ):
+            yield chunk
+        state_snapshot = state_update_result["state_snapshot"]
 
         # 6. Decision (BT + MAUT)
         t_start = time.perf_counter()
@@ -278,67 +461,27 @@ class CognitivePipeline:
             )
 
         # Post-Decision ToM Application: ingest LLM-inferred parameters to state
-        if event.event_type == "USER_MESSAGE":
-            tom_inferences = event.metadata.get("tom_inferences")
-            if tom_inferences:
-                await self.state.update_theory_of_mind(
-                    event.raw_content, tom_inferences
-                )
-                state_snapshot = self.state.get_context_snapshot()
-                yield {
-                    "type": "mesh_signal",
-                    "subject": "state.update",
-                    "data": StateUpdate.from_snapshot(state_snapshot).model_dump(),
-                }
+        tom_result: dict[str, Any] = {}
+        async for chunk in self._apply_post_decision_tom(
+            event, state_snapshot, tom_result
+        ):
+            yield chunk
+        state_snapshot = tom_result["state_snapshot"]
         stage_times["stage_6_decision_ms"] = (time.perf_counter() - t_start) * 1000.0
 
         # 7. Action Preparation
         t_start = time.perf_counter()
-        plan.payload["identity_prompt"] = self.identity.get_persona_prompt(
-            state_directive
-        )
-        plan.payload["cortisol"] = state_snapshot.get("cortisol", 0.5)
-        plan.payload["dopamine"] = state_snapshot.get("dopamine", 0.0)
-        plan.payload["fatigue"] = state_snapshot.get("fatigue", 0.0)
-        plan.payload["user_mental_model"] = state_snapshot.get("user_mental_model")
-        plan.payload["valence"] = state_snapshot.get("mood", 0.0)
-        plan.payload["arousal"] = state_snapshot.get("energy", 0.5)
-        plan.payload["dominance"] = state_snapshot.get("dominance", 0.5)
-        plan.payload["speculative"] = (
-            event.metadata.get("speculative", False) if event.metadata else False
-        )
-        plan.payload["visual_context"] = (
-            event.metadata.get("visuals") if event.metadata else None
-        )
+        self._prepare_action_payload(plan, state_snapshot, event, state_directive)
         stage_times["stage_7_action_prep_ms"] = (time.perf_counter() - t_start) * 1000.0
 
-        # Calculate Pre-LLM total time
-        pre_llm_total = sum(
-            [
-                stage_times["stage_1_extraction_ms"],
-                stage_times["stage_2_conflict_resolution_ms"],
-                stage_times["stage_3_perception_ms"],
-                stage_times["stage_4_appraisal_ms"],
-                stage_times["stage_5_state_update_ms"],
-                stage_times["stage_6_decision_ms"],
-                stage_times["stage_7_action_prep_ms"],
-            ]
-        )
-        stage_times["pre_llm_total_ms"] = pre_llm_total
-        stage_times["heuristic_intent"] = (
-            event.metadata.get("heuristic_intent") or event.intent
-        )
-        stage_times["llm_intent"] = event.intent
-        tom_inferences = event.metadata.get("tom_inferences") or {}
-        stage_times["inferred_valence"] = tom_inferences.get("inferred_valence")
-        stage_times["inferred_arousal"] = tom_inferences.get("inferred_arousal")
+        self._compute_pre_llm_telemetry(stage_times, event)
 
         # 8. Action Execution
         t_start = time.perf_counter()
-        full_response = ""
-        done_chunk = None
+        full_response: str = ""
+        done_chunk: dict[str, Any] | None = None
         is_spec = plan.payload.get("speculative", False)
-        pass_result = {"response": "", "done": None}
+        pass_result: dict[str, Any] = {"response": "", "done": None}
         async for chunk in self._stream_action_pass(plan, is_spec, pass_result):
             yield chunk
         full_response = pass_result["response"]
@@ -349,46 +492,27 @@ class CognitivePipeline:
 
         # 9. Validation & Self-Correction
         t_start = time.perf_counter()
-        if full_response:
-            is_valid, reason = await self.identity.validate_response(
-                full_response, plan.goal
-            )
-            if not is_valid:
-                logger.warning(
-                    f"[Identity] Validation failed: {reason}. SELF-CORRECTION."
-                )
-                plan.payload["identity_prompt"] += (
-                    f"\n\nCRITICAL FIX: Your previous response was rejected for: {reason}. Correct this immediately."
-                )
-                retry_result = {"response": "", "done": None}
-                async for chunk in self._stream_action_pass(
-                    plan, is_spec, retry_result
-                ):
-                    yield chunk
-                full_response = retry_result["response"]
-                done_chunk = retry_result["done"]
+        validation_result: dict[str, Any] = {}
+        async for chunk in self._validate_and_self_correct(
+            plan, is_spec, full_response, done_chunk, validation_result
+        ):
+            yield chunk
+        full_response = validation_result["full_response"]
+        done_chunk = validation_result["done_chunk"]
         stage_times["stage_9_validation_ms"] = (time.perf_counter() - t_start) * 1000.0
 
         # 10. Learning + Episodic Memory (§6.1)
         t_start = time.perf_counter()
         if event.intent in ["CHAT", "REMEMBER"] and full_response:
-            episode = {
-                "id": event.event_id,
-                "event": event.raw_content,
-                "speaker": raw_event.get("user_id") or "User",
-                "context": state_directive,
-                "emotion_vector": {
-                    "V": self.state.current_state.valence,
-                    "Ar": self.state.current_state.arousal,
-                    "D": self.state.current_state.dominance,
-                },
-                "appraisal": appraisal_vector.to_dict(),
-                "relationship_delta": appraisal_vector.relationship_impact,
-                "intent": event.intent,
-                "content": event.raw_content,
-                "state": state_snapshot,
-                "response": full_response,
-            }
+            episode = self._build_consolidation_episode(
+                event,
+                raw_event,
+                state_directive,
+                appraisal_vector,
+                self.state,
+                state_snapshot,
+                full_response,
+            )
             yield {"type": "reflection_needed", "data": [episode]}
         stage_times["stage_10_learning_ms"] = (time.perf_counter() - t_start) * 1000.0
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -502,12 +502,12 @@ class AppSettings(BaseSettings):
     # derived config, and easy to miss when adding a third computed value.
     # Real computed_field properties are visible on AppSettings itself, so
     # ConfigMeta's job shrinks to "look up the instance," nothing more.
-    @computed_field
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def ALLOWED_ORIGINS(self) -> list[str]:
         return self.ALLOWED_ORIGINS_STR.split(",")
 
-    @computed_field
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def OLLAMA_REQUIRED_MODELS(self) -> list[str]:
         if self.OLLAMA_REQUIRED_MODELS_STR.strip():
@@ -516,10 +516,12 @@ class AppSettings(BaseSettings):
                 for model in self.OLLAMA_REQUIRED_MODELS_STR.split(",")
                 if model.strip()
             ]
+        # set_defaults() (a model_validator) already backfills these from
+        # LLM_FAST_MODEL, but that invariant isn't visible to mypy here.
         models = [
-            self.LLM_CHAT_MODEL,
+            self.LLM_CHAT_MODEL or self.LLM_FAST_MODEL,
             self.LLM_FAST_MODEL,
-            self.LLM_REFLECTION_MODEL,
+            self.LLM_REFLECTION_MODEL or self.LLM_FAST_MODEL,
             "nomic-embed-text",
         ]
         if self.VLM_ENABLED:

--- a/backend/app/llm/__init__.py
+++ b/backend/app/llm/__init__.py
@@ -19,7 +19,10 @@ from typing import Any, Protocol, runtime_checkable
 
 @runtime_checkable
 class LLMClient(Protocol):
-    async def generate_stream(
+    # Not `async def`: the real implementations are async-generator functions
+    # (they `yield`), so calling them returns the generator directly rather
+    # than a coroutine that resolves to one.
+    def generate_stream(
         self,
         prompt: str,
         system: str | None = None,

--- a/backend/app/llm/ollama_client.py
+++ b/backend/app/llm/ollama_client.py
@@ -251,6 +251,61 @@ class OllamaClient:
 
         yield "I'm having trouble thinking right now..."
 
+    def _mock_generate_response(self, prompt: str) -> str:
+        """Deterministic MOCK_LLM_TEXT reply, keyed on prompt content shape."""
+        lower_prompt = prompt.lower()
+
+        # Corpus-agnostic deterministic mock: reflect back the memory content
+        # retrieval actually surfaced, rather than hardcoding eval entities.
+        snippet = self._extract_first_memory_snippet(prompt)
+        if snippet and "shared history / recent context" in lower_prompt:
+            return f"I remember that — {snippet}"
+
+        if "subject_type" in lower_prompt or "output json list only" in lower_prompt:
+            return json.dumps(
+                [
+                    {
+                        "subject": "User",
+                        "subject_type": "person",
+                        "relation": "likes",
+                        "object": "reading sci-fi",
+                        "object_type": "activity",
+                        "category": "social",
+                        "confidence": 0.9,
+                        "reason": "User mentioned reading sci-fi and we had a warm discussion about it.",
+                    }
+                ]
+            )
+        elif "new_traits" in lower_prompt or "relationship" in lower_prompt:
+            return json.dumps(
+                {"new_traits": [], "relationship": "friend", "confidence": 0.9}
+            )
+        elif (
+            "goal_congruence" in lower_prompt
+            or "appraisal dimensions" in lower_prompt
+        ):
+            return json.dumps(
+                {"goal_congruence": 0.0, "norm_alignment": 1.0, "expectedness": 0.5}
+            )
+        elif "inferred_valence" in lower_prompt or "implied_goals" in lower_prompt:
+            return json.dumps(
+                {
+                    "intent": "CHAT",
+                    "goal": "socialize",
+                    "inferred_valence": 0.5,
+                    "inferred_arousal": 0.3,
+                    "implied_goals": ["chat_socially"],
+                }
+            )
+        elif "consolidate" in lower_prompt or "episodic memory summary" in lower_prompt:
+            return "We discussed our shared interests, including sci-fi books and coding algorithms, and enjoyed a friendly conversation."
+        elif "dream" in lower_prompt:
+            return "Processing memories of my friend, feeling a deep sense of connection through shared projects and programming ideas."
+        elif "thought" in lower_prompt or "inner monologue" in lower_prompt:
+            return "I appreciate my friend. I wonder what they are coding today."
+        else:
+            return "I am glad we are chatting, my friend. What should we work on next?"
+
     async def generate(
         self,
         prompt: str,
@@ -259,66 +314,7 @@ class OllamaClient:
         options_override: dict[str, Any] | None = None,
     ) -> str:
         if getattr(Config, "MOCK_LLM_TEXT", False):
-            lower_prompt = prompt.lower()
-
-            # Corpus-agnostic deterministic mock: reflect back the memory content
-            # retrieval actually surfaced, rather than hardcoding eval entities.
-            snippet = self._extract_first_memory_snippet(prompt)
-            if snippet and "shared history / recent context" in lower_prompt:
-                return f"I remember that — {snippet}"
-
-            if (
-                "subject_type" in lower_prompt
-                or "output json list only" in lower_prompt
-            ):
-                return json.dumps(
-                    [
-                        {
-                            "subject": "User",
-                            "subject_type": "person",
-                            "relation": "likes",
-                            "object": "reading sci-fi",
-                            "object_type": "activity",
-                            "category": "social",
-                            "confidence": 0.9,
-                            "reason": "User mentioned reading sci-fi and we had a warm discussion about it.",
-                        }
-                    ]
-                )
-            elif "new_traits" in lower_prompt or "relationship" in lower_prompt:
-                return json.dumps(
-                    {"new_traits": [], "relationship": "friend", "confidence": 0.9}
-                )
-            elif (
-                "goal_congruence" in lower_prompt
-                or "appraisal dimensions" in lower_prompt
-            ):
-                return json.dumps(
-                    {"goal_congruence": 0.0, "norm_alignment": 1.0, "expectedness": 0.5}
-                )
-            elif "inferred_valence" in lower_prompt or "implied_goals" in lower_prompt:
-                return json.dumps(
-                    {
-                        "intent": "CHAT",
-                        "goal": "socialize",
-                        "inferred_valence": 0.5,
-                        "inferred_arousal": 0.3,
-                        "implied_goals": ["chat_socially"],
-                    }
-                )
-            elif (
-                "consolidate" in lower_prompt
-                or "episodic memory summary" in lower_prompt
-            ):
-                return "We discussed our shared interests, including sci-fi books and coding algorithms, and enjoyed a friendly conversation."
-            elif "dream" in lower_prompt:
-                return "Processing memories of my friend, feeling a deep sense of connection through shared projects and programming ideas."
-            elif "thought" in lower_prompt or "inner monologue" in lower_prompt:
-                return "I appreciate my friend. I wonder what they are coding today."
-            else:
-                return (
-                    "I am glad we are chatting, my friend. What should we work on next?"
-                )
+            return self._mock_generate_response(prompt)
 
         self._trace_prompt(prompt, system, model or self.model)
         payload_attempts = self._build_payload_attempts(

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -32,10 +32,10 @@ class SubjectMetrics:
         self._tracked_subjects = tracked_subjects
         self._log_every = max(1, log_every)
         self._tag = tag
-        self._metrics: dict[str, dict[str, float]] = {}
+        self._metrics: dict[str, dict[str, Any]] = {}
 
         # High-performance list-based atomic double buffer
-        self._buffer = []
+        self._buffer: list[tuple[str, str, float | None, dict[str, Any] | None, float]] = []
         self._lock = threading.Lock()
 
         # Thread-safe queue interface for compatibility with legacy tests

--- a/backend/app/nats_streams.py
+++ b/backend/app/nats_streams.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import os
 from collections.abc import Sequence
+from typing import cast
 
 import nats
 from nats.errors import NoRespondersError
@@ -279,8 +280,8 @@ def build_stream_config(stream_name: str, subjects: list[str]):
         subjects=list(subjects),
         retention=RetentionPolicy.LIMITS,
         storage=storage,
-        max_age=policy["max_age"],
-        max_bytes=policy["max_bytes"],
+        max_age=cast(float, policy["max_age"]),
+        max_bytes=cast(int, policy["max_bytes"]),
         # Drop the oldest messages at the limit rather than refusing new
         # ones: for both tiers, rejecting a publish would stall a live
         # conversation or the audio path, which is worse than losing the
@@ -292,7 +293,7 @@ def build_stream_config(stream_name: str, subjects: list[str]):
 async def _ensure_stream(
     jsm, stream_name: str, subjects: list[str], retries: int, delay_seconds: float
 ) -> None:
-    last_error: Exception = None
+    last_error: Exception | None = None
 
     for attempt in range(1, retries + 1):
         try:
@@ -351,13 +352,13 @@ async def setup_streams(
     )
     logger.info("Connecting to NATS at %s", nats_url)
 
-    connect_kwargs = {}
+    connect_kwargs: dict[str, str] = {}
     nats_user = os.getenv("NATS_USER")
     nats_password = os.getenv("NATS_PASSWORD")
     if nats_user and nats_password:
         connect_kwargs.update(user=nats_user, password=nats_password)
 
-    nc = await nats.connect(nats_url, **connect_kwargs)
+    nc = await nats.connect(cast(str, nats_url), **connect_kwargs)
     try:
         jsm = nc.jsm()
         await _wait_for_jetstream_ready(

--- a/backend/app/state/agent_state.py
+++ b/backend/app/state/agent_state.py
@@ -19,7 +19,7 @@ import sqlite3
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import redis
 
@@ -363,7 +363,7 @@ class StateService:
         redis_host="127.0.0.1",
         redis_port=6379,
         publish_cb=None,
-        persona: "PersonaProfile" = None,
+        persona: "PersonaProfile | None" = None,
     ):
         self.graph = graph_store
         self.db_path = db_path
@@ -383,7 +383,11 @@ class StateService:
             trust_competence=self.persona.initial_trust,
             trust_integrity=self.persona.initial_trust,
             attachment=self.persona.initial_attachment,
-            **self.persona.hormone_halflives(),
+            # Named rather than **-unpacked: a generic dict[str, float] spread
+            # makes mypy check every AgentState field for float-compatibility,
+            # not just these two.
+            dopamine_halflife_s=self.persona.hormone_halflives()["dopamine_halflife_s"],
+            cortisol_halflife_s=self.persona.hormone_halflives()["cortisol_halflife_s"],
         )
         self.last_speculative_intent = None  # Transient sensory state
         # A2: serializes short-term affect mutation so the fire-and-forget
@@ -400,6 +404,7 @@ class StateService:
         self._background_tasks: set[asyncio.Task] = set()
 
         # Connect to Redis
+        self.redis_client: redis.Redis | None
         try:
             self.redis_client = redis.Redis(
                 host=redis_host,
@@ -506,8 +511,14 @@ class StateService:
             try:
                 # Off the loop: synchronous client, and a dead Redis costs a
                 # full connect timeout here rather than returning quickly.
-                data = await asyncio.to_thread(
-                    self.redis_client.hgetall, f"state:{agent_name}"
+                # redis-py's sync Redis shares stubs with the async client, so
+                # hgetall is typed Awaitable[dict] | dict even on this
+                # always-sync client -- cast to the runtime-true shape.
+                data = cast(
+                    "dict[str, str]",
+                    await asyncio.to_thread(
+                        self.redis_client.hgetall, f"state:{agent_name}"
+                    ),
                 )
                 if data:
                     self.current_state.mood = float(data.get("mood", 0.0))

--- a/backend/app/state/memory_store.py
+++ b/backend/app/state/memory_store.py
@@ -877,6 +877,98 @@ class MemoryStore:
                 return [self._mock_embedding_vector() for _ in chunk]
             return [None] * len(chunk)
 
+    async def _prelink_memory_entities(self, content: str) -> list[str]:
+        """Entities from the graph whose name literally appears in `content`,
+        for the memory's `metadata["entities"]` and Qdrant payload."""
+        present_entities: list[str] = []
+        if not self.graph_db:
+            return present_entities
+        try:
+            entity_records = await self.graph_db.execute_query(
+                "MATCH (e:Entity) "
+                "WHERE e.name IS NOT NULL "
+                "AND toLower($content) CONTAINS toLower(e.name) "
+                "RETURN e.name AS name",
+                {"content": content},
+                use_cache=True,
+            )
+            entity_names = [r["name"] for r in entity_records]
+            content_lower = content.lower()
+            for name in entity_names:
+                name_lower = name.lower()
+                pattern = rf"\b{re.escape(name_lower)}\b"
+                if re.search(pattern, content_lower):
+                    present_entities.append(name)
+        except Exception as ge:
+            logger.debug(
+                f"Failed to fetch entities for pre-linking in add_memory: {ge}"
+            )
+        return present_entities
+
+    async def _upsert_qdrant_memory(
+        self,
+        *,
+        memory_id: str,
+        vector,
+        content: str,
+        wing,
+        room,
+        importance,
+        emotion,
+        valence,
+        certainty,
+        source,
+        lifespan_stage,
+        crisis,
+        virtue,
+        relations,
+        relation_circles,
+        modality,
+        present_entities: list[str],
+        metadata: dict,
+        current_time,
+    ) -> None:
+        if not self.qdrant_store.client:
+            return
+        qdrant_ts = (
+            str(current_time.timestamp())
+            if current_time is not None
+            else str(time.time())
+        )
+        metadata_qdrant = {
+            "wing": wing,
+            "room": room or "",
+            "importance_score": importance,
+            "emotional_weight": emotion,
+            "valence": valence,
+            "certainty": certainty,
+            "source": source,
+            "recall_count": 1,
+            "last_recalled_at": qdrant_ts,
+            "created_at": qdrant_ts,
+            "lifespan_stage": lifespan_stage or "",
+            "crisis": crisis or "",
+            "virtue": virtue or "",
+            "relations": relations or "",
+            "relation_circles": relation_circles or "",
+            "modality": modality or "",
+            "entities": present_entities,
+        }
+        if metadata:
+            metadata_qdrant["custom_metadata"] = orjson.dumps(metadata).decode()
+
+        # P3-13a: the three other add_vector_memory call sites in this file
+        # all wrap the Qdrant client's synchronous network I/O in
+        # asyncio.to_thread; this one didn't, blocking the event loop for
+        # the duration of every memory write.
+        await asyncio.to_thread(
+            self.qdrant_store.add_vector_memory,
+            memory_id=memory_id,
+            vector=vector,
+            content=content,
+            metadata=metadata_qdrant,
+        )
+
     async def add_memory(
         self,
         content,
@@ -935,28 +1027,7 @@ class MemoryStore:
                     return True
 
             # Pre-link entities from graph to metadata
-            present_entities = []
-            if self.graph_db:
-                try:
-                    entity_records = await self.graph_db.execute_query(
-                        "MATCH (e:Entity) "
-                        "WHERE e.name IS NOT NULL "
-                        "AND toLower($content) CONTAINS toLower(e.name) "
-                        "RETURN e.name AS name",
-                        {"content": content},
-                        use_cache=True,
-                    )
-                    entity_names = [r["name"] for r in entity_records]
-                    content_lower = content.lower()
-                    for name in entity_names:
-                        name_lower = name.lower()
-                        pattern = rf"\b{re.escape(name_lower)}\b"
-                        if re.search(pattern, content_lower):
-                            present_entities.append(name)
-                except Exception as ge:
-                    logger.debug(
-                        f"Failed to fetch entities for pre-linking in add_memory: {ge}"
-                    )
+            present_entities = await self._prelink_memory_entities(content)
 
             if metadata is None:
                 metadata = {}
@@ -991,45 +1062,27 @@ class MemoryStore:
                     current_time=current_time,
                 )
             # Upsert into Qdrant if online using the same memory_id
-            if self.qdrant_store.client:
-                qdrant_ts = (
-                    str(current_time.timestamp())
-                    if current_time is not None
-                    else str(time.time())
-                )
-                metadata_qdrant = {
-                    "wing": wing,
-                    "room": room or "",
-                    "importance_score": importance,
-                    "emotional_weight": emotion,
-                    "valence": valence,
-                    "certainty": certainty,
-                    "source": source,
-                    "recall_count": 1,
-                    "last_recalled_at": qdrant_ts,
-                    "created_at": qdrant_ts,
-                    "lifespan_stage": lifespan_stage or "",
-                    "crisis": crisis or "",
-                    "virtue": virtue or "",
-                    "relations": relations or "",
-                    "relation_circles": relation_circles or "",
-                    "modality": modality or "",
-                    "entities": present_entities,
-                }
-                if metadata:
-                    metadata_qdrant["custom_metadata"] = orjson.dumps(metadata).decode()
-
-                # P3-13a: the three other add_vector_memory call sites in this
-                # file all wrap the Qdrant client's synchronous network I/O in
-                # asyncio.to_thread; this one didn't, blocking the event loop
-                # for the duration of every memory write.
-                await asyncio.to_thread(
-                    self.qdrant_store.add_vector_memory,
-                    memory_id=memory_id,
-                    vector=vector,
-                    content=content,
-                    metadata=metadata_qdrant,
-                )
+            await self._upsert_qdrant_memory(
+                memory_id=memory_id,
+                vector=vector,
+                content=content,
+                wing=wing,
+                room=room,
+                importance=importance,
+                emotion=emotion,
+                valence=valence,
+                certainty=certainty,
+                source=source,
+                lifespan_stage=lifespan_stage,
+                crisis=crisis,
+                virtue=virtue,
+                relations=relations,
+                relation_circles=relation_circles,
+                modality=modality,
+                present_entities=present_entities,
+                metadata=metadata,
+                current_time=current_time,
+            )
 
             logger.info(
                 f"🧠 Memory Stored [{wing}:{room or 'global'}]: {content[:50]}..."
@@ -1247,6 +1300,122 @@ class MemoryStore:
             relation_records = []
         return candidates, entity_records, relation_records
 
+    @staticmethod
+    def _db_or_meta(db_meta, meta: dict, key: str, default):
+        """The SQL row wins over the Qdrant payload where present -- Qdrant
+        payloads can lag it (recall_count/last_recalled_at move on every
+        recall)."""
+        if db_meta and db_meta.get(key) is not None:
+            return db_meta.get(key)
+        return meta.get(key, default)
+
+    @staticmethod
+    def _parse_qdrant_created_at(created_val, current_time):
+        try:
+            if created_val:
+                return datetime.fromtimestamp(float(created_val), UTC)
+        except Exception:  # nosec B110 - falls through to the current_time/now() fallback below regardless of cause
+            pass
+        return current_time if current_time is not None else datetime.now(UTC)
+
+    def _score_one_qdrant_candidate(
+        self,
+        cand,
+        db_metadata: dict,
+        *,
+        wing,
+        room,
+        excluded,
+        threshold,
+        current_valence,
+        current_arousal,
+        current_cortisol,
+        current_time,
+        now_ts,
+    ) -> dict | None:
+        """ACT-R activation + neuromodulatory gating for one Qdrant hit.
+        Returns None for anything filtered out (wrong wing/room, excluded
+        content, or below the loose pre-threshold)."""
+        meta = cand["metadata"]
+        c_wing = meta.get("wing")
+        c_room = meta.get("room")
+        if wing is not None and c_wing != wing:
+            return None
+        if room is not None and c_room != room:
+            return None
+
+        c_content = cand["content"]
+        if c_content in excluded:
+            return None
+
+        memory_id = cand["id"]
+        db_meta = db_metadata.get(str(memory_id))
+
+        memory_valence = self._db_or_meta(db_meta, meta, "valence", 0.0)
+        emotion_weight_row = self._db_or_meta(db_meta, meta, "emotional_weight", 0.0)
+        importance_score = self._db_or_meta(db_meta, meta, "importance_score", 0.5)
+        recall_count = max(1, self._db_or_meta(db_meta, meta, "recall_count", 1))
+
+        last_recall_time = self._coerce_last_recall_ts(db_meta, meta, now_ts)
+        hours_since = max(0.001, (now_ts - last_recall_time) / 3600.0)
+
+        # 2D/3D Emotional Distance matching the research simulator
+        dist_emo = math.sqrt(
+            (memory_valence - current_valence) ** 2
+            + (emotion_weight_row - current_arousal) ** 2
+        )
+
+        base_activation = self._base_activation(
+            recall_count, hours_since, importance_score, dist_emo
+        )
+
+        similarity = cand["score"]
+        effective_similarity = self._effective_similarity(
+            similarity,
+            memory_valence,
+            emotion_weight_row,
+            current_arousal,
+            current_cortisol,
+        )
+
+        spread_activation = self.spread_weight * effective_similarity
+        score = (
+            base_activation + spread_activation - ACTR_EMO_DISTANCE_PENALTY * dist_emo
+        )
+
+        if score <= (threshold - 2.5) and importance_score < 0.7:
+            return None
+
+        created = self._parse_qdrant_created_at(meta.get("created_at"), current_time)
+
+        custom_metadata = {}
+        if "custom_metadata" in meta:
+            try:
+                custom_metadata = orjson.loads(meta["custom_metadata"])
+            except Exception:
+                pass  # nosec B110 - malformed/non-JSON custom_metadata degrades to {} regardless of cause
+
+        return {
+            "id": memory_id,
+            "content": c_content,
+            "raw_content": c_content,
+            "wing": c_wing or "personal",
+            "room": c_room,
+            "score": score,
+            "valence": memory_valence,
+            "created_at": created,
+            "recall_count": recall_count,
+            "metadata": custom_metadata,
+            "lifespan_stage": meta.get("lifespan_stage"),
+            "crisis": meta.get("crisis"),
+            "virtue": meta.get("virtue"),
+            "relations": meta.get("relations"),
+            "relation_circles": meta.get("relation_circles"),
+            "modality": meta.get("modality"),
+            "similarity": similarity,
+            "last_recalled_at": datetime.fromtimestamp(last_recall_time, UTC),
+        }
+
     async def _score_qdrant_candidates(
         self,
         candidates,
@@ -1267,124 +1436,21 @@ class MemoryStore:
             db_metadata = await self._fetch_candidate_db_metadata(candidates)
 
             for cand in candidates:
-                meta = cand["metadata"]
-                c_wing = meta.get("wing")
-                c_room = meta.get("room")
-                if wing is not None and c_wing != wing:
-                    continue
-                if room is not None and c_room != room:
-                    continue
-
-                c_content = cand["content"]
-                if c_content in excluded:
-                    continue
-
-                memory_id = cand["id"]
-                db_meta = db_metadata.get(str(memory_id))
-
-                memory_valence = (
-                    db_meta.get("valence")
-                    if (db_meta and db_meta.get("valence") is not None)
-                    else meta.get("valence", 0.0)
+                scored = self._score_one_qdrant_candidate(
+                    cand,
+                    db_metadata,
+                    wing=wing,
+                    room=room,
+                    excluded=excluded,
+                    threshold=threshold,
+                    current_valence=current_valence,
+                    current_arousal=current_arousal,
+                    current_cortisol=current_cortisol,
+                    current_time=current_time,
+                    now_ts=now_ts,
                 )
-                emotion_weight_row = (
-                    db_meta.get("emotional_weight")
-                    if (db_meta and db_meta.get("emotional_weight") is not None)
-                    else meta.get("emotional_weight", 0.0)
-                )
-                importance_score = (
-                    db_meta.get("importance_score")
-                    if (db_meta and db_meta.get("importance_score") is not None)
-                    else meta.get("importance_score", 0.5)
-                )
-                recall_count = max(
-                    1,
-                    db_meta.get("recall_count")
-                    if (db_meta and db_meta.get("recall_count") is not None)
-                    else meta.get("recall_count", 1),
-                )
-
-                last_recall_time = self._coerce_last_recall_ts(db_meta, meta, now_ts)
-                hours_since = max(0.001, (now_ts - last_recall_time) / 3600.0)
-
-                # 2D/3D Emotional Distance matching the research simulator
-                dist_emo = math.sqrt(
-                    (memory_valence - current_valence) ** 2
-                    + (emotion_weight_row - current_arousal) ** 2
-                )
-
-                base_activation = self._base_activation(
-                    recall_count, hours_since, importance_score, dist_emo
-                )
-
-                similarity = cand["score"]
-                effective_similarity = self._effective_similarity(
-                    similarity,
-                    memory_valence,
-                    emotion_weight_row,
-                    current_arousal,
-                    current_cortisol,
-                )
-
-                spread_activation = self.spread_weight * effective_similarity
-                score = (
-                    base_activation
-                    + spread_activation
-                    - ACTR_EMO_DISTANCE_PENALTY * dist_emo
-                )
-
-                if score <= (threshold - 2.5) and importance_score < 0.7:
-                    continue
-
-                created_val = meta.get("created_at")
-                try:
-                    created = (
-                        datetime.fromtimestamp(float(created_val), UTC)
-                        if created_val
-                        else (
-                            current_time
-                            if current_time is not None
-                            else datetime.now(UTC)
-                        )
-                    )
-                except Exception:
-                    created = (
-                        current_time
-                        if current_time is not None
-                        else datetime.now(UTC)
-                    )
-
-                custom_metadata = {}
-                if "custom_metadata" in meta:
-                    try:
-                        custom_metadata = orjson.loads(meta["custom_metadata"])
-                    except Exception:
-                        pass  # nosec B110 - malformed/non-JSON custom_metadata degrades to {} regardless of cause
-
-                raw_candidates.append(
-                    {
-                        "id": memory_id,
-                        "content": c_content,
-                        "raw_content": c_content,
-                        "wing": c_wing or "personal",
-                        "room": c_room,
-                        "score": score,
-                        "valence": memory_valence,
-                        "created_at": created,
-                        "recall_count": recall_count,
-                        "metadata": custom_metadata,
-                        "lifespan_stage": meta.get("lifespan_stage"),
-                        "crisis": meta.get("crisis"),
-                        "virtue": meta.get("virtue"),
-                        "relations": meta.get("relations"),
-                        "relation_circles": meta.get("relation_circles"),
-                        "modality": meta.get("modality"),
-                        "similarity": similarity,
-                        "last_recalled_at": datetime.fromtimestamp(
-                            last_recall_time, UTC
-                        ),
-                    }
-                )
+                if scored is not None:
+                    raw_candidates.append(scored)
         except Exception as qe:
             logger.error(f"Qdrant retrieval failed, falling back to database: {qe}")
         return raw_candidates
@@ -1857,48 +1923,36 @@ class MemoryStore:
         return entity_names, adj, cand_entities
 
     @staticmethod
-    def _resolve_identity_nodes(entity_records, entity_names, adj, user_id):
-        """Discover which graph nodes represent the agent and the user.
-
-        Falls back through description text, configured AI_NAME, and finally
-        the most-connected non-agent entity, so pronoun resolution still works
-        on a graph that was never explicitly annotated.
-        """
-        agent_node_name = None
-        user_node_name = None
-
-        # 1. Discover Agent Node Name dynamically
+    def _resolve_agent_node_name(entity_records, entity_names) -> str:
         for r in entity_records:
             desc = r.get("description") or ""
             if "central cognitive system" in desc.lower():
-                agent_node_name = r["name"]
-                break
-        if not agent_node_name:
-            ai_name = getattr(Config, "AI_NAME", "AI Friend")
-            for name in entity_names:
-                if name.lower() == ai_name.lower():
-                    agent_node_name = name
-                    break
-        if not agent_node_name:
-            agent_node_name = getattr(Config, "AI_NAME", "AI Friend")
+                return r["name"]
+        ai_name = getattr(Config, "AI_NAME", "AI Friend")
+        for name in entity_names:
+            if name.lower() == ai_name.lower():
+                return name
+        return ai_name
 
-        # 2. Discover User Node Name dynamically
+    @staticmethod
+    def _resolve_user_node_name(
+        entity_records, entity_names, adj, user_id, agent_node_name: str
+    ) -> str:
         if user_id:
             for name in entity_names:
                 if name.lower() == user_id.lower():
-                    user_node_name = name
-                    break
-        if not user_node_name:
-            for r in entity_records:
-                desc = r.get("description") or ""
-                if (
-                    "user" in desc.lower()
-                    or "companion" in desc.lower()
-                    or "friend" in desc.lower()
-                ) and r["name"] != agent_node_name:
-                    user_node_name = r["name"]
-                    break
-        if not user_node_name and entity_names:
+                    return name
+
+        for r in entity_records:
+            desc = r.get("description") or ""
+            if (
+                "user" in desc.lower()
+                or "companion" in desc.lower()
+                or "friend" in desc.lower()
+            ) and r["name"] != agent_node_name:
+                return r["name"]
+
+        if entity_names:
             ai_names = {"ai friend", "my friend", agent_node_name.lower()}
             if getattr(Config, "AI_NAME", None):
                 ai_names.add(Config.AI_NAME.lower())
@@ -1909,9 +1963,25 @@ class MemoryStore:
                 candidates_names.sort(
                     key=lambda name: len(adj.get(name, set())), reverse=True
                 )
-                user_node_name = candidates_names[0]
-        if not user_node_name:
-            user_node_name = user_id or "user"
+                return candidates_names[0]
+
+        return user_id or "user"
+
+    @classmethod
+    def _resolve_identity_nodes(cls, entity_records, entity_names, adj, user_id):
+        """Discover which graph nodes represent the agent and the user.
+
+        Falls back through description text, configured AI_NAME, and finally
+        the most-connected non-agent entity, so pronoun resolution still works
+        on a graph that was never explicitly annotated.
+        """
+        # 1. Discover Agent Node Name dynamically
+        agent_node_name = cls._resolve_agent_node_name(entity_records, entity_names)
+
+        # 2. Discover User Node Name dynamically
+        user_node_name = cls._resolve_user_node_name(
+            entity_records, entity_names, adj, user_id, agent_node_name
+        )
 
         return agent_node_name, user_node_name
 
@@ -2456,6 +2526,111 @@ class MemoryStore:
             "custom_metadata": orjson.dumps(raw_meta or {}).decode(),
         }
 
+    async def _promote_one_archived_row(
+        self,
+        row,
+        emb,
+        similarity,
+        matched_cues,
+        *,
+        threshold,
+        current_valence,
+        current_arousal,
+        current_cortisol,
+        current_time,
+    ) -> dict | None:
+        """Score, gate, and (if it qualifies) persist one archived row's
+        promotion to the active tier. Returns the active-shaped result dict,
+        or None if it doesn't qualify or the write failed."""
+        content = row["content"]
+        if not emb:
+            return None
+
+        (
+            score,
+            spread_activation,
+            dist_emo,
+            recall_count,
+            now,
+        ) = self._archive_row_activation(
+            row,
+            similarity,
+            current_valence=current_valence,
+            current_arousal=current_arousal,
+            current_cortisol=current_cortisol,
+            current_time=current_time,
+        )
+
+        # Only promote if it passes the threshold or is a milestone memory
+        if not (
+            score > (threshold - 2.5) or (row.get("importance_score") or 0.5) >= 0.7
+        ):
+            return None
+
+        mem_id = str(row.get("id") or uuid.uuid4())
+        raw_meta = row.get("metadata")
+        if isinstance(raw_meta, str):
+            try:
+                raw_meta = json.loads(raw_meta)
+            except Exception:
+                raw_meta = {}
+        elif not isinstance(raw_meta, dict):
+            raw_meta = {}
+
+        payload_meta = self._build_promotion_payload(row, raw_meta)
+
+        try:
+            await self._write_promoted_memory(
+                mem_id,
+                content,
+                row,
+                emb,
+                recall_count,
+                now,
+                payload_meta,
+                sql_meta=raw_meta,
+            )
+        except Exception as prom_err:
+            # The move did not persist, so this memory is still archived.
+            # Returning it anyway surfaced a result the next turn could not
+            # find again, and cached it as though it were active.
+            logger.error(f"Failed to promote memory {mem_id}: {prom_err}")
+            return None
+
+        created = self._as_aware_utc(row.get("created_at"))
+
+        # Rescore as an active memory: recall_count was incremented on
+        # promotion and last_recalled_at is now, so recency is ~0.
+        base_activation_active = self._base_activation(
+            recall_count + 1, 0.001, row.get("importance_score") or 0.5, dist_emo
+        )
+        score_active = (
+            base_activation_active
+            + spread_activation
+            - ACTR_EMO_DISTANCE_PENALTY * dist_emo
+        )
+        # Apply direct cue boost since it was promoted for keyword matches
+        match_count = sum(1 for mc in matched_cues if mc in content.lower())
+        score_active += DIRECT_CUE_BOOST * match_count
+
+        return {
+            "content": content,
+            "raw_content": row.get("raw_content") or content,
+            "wing": row.get("wing", "personal"),
+            "room": row.get("room"),
+            "score": score_active,
+            "valence": row.get("valence") or 0.0,
+            "created_at": created.isoformat() if created else None,
+            "recall_count": recall_count + 1,
+            "metadata": raw_meta or {},
+            "lifespan_stage": row.get("lifespan_stage"),
+            "crisis": row.get("crisis"),
+            "virtue": row.get("virtue"),
+            "relations": row.get("relations"),
+            "relation_circles": row.get("relation_circles"),
+            "modality": row.get("modality"),
+        }
+
     async def _promote_archived_rows(
         self,
         scored_archive_rows,
@@ -2486,102 +2661,22 @@ class MemoryStore:
                 parsed_embeddings[idx] = vec
 
         promoted_results = []
-        for row_index, (_ranking_score, score, similarity, row) in enumerate(
+        for row_index, (_ranking_score, _score, similarity, row) in enumerate(
             scored_archive_rows
         ):
-            content = row["content"]
-
-            emb = parsed_embeddings[row_index]
-            if not emb:
-                continue
-
-            (
-                _score,
-                spread_activation,
-                dist_emo,
-                recall_count,
-                now,
-            ) = self._archive_row_activation(
+            promoted = await self._promote_one_archived_row(
                 row,
+                parsed_embeddings[row_index],
                 similarity,
+                matched_cues,
+                threshold=threshold,
                 current_valence=current_valence,
                 current_arousal=current_arousal,
                 current_cortisol=current_cortisol,
                 current_time=current_time,
             )
-
-            # Only promote if it passes the threshold or is a milestone memory
-            if not (
-                score > (threshold - 2.5)
-                or (row.get("importance_score") or 0.5) >= 0.7
-            ):
-                continue
-
-            mem_id = str(row.get("id") or uuid.uuid4())
-            raw_meta = row.get("metadata")
-            if isinstance(raw_meta, str):
-                try:
-                    raw_meta = json.loads(raw_meta)
-                except Exception:
-                    raw_meta = {}
-            elif not isinstance(raw_meta, dict):
-                raw_meta = {}
-
-            payload_meta = self._build_promotion_payload(row, raw_meta)
-
-            try:
-                await self._write_promoted_memory(
-                    mem_id,
-                    content,
-                    row,
-                    emb,
-                    recall_count,
-                    now,
-                    payload_meta,
-                    sql_meta=raw_meta,
-                )
-            except Exception as prom_err:
-                # The move did not persist, so this memory is still archived.
-                # Returning it anyway surfaced a result the next turn could not
-                # find again, and cached it as though it were active.
-                logger.error(f"Failed to promote memory {mem_id}: {prom_err}")
-                continue
-
-            created = self._as_aware_utc(row.get("created_at"))
-
-            # Rescore as an active memory: recall_count was incremented on
-            # promotion and last_recalled_at is now, so recency is ~0.
-            base_activation_active = self._base_activation(
-                recall_count + 1, 0.001, row.get("importance_score") or 0.5, dist_emo
-            )
-            score_active = (
-                base_activation_active
-                + spread_activation
-                - ACTR_EMO_DISTANCE_PENALTY * dist_emo
-            )
-            # Apply direct cue boost since it was promoted for keyword matches
-            match_count = sum(1 for mc in matched_cues if mc in content.lower())
-            score_active += DIRECT_CUE_BOOST * match_count
-
-            promoted_results.append(
-                {
-                    "content": content,
-                    "raw_content": row.get("raw_content") or content,
-                    "wing": row.get("wing", "personal"),
-                    "room": row.get("room"),
-                    "score": score_active,
-                    "valence": row.get("valence") or 0.0,
-                    "created_at": created.isoformat() if created else None,
-                    "recall_count": recall_count + 1,
-                    "metadata": raw_meta or {},
-                    "lifespan_stage": row.get("lifespan_stage"),
-                    "crisis": row.get("crisis"),
-                    "virtue": row.get("virtue"),
-                    "relations": row.get("relations"),
-                    "relation_circles": row.get("relation_circles"),
-                    "modality": row.get("modality"),
-                }
-            )
+            if promoted is not None:
+                promoted_results.append(promoted)
         return promoted_results
 
     async def _recall_from_archive(
@@ -2645,6 +2740,226 @@ class MemoryStore:
             current_time=current_time,
         )
 
+    @staticmethod
+    def _build_search_cache_key(
+        query_text,
+        wing,
+        room,
+        threshold,
+        limit,
+        current_valence: float,
+        current_arousal: float,
+        current_cortisol: float,
+        exclude_contents,
+        user_id,
+        is_self_reflection: bool,
+        current_time,
+    ) -> tuple:
+        """L1 cache key. Affect/time are quantized (see L1_CACHE_AFFECT_BUCKET
+        / L1_CACHE_TIME_BUCKET_S) -- "close enough to be the same context,"
+        not the precise floats scoring uses."""
+        return (
+            query_text,
+            wing,
+            room,
+            threshold,
+            limit,
+            _quantize(current_valence, L1_CACHE_AFFECT_BUCKET),
+            _quantize(current_arousal, L1_CACHE_AFFECT_BUCKET),
+            _quantize(current_cortisol, L1_CACHE_AFFECT_BUCKET),
+            tuple(sorted(exclude_contents or [])),
+            user_id,
+            # Pronoun cues resolve in opposite directions depending on this
+            # flag ("I"/"my" bind to the agent when self-reflecting, to the
+            # user otherwise), so the two modes must not share a cache entry.
+            is_self_reflection,
+            (
+                int(current_time.timestamp() // L1_CACHE_TIME_BUCKET_S)
+                if current_time is not None
+                else None
+            ),
+        )
+
+    def _resolve_search_entity_context(
+        self, entity_records, relation_records, raw_candidates, user_id
+    ):
+        """Build the entity graph and identify the agent/user nodes in it,
+        tolerating a malformed graph (search still works without cues)."""
+        entity_names: list = []
+        adj: dict = {}
+        cand_entities: dict = {}
+        agent_node_name = None
+        user_node_name = None
+        try:
+            entity_names, adj, cand_entities = self._build_entity_graph(
+                entity_records, relation_records, raw_candidates
+            )
+            agent_node_name, user_node_name = self._resolve_identity_nodes(
+                entity_records, entity_names, adj, user_id
+            )
+        except Exception as e:
+            logger.debug("Failed to process entities: %s", e)
+        return entity_names, adj, cand_entities, agent_node_name, user_node_name
+
+    def _finalize_search_results(
+        self,
+        results: list,
+        *,
+        query_text: str,
+        limit,
+        refresh_on_recall: bool,
+        current_valence: float,
+        current_time,
+        cache_key: tuple,
+        now_ts: float,
+    ) -> list:
+        """Sort/limit, spawn the background recall-strengthening refresh, and
+        populate the L1 cache -- the shared tail of every non-early-return
+        path through `search_memories`."""
+        if results:
+            # Sort and limit results to maintain full compatibility with offline tests
+            results.sort(key=lambda x: x["score"], reverse=True)
+            if limit:
+                results = results[:limit]
+
+            logger.info(
+                f"\U0001f9e0 ACT-R Recall: {len(results)} memories for: '{query_text[:30]}...'"
+            )
+
+        if results and refresh_on_recall:
+
+            def _done_callback(t):
+                try:
+                    t.result()
+                except Exception as e:
+                    logger.error(f"Background Memory Refresh Failed: {e}")
+
+            # P4-8: spawn_background keeps a strong reference so this task
+            # cannot be GC'd mid-refresh; _done_callback is chained after it
+            # purely for the existing error-logging behavior.
+            task = spawn_background(
+                self._background_tasks,
+                self._refresh_memories(
+                    results,
+                    current_valence=current_valence,
+                    current_time=current_time,
+                ),
+            )
+            task.add_done_callback(_done_callback)
+
+        # Cache results in L1 memory cache before returning
+        self._l1_cache_put(cache_key, (now_ts, results))
+        return results
+
+    async def _fetch_raw_candidates(
+        self,
+        *,
+        candidates,
+        query_vector,
+        mrl_query_vector,
+        vector_str: str,
+        wing,
+        room,
+        excluded,
+        threshold,
+        candidate_limit: int,
+        current_valence: float,
+        current_arousal: float,
+        current_cortisol: float,
+        current_time,
+        now_ts: float,
+        is_sqlite: bool,
+    ) -> tuple[list, float]:
+        """Qdrant selective-vector path, falling back to a direct SQL scan
+        (dialect-branched) when Qdrant is offline or returned nothing."""
+        # 1. Qdrant Selective Vector Path
+        raw_candidates = []
+        if self.qdrant_store.client and candidates:
+            raw_candidates = await self._score_qdrant_candidates(
+                candidates,
+                wing=wing,
+                room=room,
+                excluded=excluded,
+                threshold=threshold,
+                current_valence=current_valence,
+                current_arousal=current_arousal,
+                current_cortisol=current_cortisol,
+                current_time=current_time,
+                now_ts=now_ts,
+            )
+
+        # 2. Database Fallback (Qdrant offline or returned no candidates)
+        if not raw_candidates:
+            async with self.pool.acquire() as conn:
+                if is_sqlite:
+                    # The SQLite path recomputes "now"; keep its value, it is
+                    # what stamps the L1 cache entry below.
+                    raw_candidates, now_ts = await self._fetch_sqlite_candidates(
+                        conn,
+                        query_vector=query_vector,
+                        wing=wing,
+                        room=room,
+                        excluded=excluded,
+                        threshold=threshold,
+                        current_valence=current_valence,
+                        current_arousal=current_arousal,
+                        current_cortisol=current_cortisol,
+                        current_time=current_time,
+                        candidate_limit=candidate_limit,
+                    )
+                else:
+                    raw_candidates = await self._fetch_postgres_candidates(
+                        conn,
+                        vector_str=vector_str,
+                        wing=wing,
+                        room=room,
+                        excluded=excluded,
+                        threshold=threshold,
+                        candidate_limit=candidate_limit,
+                        current_valence=current_valence,
+                        current_arousal=current_arousal,
+                        current_cortisol=current_cortisol,
+                        current_time=current_time,
+                    )
+        return raw_candidates, now_ts
+
+    async def _l1_cache_hit(
+        self,
+        cache_key: tuple,
+        now_ts: float,
+        *,
+        refresh_on_recall: bool,
+        current_valence: float,
+        current_time,
+    ) -> list | None:
+        """A fresh L1 hit, refreshed if requested; None on a miss/stale entry."""
+        if cache_key not in self._l1_cache:
+            return None
+        ts, cached_results = self._l1_cache[cache_key]
+        if now_ts - ts >= self._l1_cache_ttl:
+            return None
+        self._l1_cache.move_to_end(cache_key)
+        if cached_results and refresh_on_recall:
+            await self._refresh_memories(
+                cached_results,
+                current_valence=current_valence,
+                current_time=current_time,
+            )
+        return cached_results
+
+    async def _refresh_stop_words_if_stale(self, now_ts: float) -> None:
+        """Periodically refresh database-derived stop words (TTL = 5 minutes)."""
+        if (
+            hasattr(self, "_last_stop_words_update")
+            and now_ts - self._last_stop_words_update <= 300.0
+        ):
+            return
+        await self._update_dynamic_stop_words()
+        # Reload the learned-vocabulary association cache on the same
+        # cadence (first call also creates tables + plants the seed).
+        await self.lexicon.refresh()
+        self._last_stop_words_update = now_ts
+
     async def search_memories(
         self,
         query_text,
@@ -2690,51 +3005,33 @@ class MemoryStore:
         # L1_CACHE_AFFECT_BUCKET / L1_CACHE_TIME_BUCKET_S above) -- this key is
         # "close enough to be the same context," not the precise floats scoring
         # uses below.
-        cache_key = (
+        cache_key = self._build_search_cache_key(
             query_text,
             wing,
             room,
             threshold,
             limit,
-            _quantize(current_valence, L1_CACHE_AFFECT_BUCKET),
-            _quantize(current_arousal, L1_CACHE_AFFECT_BUCKET),
-            _quantize(current_cortisol, L1_CACHE_AFFECT_BUCKET),
-            tuple(sorted(exclude_contents or [])),
+            current_valence,
+            current_arousal,
+            current_cortisol,
+            exclude_contents,
             user_id,
-            # Pronoun cues resolve in opposite directions depending on this flag
-            # ("I"/"my" bind to the agent when self-reflecting, to the user
-            # otherwise), so the two modes must not share a cache entry.
             is_self_reflection,
-            (
-                int(current_time.timestamp() // L1_CACHE_TIME_BUCKET_S)
-                if current_time is not None
-                else None
-            ),
+            current_time,
         )
         now_ts = current_time.timestamp() if current_time is not None else time.time()
-        if cache_key in self._l1_cache:
-            ts, cached_results = self._l1_cache[cache_key]
-            if now_ts - ts < self._l1_cache_ttl:
-                self._l1_cache.move_to_end(cache_key)
-                if cached_results and refresh_on_recall:
-                    await self._refresh_memories(
-                        cached_results,
-                        current_valence=current_valence,
-                        current_time=current_time,
-                    )
-                return cached_results
+        cache_hit = await self._l1_cache_hit(
+            cache_key,
+            now_ts,
+            refresh_on_recall=refresh_on_recall,
+            current_valence=current_valence,
+            current_time=current_time,
+        )
+        if cache_hit is not None:
+            return cache_hit
 
         try:
-            # Periodically refresh database-derived stop words (TTL = 5 minutes)
-            if (
-                not hasattr(self, "_last_stop_words_update")
-                or now_ts - self._last_stop_words_update > 300.0
-            ):
-                await self._update_dynamic_stop_words()
-                # Reload the learned-vocabulary association cache on the same
-                # cadence (first call also creates tables + plants the seed).
-                await self.lexicon.refresh()
-                self._last_stop_words_update = now_ts
+            await self._refresh_stop_words_if_stale(now_ts)
 
             query_vector = await self.get_embedding(query_text)
             if not query_vector:
@@ -2771,55 +3068,23 @@ class MemoryStore:
                 mrl_query_vector, candidate_limit, query_text, user_id
             )
 
-            # 1. Qdrant Selective Vector Path
-            raw_candidates = []
-            if self.qdrant_store.client and candidates:
-                raw_candidates = await self._score_qdrant_candidates(
-                    candidates,
-                    wing=wing,
-                    room=room,
-                    excluded=excluded,
-                    threshold=threshold,
-                    current_valence=current_valence,
-                    current_arousal=current_arousal,
-                    current_cortisol=current_cortisol,
-                    current_time=current_time,
-                    now_ts=now_ts,
-                )
-
-            # 2. Database Fallback (Qdrant offline or returned no candidates)
-            if not raw_candidates:
-                async with self.pool.acquire() as conn:
-                    if is_sqlite:
-                        # The SQLite path recomputes "now"; keep its value, it is
-                        # what stamps the L1 cache entry below.
-                        raw_candidates, now_ts = await self._fetch_sqlite_candidates(
-                            conn,
-                            query_vector=query_vector,
-                            wing=wing,
-                            room=room,
-                            excluded=excluded,
-                            threshold=threshold,
-                            current_valence=current_valence,
-                            current_arousal=current_arousal,
-                            current_cortisol=current_cortisol,
-                            current_time=current_time,
-                            candidate_limit=candidate_limit,
-                        )
-                    else:
-                        raw_candidates = await self._fetch_postgres_candidates(
-                            conn,
-                            vector_str=vector_str,
-                            wing=wing,
-                            room=room,
-                            excluded=excluded,
-                            threshold=threshold,
-                            candidate_limit=candidate_limit,
-                            current_valence=current_valence,
-                            current_arousal=current_arousal,
-                            current_cortisol=current_cortisol,
-                            current_time=current_time,
-                        )
+            raw_candidates, now_ts = await self._fetch_raw_candidates(
+                candidates=candidates,
+                query_vector=query_vector,
+                mrl_query_vector=mrl_query_vector,
+                vector_str=vector_str,
+                wing=wing,
+                room=room,
+                excluded=excluded,
+                threshold=threshold,
+                candidate_limit=candidate_limit,
+                current_valence=current_valence,
+                current_arousal=current_arousal,
+                current_cortisol=current_cortisol,
+                current_time=current_time,
+                now_ts=now_ts,
+                is_sqlite=is_sqlite,
+            )
 
             # 3. Post-process in Python: direct cue boost + spreading activation
             query_words = re.findall(r"\b\w{3,}\b", query_text.lower())
@@ -2827,20 +3092,15 @@ class MemoryStore:
             matched_cues = [w for w in query_words if w not in dynamic_stop_words]
             self.goal_buffer.update_buffer(query_text, dynamic_stop_words)
 
-            entity_names = []
-            adj = {}
-            cand_entities = {}
-            agent_node_name = None
-            user_node_name = None
-            try:
-                entity_names, adj, cand_entities = self._build_entity_graph(
-                    entity_records, relation_records, raw_candidates
-                )
-                agent_node_name, user_node_name = self._resolve_identity_nodes(
-                    entity_records, entity_names, adj, user_id
-                )
-            except Exception as e:
-                logger.debug("Failed to process entities: %s", e)
+            (
+                entity_names,
+                adj,
+                cand_entities,
+                agent_node_name,
+                user_node_name,
+            ) = self._resolve_search_entity_context(
+                entity_records, relation_records, raw_candidates, user_id
+            )
 
             resolved_cues = self._resolve_pronoun_cues(
                 query_text,
@@ -2893,40 +3153,16 @@ class MemoryStore:
                 if promoted_results:
                     results.extend(promoted_results)
 
-            if results:
-                # Sort and limit results to maintain full compatibility with offline tests
-                results.sort(key=lambda x: x["score"], reverse=True)
-                if limit:
-                    results = results[:limit]
-
-                logger.info(
-                    f"\U0001f9e0 ACT-R Recall: {len(results)} memories for: '{query_text[:30]}...'"
-                )
-
-            if results and refresh_on_recall:
-
-                def _done_callback(t):
-                    try:
-                        t.result()
-                    except Exception as e:
-                        logger.error(f"Background Memory Refresh Failed: {e}")
-
-                # P4-8: spawn_background keeps a strong reference so this
-                # task cannot be GC'd mid-refresh; _done_callback is chained
-                # after it purely for the existing error-logging behavior.
-                task = spawn_background(
-                    self._background_tasks,
-                    self._refresh_memories(
-                        results,
-                        current_valence=current_valence,
-                        current_time=current_time,
-                    ),
-                )
-                task.add_done_callback(_done_callback)
-
-            # Cache results in L1 memory cache before returning
-            self._l1_cache_put(cache_key, (now_ts, results))
-            return results
+            return self._finalize_search_results(
+                results,
+                query_text=query_text,
+                limit=limit,
+                refresh_on_recall=refresh_on_recall,
+                current_valence=current_valence,
+                current_time=current_time,
+                cache_key=cache_key,
+                now_ts=now_ts,
+            )
 
         except Exception as e:
             import traceback
@@ -3126,10 +3362,240 @@ class MemoryStore:
         except Exception as e:
             logger.error(f"Failed to mark episodes consolidated: {e}")
 
-    async def apply_actr_decay(self, memory_contents: list[str], current_time=None):
-        """Decays the importance score of consolidated raw episodic memories using ACT-R feedback."""
+    @staticmethod
+    def _parse_actr_created_at(created_at, current_time):
+        """Best-effort parse of a stored `created_at` into a datetime,
+        falling back to `current_time`/now for anything unparseable."""
+        if not created_at:
+            return current_time if current_time is not None else datetime.now()
+
+        if not isinstance(created_at, str):
+            return created_at
+
+        for fmt in (
+            "%Y-%m-%d %H:%M:%S",
+            "%Y-%m-%dT%H:%M:%S",
+            "%Y-%m-%d %H:%M:%S.%f",
+            "%Y-%m-%dT%H:%M:%S.%f",
+        ):
+            try:
+                return datetime.strptime(created_at.split("+")[0], fmt)
+            except ValueError:
+                continue
+        return current_time if current_time is not None else datetime.now()
+
+    @staticmethod
+    def _extract_actr_decay_rate(metadata, default_rate: float) -> float:
+        """Per-memory decay_rate override from metadata, if present."""
         import json
 
+        meta = {}
+        if isinstance(metadata, str):
+            try:
+                meta = json.loads(metadata)
+            except Exception:  # nosec B110 - malformed metadata falls back to {} / default_rate below
+                pass
+        elif isinstance(metadata, dict):
+            meta = metadata
+
+        return float(meta.get("decay_rate", default_rate)) if meta else default_rate
+
+    def _compute_actr_decay(
+        self, rows: list, current_time=None
+    ) -> tuple[list, list]:
+        """Pure ACT-R activation decision per row: which memory ids should be
+        pruned to the archive (`to_delete`) and which get a softened
+        importance score in place (`to_update`). No I/O -- isolated so the
+        date-parsing/activation math can be reasoned about (and radon-scored)
+        apart from the dual-backend persistence that follows it."""
+        to_delete = []
+        to_update = []
+
+        for row in rows:
+            mem_id = row.get("id")
+            recall_count = row.get("recall_count")
+            metadata = row.get("metadata")
+            importance_score = row.get("importance_score") or 0.5
+
+            # Fallbacks
+            n_recalls = max(1, recall_count if recall_count is not None else 1)
+
+            dt = self._parse_actr_created_at(row.get("created_at"), current_time)
+
+            # Calculate hours since creation. Coerce both operands to
+            # aware-UTC so a naive stored created_at and an aware
+            # current_time (or vice versa) never raise on subtraction.
+            now = (
+                self._as_aware_utc(current_time)
+                if current_time is not None
+                else datetime.now(UTC)
+            )
+            delta = now - (self._as_aware_utc(dt) or now)
+            hours_since = max(0.0, delta.total_seconds() / 3600.0)
+
+            decay_rate = self._extract_actr_decay_rate(metadata, self.decay_rate)
+
+            # Shield recent memories created in the last 24 hours from pruning (deletion)
+            is_shielded = hours_since < 24.0
+
+            # Milestones (importance >= 0.7) are protected from active importance decay,
+            # but they are allowed to decay and be pruned to the archive when inactive.
+            activation = math.log(n_recalls) - decay_rate * math.log(hours_since + 1.0)
+
+            # Dual-threshold active pruning:
+            # Distractors (< 0.5) pruned below -3.5, Anecdotes/Milestones (>= 0.5) pruned below -4.5
+            threshold = -3.5 if importance_score < 0.5 else -4.5
+            if activation < threshold and not is_shielded:
+                to_delete.append(mem_id)
+            elif importance_score < 0.7:
+                # Decay importance score slightly for non-milestones
+                new_importance = max(0.01, importance_score * 0.8)
+                to_update.append((new_importance, mem_id))
+
+        return to_delete, to_update
+
+    async def _archive_and_delete_decayed_memories(self, conn, to_delete: list) -> None:
+        """Copy pruned rows to `archived_memories`, delete them from the
+        active table (and Qdrant), for whichever backend `conn` is."""
+        if self.is_sqlite:
+            placeholders = ",".join("?" for _ in to_delete)
+            # Copy to archived_memories
+            await conn.execute(
+                """
+                INSERT INTO archived_memories (
+                    id, content, raw_content, wing, room, importance_score, emotional_weight,
+                    valence, certainty, source, recall_count, last_recalled_at, created_at,
+                    metadata, lifespan_stage, crisis, virtue, relations, relation_circles, modality, embedding
+                )
+                SELECT
+                    id, content, raw_content, wing, room, importance_score, emotional_weight,
+                    valence, certainty, source, recall_count, last_recalled_at, created_at,
+                    metadata, lifespan_stage, crisis, virtue, relations, relation_circles, modality, embedding
+                FROM memories
+                WHERE id IN ("""
+                f"{placeholders}"  # nosec B608 - placeholders is only comma-separated "?" marks, ids bound via *to_delete
+                """)
+                ON CONFLICT(id) DO UPDATE SET
+                    recall_count = excluded.recall_count,
+                    last_recalled_at = excluded.last_recalled_at,
+                    importance_score = excluded.importance_score
+                """,
+                *to_delete,
+            )
+            # Delete from memories
+            await conn.execute(
+                f"DELETE FROM memories WHERE id IN ({placeholders})",  # nosec B608 - placeholders is only comma-separated "?" marks, ids bound via *to_delete
+                *to_delete,
+            )
+        else:
+            # Copy to archived_memories
+            await conn.execute(
+                """
+                INSERT INTO archived_memories (
+                    id, content, raw_content, wing, room, importance_score, emotional_weight,
+                    valence, certainty, source, recall_count, last_recalled_at, created_at,
+                    metadata, lifespan_stage, crisis, virtue, relations, relation_circles, modality, embedding
+                )
+                SELECT
+                    id, content, raw_content, wing, room, importance_score, emotional_weight,
+                    valence, certainty, source, recall_count, last_recalled_at, created_at,
+                    metadata, lifespan_stage, crisis, virtue, relations, relation_circles, modality, embedding::halfvec
+                FROM memories
+                WHERE id = ANY($1)
+                ON CONFLICT(id) DO UPDATE SET
+                    recall_count = EXCLUDED.recall_count,
+                    last_recalled_at = EXCLUDED.last_recalled_at,
+                    importance_score = EXCLUDED.importance_score
+                """,
+                to_delete,
+            )
+            # Delete from memories
+            await conn.execute("DELETE FROM memories WHERE id = ANY($1)", to_delete)
+
+        # Delete from Qdrant if active
+        if self.qdrant_store and self.qdrant_store.client:
+            try:
+                from qdrant_client.http import models
+
+                await asyncio.to_thread(
+                    self.qdrant_store.client.delete,
+                    collection_name=self.qdrant_store.collection_name,
+                    points_selector=models.PointIdsList(
+                        points=[str(pid) for pid in to_delete]
+                    ),
+                )
+            except Exception as qe:
+                logger.error(f"Failed to delete points from Qdrant: {qe}")
+
+        logger.info(
+            f"🗑️ Pruned {len(to_delete)} memories with base activation below {self.pruning_threshold} to subconscious archive."
+        )
+
+    async def _apply_importance_updates(self, conn, to_update: list) -> None:
+        if self.is_sqlite:
+            for importance, mem_id in to_update:
+                await conn.execute(
+                    "UPDATE memories SET importance_score = ? WHERE id = ?",
+                    importance,
+                    mem_id,
+                )
+        else:
+            # Batch update for PostgreSQL
+            await conn.executemany(
+                "UPDATE memories SET importance_score = $1 WHERE id = $2",
+                to_update,
+            )
+
+    async def _cleanup_expired_archived_memories(self, conn, current_time=None) -> None:
+        """Permanent cleanup on archived_memories based on biological timelines."""
+        now_cleanup = current_time if current_time is not None else datetime.now(UTC)
+        cutoff_distractors = now_cleanup - timedelta(days=30)
+        cutoff_anecdotes = now_cleanup - timedelta(days=180)
+        cutoff_milestones = now_cleanup - timedelta(days=720)
+
+        try:
+            # COALESCE(last_recalled_at, created_at): a memory that was
+            # archived but never recalled has NULL last_recalled_at, and
+            # `NULL < cutoff` is NULL (never true) -- such rows would be
+            # immortal in the archive. Age them out by creation time
+            # instead, matching how the activation SQL already coalesces
+            # this column (db/schema.sql).
+            if self.is_sqlite:
+                # Normalise both operands through datetime(): the SQLite
+                # fallback stores timestamps as text, so a raw string
+                # comparison of differing ISO formats/precision/offsets
+                # is unreliable. datetime() canonicalises to UTC.
+                await conn.execute(
+                    """
+                    DELETE FROM archived_memories
+                    WHERE (importance_score < 0.5 AND datetime(COALESCE(last_recalled_at, created_at)) < datetime(?))
+                       OR (importance_score >= 0.5 AND importance_score < 0.7 AND datetime(COALESCE(last_recalled_at, created_at)) < datetime(?))
+                       OR (importance_score >= 0.7 AND importance_score < 0.9 AND datetime(COALESCE(last_recalled_at, created_at)) < datetime(?));
+                    """,
+                    cutoff_distractors.isoformat(),
+                    cutoff_anecdotes.isoformat(),
+                    cutoff_milestones.isoformat(),
+                )
+            else:
+                await conn.execute(
+                    """
+                    DELETE FROM archived_memories
+                    WHERE (importance_score < 0.5 AND COALESCE(last_recalled_at, created_at) < $1)
+                       OR (importance_score >= 0.5 AND importance_score < 0.7 AND COALESCE(last_recalled_at, created_at) < $2)
+                       OR (importance_score >= 0.7 AND importance_score < 0.9 AND COALESCE(last_recalled_at, created_at) < $3);
+                    """,
+                    cutoff_distractors,
+                    cutoff_anecdotes,
+                    cutoff_milestones,
+                )
+            logger.info(
+                "🗑️ Completed permanent cleanup on subconscious archived memories."
+            )
+        except Exception as clean_err:
+            logger.error(f"Failed subconscious archive cleanup: {clean_err}")
+
+    async def apply_actr_decay(self, memory_contents: list[str], current_time=None):
+        """Decays the importance score of consolidated raw episodic memories using ACT-R feedback."""
         try:
             if not memory_contents:
                 return
@@ -3149,235 +3615,18 @@ class MemoryStore:
                 if not rows:
                     return
 
-                to_delete = []
-                to_update = []
+                # 2. Decide which rows get pruned vs. softened
+                to_delete, to_update = self._compute_actr_decay(rows, current_time)
 
-                for row in rows:
-                    mem_id = row.get("id")
-                    recall_count = row.get("recall_count")
-                    created_at = row.get("created_at")
-                    metadata = row.get("metadata")
-                    importance_score = row.get("importance_score") or 0.5
-
-                    # Fallbacks
-                    n_recalls = max(1, recall_count if recall_count is not None else 1)
-
-                    # Parse created_at safely
-                    if not created_at:
-                        created_at = (
-                            current_time if current_time is not None else datetime.now()
-                        )
-
-                    if isinstance(created_at, str):
-                        for fmt in (
-                            "%Y-%m-%d %H:%M:%S",
-                            "%Y-%m-%dT%H:%M:%S",
-                            "%Y-%m-%d %H:%M:%S.%f",
-                            "%Y-%m-%dT%H:%M:%S.%f",
-                        ):
-                            try:
-                                dt = datetime.strptime(created_at.split("+")[0], fmt)
-                                break
-                            except ValueError:
-                                continue
-                        else:
-                            dt = (
-                                current_time
-                                if current_time is not None
-                                else datetime.now()
-                            )
-                    else:
-                        dt = created_at
-
-                    # Calculate hours since creation. Coerce both operands to
-                    # aware-UTC so a naive stored created_at and an aware
-                    # current_time (or vice versa) never raise on subtraction.
-                    now = (
-                        self._as_aware_utc(current_time)
-                        if current_time is not None
-                        else datetime.now(UTC)
-                    )
-                    delta = now - (self._as_aware_utc(dt) or now)
-                    hours_since = max(0.0, delta.total_seconds() / 3600.0)
-
-                    # Extract decay_rate from metadata if possible
-                    meta = {}
-                    if isinstance(metadata, str):
-                        try:
-                            meta = json.loads(metadata)
-                        except Exception:  # nosec B110 - malformed metadata falls back to {} / self.decay_rate below
-                            pass
-                    elif isinstance(metadata, dict):
-                        meta = metadata
-
-                    decay_rate = (
-                        float(meta.get("decay_rate", self.decay_rate))
-                        if meta
-                        else self.decay_rate
-                    )
-
-                    # Shield recent memories created in the last 24 hours from pruning (deletion)
-                    is_shielded = hours_since < 24.0
-
-                    # Milestones (importance >= 0.7) are protected from active importance decay,
-                    # but they are allowed to decay and be pruned to the archive when inactive.
-                    activation = math.log(n_recalls) - decay_rate * math.log(
-                        hours_since + 1.0
-                    )
-
-                    # Dual-threshold active pruning:
-                    # Distractors (< 0.5) pruned below -3.5, Anecdotes/Milestones (>= 0.5) pruned below -4.5
-                    threshold = -3.5 if importance_score < 0.5 else -4.5
-                    if activation < threshold and not is_shielded:
-                        to_delete.append(mem_id)
-                    elif importance_score < 0.7:
-                        # Decay importance score slightly for non-milestones
-                        new_importance = max(0.01, importance_score * 0.8)
-                        to_update.append((new_importance, mem_id))
-
-                # 2. Execute Archiving, Deletions and Updates
+                # 3. Execute Archiving, Deletions and Updates
                 if to_delete:
-                    if self.is_sqlite:
-                        placeholders = ",".join("?" for _ in to_delete)
-                        # Copy to archived_memories
-                        await conn.execute(
-                            """
-                            INSERT INTO archived_memories (
-                                id, content, raw_content, wing, room, importance_score, emotional_weight,
-                                valence, certainty, source, recall_count, last_recalled_at, created_at,
-                                metadata, lifespan_stage, crisis, virtue, relations, relation_circles, modality, embedding
-                            )
-                            SELECT
-                                id, content, raw_content, wing, room, importance_score, emotional_weight,
-                                valence, certainty, source, recall_count, last_recalled_at, created_at,
-                                metadata, lifespan_stage, crisis, virtue, relations, relation_circles, modality, embedding
-                            FROM memories
-                            WHERE id IN ("""
-                            f"{placeholders}"  # nosec B608 - placeholders is only comma-separated "?" marks, ids bound via *to_delete
-                            """)
-                            ON CONFLICT(id) DO UPDATE SET
-                                recall_count = excluded.recall_count,
-                                last_recalled_at = excluded.last_recalled_at,
-                                importance_score = excluded.importance_score
-                            """,
-                            *to_delete,
-                        )
-                        # Delete from memories
-                        await conn.execute(
-                            f"DELETE FROM memories WHERE id IN ({placeholders})",  # nosec B608 - placeholders is only comma-separated "?" marks, ids bound via *to_delete
-                            *to_delete,
-                        )
-                    else:
-                        # Copy to archived_memories
-                        await conn.execute(
-                            """
-                            INSERT INTO archived_memories (
-                                id, content, raw_content, wing, room, importance_score, emotional_weight,
-                                valence, certainty, source, recall_count, last_recalled_at, created_at,
-                                metadata, lifespan_stage, crisis, virtue, relations, relation_circles, modality, embedding
-                            )
-                            SELECT
-                                id, content, raw_content, wing, room, importance_score, emotional_weight,
-                                valence, certainty, source, recall_count, last_recalled_at, created_at,
-                                metadata, lifespan_stage, crisis, virtue, relations, relation_circles, modality, embedding::halfvec
-                            FROM memories
-                            WHERE id = ANY($1)
-                            ON CONFLICT(id) DO UPDATE SET
-                                recall_count = EXCLUDED.recall_count,
-                                last_recalled_at = EXCLUDED.last_recalled_at,
-                                importance_score = EXCLUDED.importance_score
-                            """,
-                            to_delete,
-                        )
-                        # Delete from memories
-                        await conn.execute(
-                            "DELETE FROM memories WHERE id = ANY($1)", to_delete
-                        )
-
-                    # Delete from Qdrant if active
-                    if self.qdrant_store and self.qdrant_store.client:
-                        try:
-                            from qdrant_client.http import models
-
-                            await asyncio.to_thread(
-                                self.qdrant_store.client.delete,
-                                collection_name=self.qdrant_store.collection_name,
-                                points_selector=models.PointIdsList(
-                                    points=[str(pid) for pid in to_delete]
-                                ),
-                            )
-                        except Exception as qe:
-                            logger.error(f"Failed to delete points from Qdrant: {qe}")
-
-                    logger.info(
-                        f"🗑️ Pruned {len(to_delete)} memories with base activation below {self.pruning_threshold} to subconscious archive."
-                    )
+                    await self._archive_and_delete_decayed_memories(conn, to_delete)
 
                 if to_update:
-                    if self.is_sqlite:
-                        for importance, mem_id in to_update:
-                            await conn.execute(
-                                "UPDATE memories SET importance_score = ? WHERE id = ?",
-                                importance,
-                                mem_id,
-                            )
-                    else:
-                        # Batch update for PostgreSQL
-                        await conn.executemany(
-                            "UPDATE memories SET importance_score = $1 WHERE id = $2",
-                            to_update,
-                        )
+                    await self._apply_importance_updates(conn, to_update)
 
-                # 3. Permanent Cleanup on archived_memories based on biological timelines
-                now_cleanup = (
-                    current_time
-                    if current_time is not None
-                    else datetime.now(UTC)
-                )
-                cutoff_distractors = now_cleanup - timedelta(days=30)
-                cutoff_anecdotes = now_cleanup - timedelta(days=180)
-                cutoff_milestones = now_cleanup - timedelta(days=720)
-
-                try:
-                    # COALESCE(last_recalled_at, created_at): a memory that was
-                    # archived but never recalled has NULL last_recalled_at, and
-                    # `NULL < cutoff` is NULL (never true) -- such rows would be
-                    # immortal in the archive. Age them out by creation time
-                    # instead, matching how the activation SQL already coalesces
-                    # this column (db/schema.sql).
-                    if self.is_sqlite:
-                        # Normalise both operands through datetime(): the SQLite
-                        # fallback stores timestamps as text, so a raw string
-                        # comparison of differing ISO formats/precision/offsets
-                        # is unreliable. datetime() canonicalises to UTC.
-                        await conn.execute(
-                            """
-                            DELETE FROM archived_memories
-                            WHERE (importance_score < 0.5 AND datetime(COALESCE(last_recalled_at, created_at)) < datetime(?))
-                               OR (importance_score >= 0.5 AND importance_score < 0.7 AND datetime(COALESCE(last_recalled_at, created_at)) < datetime(?))
-                               OR (importance_score >= 0.7 AND importance_score < 0.9 AND datetime(COALESCE(last_recalled_at, created_at)) < datetime(?));
-                            """,
-                            cutoff_distractors.isoformat(),
-                            cutoff_anecdotes.isoformat(),
-                            cutoff_milestones.isoformat(),
-                        )
-                    else:
-                        await conn.execute(
-                            """
-                            DELETE FROM archived_memories
-                            WHERE (importance_score < 0.5 AND COALESCE(last_recalled_at, created_at) < $1)
-                               OR (importance_score >= 0.5 AND importance_score < 0.7 AND COALESCE(last_recalled_at, created_at) < $2)
-                               OR (importance_score >= 0.7 AND importance_score < 0.9 AND COALESCE(last_recalled_at, created_at) < $3);
-                            """,
-                            cutoff_distractors,
-                            cutoff_anecdotes,
-                            cutoff_milestones,
-                        )
-                    logger.info(
-                        "🗑️ Completed permanent cleanup on subconscious archived memories."
-                    )
-                except Exception as clean_err:
-                    logger.error(f"Failed subconscious archive cleanup: {clean_err}")
+                # 4. Permanent Cleanup on archived_memories based on biological timelines
+                await self._cleanup_expired_archived_memories(conn, current_time)
 
             # Pruning and importance decay change what search over the active
             # `memories` table should return, so drop the L1 cache when either

--- a/backend/app/vision/appraisal.py
+++ b/backend/app/vision/appraisal.py
@@ -38,7 +38,7 @@ class VisualAppraisalService:
 
         self._last_description: str = ""
         self._last_appraisal_time: float = 0.0
-        self._last_visual_vector = None
+        self._last_visual_vector: list[float] | None = None
         self._habituation_disabled_logged = False
 
         # P3-1: reuses the same delta this class already computes for
@@ -125,7 +125,7 @@ class VisualAppraisalService:
             from PIL import Image
 
             img = Image.open(io.BytesIO(jpeg_bytes)).convert("L").resize((16, 16))
-            return [px / 255.0 for px in img.getdata()]
+            return [px / 255.0 for px in img.getdata()]  # type: ignore[attr-defined]
         except Exception as e:
             logger.debug(
                 "[VisualAppraisal] PIL downsampling failed too, no continuity-"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -93,6 +93,7 @@ pytest_add_cli_args = ["--benchmark-disable"]
 [tool.mypy]
 python_version = "3.12"
 files = ["app"]
+plugins = ["pydantic.mypy"]
 ignore_missing_imports = true
 warn_unused_ignores = true
 # Genuinely dynamic patterns in this codebase (the Config metaclass,

--- a/backend/tests/test_f1_decomposed_stages.py
+++ b/backend/tests/test_f1_decomposed_stages.py
@@ -99,6 +99,18 @@ class _GatingSpy:
     async def get_embedding(self, text):
         return [0.1] * 768
 
+    # F1 stage decomposition (this file's own subject): search_memories now
+    # reaches these three real methods before it ever reaches gating --
+    # delegate to the real implementations rather than reimplement them,
+    # since none of the three has any bearing on what this test asserts.
+    # Safe against this spy's minimal state: an empty `_l1_cache` is a clean
+    # miss, and `_last_stop_words_update = inf` makes the staleness check
+    # skip its own DB/lexicon calls, exactly as the pre-decomposition inline
+    # code did.
+    _build_search_cache_key = staticmethod(MemoryStore._build_search_cache_key)
+    _l1_cache_hit = MemoryStore._l1_cache_hit
+    _refresh_stop_words_if_stale = MemoryStore._refresh_stop_words_if_stale
+
     def _compute_mrl_gating(self, arousal, cortisol, limit, full_pool):
         self.seen.append(full_pool)
         raise _StopAfterGating

--- a/backend/tests/test_runtime_bootstrap.py
+++ b/backend/tests/test_runtime_bootstrap.py
@@ -12,7 +12,12 @@ import logging
 import pytest
 
 from app import config as config_module
-from app.runtime_bootstrap import _clear_sqlite_fallback, _enter_sqlite_fallback
+from app.runtime_bootstrap import (
+    _clear_sqlite_fallback,
+    _enter_sqlite_fallback,
+    _model_exists,
+    _normalized_required_models,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -105,3 +110,44 @@ def test_clearing_an_absent_sentinel_is_not_an_error(tmp_path, monkeypatch):
     )
 
     _clear_sqlite_fallback()
+
+
+def test_normalized_required_models_dedupes_preserving_first_occurrence():
+    """OLLAMA_REQUIRED_MODELS_STR is user-edited CSV in .env - a repeated
+    entry must not turn into two pull requests for the same model."""
+    result = _normalized_required_models(["llama3.2:3b", "nomic-embed-text", "llama3.2:3b"])
+    assert result == ["llama3.2:3b", "nomic-embed-text"]
+
+
+def test_normalized_required_models_strips_whitespace_and_drops_blanks():
+    """A trailing comma in the .env value (`"a,b,"`) must not turn into a
+    third, empty model name that then 404s against Ollama's pull API."""
+    result = _normalized_required_models(["  llama3.2:3b  ", "", "   "])
+    assert result == ["llama3.2:3b"]
+
+
+def test_model_exists_exact_match():
+    assert _model_exists("llama3.2:3b", ["llama3.2:3b", "nomic-embed-text"]) is True
+
+
+def test_model_exists_returns_false_when_truly_absent():
+    assert _model_exists("llama3.2:3b", ["nomic-embed-text"]) is False
+
+
+def test_model_exists_treats_bare_name_as_already_satisfied_by_latest_tag():
+    """Config lists a bare model name ("llama3.2"); Ollama's own /api/tags
+    reports it tagged `:latest`. Without this the bootstrap would re-pull a
+    model that is already present under its default tag on every boot."""
+    assert _model_exists("llama3.2", ["llama3.2:latest"]) is True
+
+
+def test_model_exists_treats_explicit_latest_as_satisfied_by_bare_name():
+    """The inverse direction: config explicitly asks for `:latest`, Ollama
+    reports the bare (untagged) name."""
+    assert _model_exists("llama3.2:latest", ["llama3.2"]) is True
+
+
+def test_model_exists_does_not_treat_different_tags_as_equivalent():
+    """The `:latest` compatibility rule must not blur into "any tag counts"
+    - a model pinned to a different tag is genuinely missing."""
+    assert _model_exists("llama3.2:3b", ["llama3.2:7b"]) is False


### PR DESCRIPTION
## Summary

Fixes what Phase 0.7's report-only `mypy`/`radon`/`bandit` CI job has been
recording since it was added, and flips that job from report-only to
blocking for the parts that are now actually clean.

- **7.2 (type errors):** 75 → 0 mypy errors across all 12 files, including
  `state/agent_state.py`'s 24 — deliberately deferred in Phase 7.3 as
  highest-risk given the state lock and concurrent System-2 writes. Turned
  out to be pure annotation fixes (`X | None`, named kwargs instead of a
  `**dict` spread, a `cast()` around a redis-py sync/async stub quirk) with
  zero behavior changes.
- **7.1 (cyclomatic complexity):** the named "worst offender" tier is fully
  eliminated — baseline 1 F + 3 E + 8 D (12 findings) → 0. Every fix is pure
  extraction (a self-contained block moved into a named helper, logic
  untouched), including `cognitive/pipeline.py::execute` (F 42 → C 20, the
  single worst function in the codebase — an async generator, so the
  extraction had to follow this file's own existing pattern for threading a
  return value out of a generator that can't `return` one) and six
  functions in `state/memory_store.py`. The remaining 46→54 C-rank findings
  are untouched, per the roadmap's own "let the tool name the actual worst
  offenders" framing.
- **7.4 (coverage), partial:** no Phase 0.7 coverage baseline was ever
  actually saved, so this is a fresh read, not a diff. Picked the clearest
  real gap in Phase-1-6-scoped code (`runtime_bootstrap.py` at 27%) and
  added 7 mutation-tested cases for two previously-untested pure functions,
  rather than a repo-wide push.
- **7.5:** `ci.yml`'s `code-quality` job now blocks on mypy, bandit, and a
  new explicit `radon cc --min D` emptiness check — verified locally against
  the exact commands in the workflow, including a deliberately-reintroduced
  D-rank function to confirm the gate actually fails. Radon's C-tier and the
  maintainability-index job stay report-only, since neither has had a real
  fix pass yet.

One real regression caught by the final full-suite run (not by radon/mypy):
an extraction shifted `search_memories`'s L1-cache-hit check into a new
method, which broke a deliberately-minimal test double
(`test_f1_decomposed_stages.py`'s `_GatingSpy`) that only implements the
attributes the real function is expected to touch before the point under
test. Fixed by extending the spy to delegate the new calls to the real
implementations, consistent with the test's own stated design, not by
loosening the assertion.

Full details, including the near-miss caught before it shipped (a first
draft of the `execute` extraction that would have silently discarded a
response chunk) and the complete list of what's explicitly NOT done, are in
`.agents/CONTEXT.md`.

## Test plan

- [x] `../.venv/bin/python -m pytest -q --junit-xml=...` → 1408 passed, 0
      failures, 0 errors (parsed from JUnit XML, not the terminal summary)
- [x] `../.venv/bin/python -m ruff check .` → clean
- [x] `../.venv/bin/python -m mypy app` → 0 errors
- [x] `../.venv/bin/python -m bandit -r app` → 0 findings
- [x] `../.venv/bin/python -m radon cc app --min D` → empty (0 D/E/F findings)
- [x] `cargo check --workspace` → clean
- [x] `scripts/check_subject_wiring.py` → OK
- [x] The three new/changed CI steps (`mypy`, `radon cc --min D` + emptiness
      check, `bandit`) run-tested locally against the literal commands in
      `ci.yml`, not just inferred from the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)