### PR TITLE
feat(cognitive): facial-reflex startle competes for the workspace (Bucket 17)

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -15291,3 +15291,79 @@ across all four units' logs came back empty.
 health was verified (clean start, no errors in logs), not end-to-end behavior. Bucket 8 (the
 dual-loop architecture split) is the only remaining item in the 16-bucket plan and was not started
 this entry; it is being scoped separately.
+
+## 2026-09-02 -- Bucket 17 (Bucket 8's real implementation): the facial-reflex channel now
+## competes for the workspace instead of only nudging background affect
+
+Per `VOICE_REMEDIATION_PLAN.md`'s Bucket 17 ("Name the workspace -- Bucket 8's full
+implementation"), items 1 and 2 are done; item 3 (live camera capture) already shipped in PR
+#211; item 4 (full-duplex S2S stays rejected) needed no code. Confirmed via three parallel
+codebase explorations this session that item 2 -- "the dual-loop split becomes a consequence" --
+requires **no new OS process**: every agent (`brain_agent`, `subconscious_agent`,
+`surfacing_agent`, `transport_agent`, `system_agent`, plus Rust `stt-agent`/`voice-agent`)
+already runs as its own container/process. "Reflex tier vs. deliberative tier" was therefore
+scoped as a per-subject latency/consumer-config property, mirroring the precedent
+`subconscious_agent` already set for `system.tick` (`MESH_CONTROL_ACK_WAIT_S`/
+`MESH_CONTROL_MAX_DELIVER`), not a new architecture.
+
+**The gap (item 1, "make the competition explicit"), confirmed real by reading the code, not
+assumed from the plan's prose:** `brain_agent._on_facial_reflex`
+(`backend/app/agents/brain_agent.py`) called `StateService.apply_facial_reflex` and nothing
+else -- a `startle` mid-turn only ever nudged background affect for whatever turn happened
+next; it never competed for or interrupted the turn already in flight.
+
+**The fix reuses an already-tested path instead of adding new cancellation logic.**
+`AudioStop` (`contracts.py`) already declared `intent_type: "VOICE_INTERRUPTION,
+VISION_INTERRUPTION, SYSTEM_HALT"` in its own docstring -- `VISION_INTERRUPTION` had never
+been published by any code before this. Added `DecisionService.is_facial_reflex_interruption_
+worthy(reflex_name)` (`cognitive/decision.py`, sibling to `is_speculative_stop_confirmed`,
+same "BT Actions" section) -- a pure, dependency-free function returning `True` only for
+`"startle"` (the one compound, highest-arousal reflex signal; `smile`/`brow_furrow` stay
+background-only, since an agent that stopped talking because the user smiled would be wrong,
+not attentive). `_on_facial_reflex` now checks it against whether a turn is actively
+generating (`self._active_response_turn_id`, under the existing `_turn_state_lock`) and, if
+both hold, publishes a confirmed `AudioStop(reason="facial_reflex_startle",
+intent_type="VISION_INTERRUPTION", turn_id=active_turn_id)` on the exact subject a real
+barge-in already uses. It therefore flows through `_on_audio_stop`'s existing, tested
+cancellation (`_cancel_active_generation`), truncation (`_truncate_interrupted_reply`), and
+adrenaline release with **zero duplicated logic** -- and because voice-agent/transport_agent
+already subscribe to `audio.stop`, this is a genuine, audible interruption (playback actually
+flushes/stops), not an internal flag nobody hears.
+
+**Item 2 made concrete for this one reflex signal:** added `Config.MESH_REFLEX_ACK_WAIT_S`
+(5.0s) / `MESH_REFLEX_MAX_DELIVER` (2), applied to both the `vision.facial_reflex` and
+`audio.stop` subscriptions in `brain_agent.start()` -- both handlers already return
+fast/synchronously by construction, so this is an honest budget, not a label. `system.tick`'s
+control tier keeps its own 30s/3 numbers; this is a second, distinct reflex tier, not a
+widening of the first.
+
+**Deliberately not built, per the plan's own scoping:** no synthetic reactive utterance after
+a startle-interrupt (a real human barge-in doesn't force one either -- the agent falls silent
+and waits for the next `chat.input`, same as today); no change to `smile`/`brow_furrow`
+handling; no new `tools/measure` latency harness (this bucket's verify line is a behavior
+change, not a wall-clock budget).
+
+**Tests** (`tests/test_facial_reflex.py`): 5 parametrized cases for
+`is_facial_reflex_interruption_worthy` (`startle`->True, `smile`/`brow_furrow`/unknown/empty->
+False); a startle-during-an-active-turn test asserting the exact `AudioStop` payload published
+(`reason`, `intent_type`, `turn_id`, `speculative=False`); a smile-during-an-active-turn test
+asserting no publish; a startle-with-no-active-turn test asserting no publish. `_brain_stub()`
+extended with a real (in-memory-store-backed) `DecisionService`, a real `asyncio.Lock` for
+`_turn_state_lock`, and a mocked `publish`, reproducing `BrainAgent.__init__`'s actual defaults
+by hand since `__new__` skips `__init__`. Mutation-tested both branches: reverting the
+arbiter to `return True` broke exactly the 4 tests that discriminate by reflex name (and left
+the 2 startle-only tests passing, as expected, since they don't exercise discrimination);
+removing the `active_turn_id and` guard broke exactly the no-active-turn test. Both confirmed
+via backup-file restore, not `git checkout --`.
+
+Full backend suite 1610/1610 (JUnit XML, not the terminal summary -- two earlier attempts this
+session produced misleading stale-looking results because the background command was
+accidentally launched from the repo root instead of `backend/`, silently resolving `../.venv/
+bin/python` to a nonexistent path and exiting immediately; the fix was an absolute interpreter
+path, not a retry), `ruff check .` clean, `cargo check --workspace` clean.
+
+**NOT done:** no live browser/mic verification that a real MediaPipe-detected startle actually
+interrupts a real in-progress TTS turn end-to-end -- this session's verification is at the
+`brain_agent`-unit level (the publish call and its payload), which is what the plan's own verify
+line asked for, not a hardware-in-the-loop test. Bucket 17 (and therefore Bucket 8) is otherwise
+closed: items 1 and 2 done here, item 3 already shipped in PR #211, item 4 needed no code.

--- a/backend/app/agents/brain_agent.py
+++ b/backend/app/agents/brain_agent.py
@@ -171,6 +171,8 @@ class BrainAgent(BaseAgent):
             Topics.VISION_FACIAL_REFLEX,
             self._on_facial_reflex,
             deliver_policy="last",
+            ack_wait=Config.MESH_REFLEX_ACK_WAIT_S,
+            max_deliver=Config.MESH_REFLEX_MAX_DELIVER,
         )
         await self.subscribe(
             Topics.VOICE_SEGMENTATION_FEEDBACK,
@@ -195,6 +197,8 @@ class BrainAgent(BaseAgent):
             self._on_audio_stop,
             durable=f"{self.name}_audio_stop_live",
             deliver_policy="new",
+            ack_wait=Config.MESH_REFLEX_ACK_WAIT_S,
+            max_deliver=Config.MESH_REFLEX_MAX_DELIVER,
         )
         await self.subscribe(
             Topics.AUDIO_PLAYBACK_BACKLOG,
@@ -257,9 +261,35 @@ class BrainAgent(BaseAgent):
         Failures are contained the same way `_appraise_somatic` contains
         them -- a dropped reflex signal should never take down the mesh
         subscriber.
+
+        Bucket 17 (voice remediation Phase 4): a `startle` arriving while a
+        turn is actively generating now competes for the workspace instead
+        of only nudging background affect for whatever turn happens next --
+        see `DecisionService.is_facial_reflex_interruption_worthy`. It
+        publishes a confirmed `AudioStop` (`intent_type=VISION_INTERRUPTION`,
+        a schema value `contracts.py` already declared but nothing ever
+        published) onto the exact subject a real barge-in uses, so it flows
+        through `_on_audio_stop`'s existing, tested cancellation/truncation/
+        adrenaline path -- no duplicated logic, and voice-agent/transport_agent
+        genuinely flush/stop playback rather than only flipping an internal flag.
         """
         try:
             await self.cognitive_core.state.apply_facial_reflex(data)
+
+            reflex_name = data.get("name")
+            async with self._turn_state_lock:
+                active_turn_id = self._active_response_turn_id
+            if active_turn_id and self.cognitive_core.decision.is_facial_reflex_interruption_worthy(
+                reflex_name
+            ):
+                stop_msg = AudioStop(
+                    interrupt=True,
+                    speculative=False,
+                    reason="facial_reflex_startle",
+                    intent_type="VISION_INTERRUPTION",
+                    turn_id=active_turn_id,
+                )
+                await self.publish(Topics.AUDIO_STOP, stop_msg.model_dump())
         except Exception:
             logger.exception("[Brain] Facial reflex appraisal failed; ignored.")
 

--- a/backend/app/cognitive/decision.py
+++ b/backend/app/cognitive/decision.py
@@ -525,6 +525,15 @@ class DecisionService:
         )
         return False
 
+    def is_facial_reflex_interruption_worthy(self, reflex_name: str) -> bool:
+        """Only `startle` -- the compound, highest-arousal reflex signal
+        (`app/vision/reflex.py`) -- is salient enough to compete for the
+        workspace and interrupt an in-flight turn. `smile`/`brow_furrow`
+        stay background-only: an agent that stopped talking because the
+        user smiled would be wrong, not attentive.
+        """
+        return reflex_name == "startle"
+
     async def _plan_social_response(self, blackboard: dict[str, Any]) -> bool:
         event = blackboard["event"]
         goal = event.metadata.get("suggested_goal", "ENGAGE")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -162,6 +162,15 @@ class AppSettings(BaseSettings):
     # Bounded, unlike the JetStream default. A tick that fails repeatedly is
     # a bug to surface, not a message to retry forever.
     MESH_CONTROL_MAX_DELIVER: int = 3
+
+    # Bucket 17 (voice remediation Phase 4): the reflex tier's consumer
+    # budget. `vision.facial_reflex` and `audio.stop` handlers both return
+    # fast and synchronously by design -- a short ack_wait is therefore an
+    # honest latency budget, not just a label, and a handler that actually
+    # stalls should be redelivered quickly rather than left holding a
+    # 30s+ control-tier or unbounded default ack_wait.
+    MESH_REFLEX_ACK_WAIT_S: float = 5.0
+    MESH_REFLEX_MAX_DELIVER: int = 2
     MOCK_LLM_TEXT: bool = False
 
     # Stage 3 (audit/ROADMAP.md §7): off by default. When true, transport_agent,

--- a/backend/app/vision/agent.py
+++ b/backend/app/vision/agent.py
@@ -119,11 +119,13 @@ class VisionAgent(BaseAgent):
         self._face_landmarker = None
         facial_reflex_enabled = getattr(Config, "FACIAL_REFLEX_ENABLED", True)
         if facial_reflex_enabled and mp_vision is not None:
-            raw_path = (
-                facial_reflex_model_path
-                or getattr(Config, "FACIAL_REFLEX_MODEL_PATH", "")
-                or _DEFAULT_FACE_LANDMARKER_PATH
-            )
+            if facial_reflex_model_path is not None:
+                raw_path = facial_reflex_model_path
+            else:
+                raw_path = (
+                    getattr(Config, "FACIAL_REFLEX_MODEL_PATH", "")
+                    or _DEFAULT_FACE_LANDMARKER_PATH
+                )
             model_path = Path(raw_path)
             if model_path.exists():
                 try:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -552,6 +552,37 @@ def _shutdown_leaked_subject_metrics_threads():
                 pass
 
 
+@pytest.fixture(autouse=True)
+def _shutdown_leaked_vision_agents():
+    """Ensure any FaceLandmarker or VisionAgent threads created during tests
+    are cleanly closed on test teardown to prevent unjoined XNNPACK threadpools."""
+    try:
+        from app.vision.agent import VisionAgent
+    except ImportError:
+        yield
+        return
+
+    instances: list[VisionAgent] = []
+    original_init = VisionAgent.__init__
+
+    def _tracked_init(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        instances.append(self)
+
+    VisionAgent.__init__ = _tracked_init
+    try:
+        yield
+    finally:
+        VisionAgent.__init__ = original_init
+        for instance in instances:
+            try:
+                landmarker = getattr(instance, "_face_landmarker", None)
+                if landmarker is not None and hasattr(landmarker, "close"):
+                    landmarker.close()
+            except Exception:
+                pass
+
+
 def pytest_sessionfinish(session, exitstatus):
     """Force exit to prevent background thread pool/connection pool hangs."""
     import os

--- a/backend/tests/test_facial_reflex.py
+++ b/backend/tests/test_facial_reflex.py
@@ -10,10 +10,12 @@ affect nudge.
 """
 
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from app.cognitive.decision import DecisionService
+from app.state.adaptive_weights_store import AdaptiveWeightsStore
 from app.state.agent_state import StateService
 from app.vision.reflex import (
     BROW_FURROW_THRESHOLD,
@@ -297,16 +299,26 @@ def test_arousal_delta_moves_the_baseline_not_the_fatigue_inflated_reading():
 
 
 def _brain_stub():
-    """The one collaborator `_on_facial_reflex` touches, nothing more --
-    mirrors `test_somatic_vision.py`'s `_brain_stub` for the sibling
-    `_on_vision_description` path."""
-    from unittest.mock import MagicMock
-
+    """The collaborators `_on_facial_reflex` touches: affect state, the
+    (real, pure) decision arbiter, and a mocked mesh `publish` -- mirrors
+    `test_somatic_vision.py`'s `_brain_stub` for the sibling
+    `_on_vision_description` path, extended for Bucket 17's competition
+    check. `_turn_state_lock`/`_active_response_turn_id` are the real
+    `BrainAgent.__init__` defaults (see brain_agent.py:113/134) reproduced
+    by hand since `__new__` skips `__init__` entirely."""
     from app.agents.brain_agent import BrainAgent
 
     agent = BrainAgent.__new__(BrainAgent)
     agent.cognitive_core = MagicMock()
     agent.cognitive_core.state = _state()
+    agent.cognitive_core.decision = DecisionService(
+        llm_service=None,
+        memory_store=None,
+        weights_store=AdaptiveWeightsStore(":memory:"),
+    )
+    agent._turn_state_lock = asyncio.Lock()
+    agent._active_response_turn_id = None
+    agent.publish = AsyncMock()
     return agent
 
 
@@ -331,3 +343,80 @@ def test_on_facial_reflex_swallows_a_failure_rather_than_raising():
 
     asyncio.run(agent._on_facial_reflex({"name": "smile", "valence_delta": 0.04}))
     # No exception means it worked; nothing else to assert.
+
+
+# --------------------------------------------------------------------------
+# Bucket 17 (voice remediation Phase 4) -- competing for the workspace
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "reflex_name,expected",
+    [
+        ("startle", True),
+        ("smile", False),
+        ("brow_furrow", False),
+        ("unknown_signal", False),
+        ("", False),
+    ],
+)
+def test_is_facial_reflex_interruption_worthy(reflex_name, expected):
+    """Only `startle` -- the compound, highest-arousal reflex -- is salient
+    enough to compete for the workspace. An agent that stopped talking
+    because the user smiled would be wrong, not attentive."""
+    decision = DecisionService(
+        llm_service=None, memory_store=None, weights_store=AdaptiveWeightsStore(":memory:")
+    )
+    assert decision.is_facial_reflex_interruption_worthy(reflex_name) is expected
+
+
+def test_a_startle_during_an_active_turn_publishes_a_confirmed_audio_stop():
+    """The plan's own verify line: a startle arriving mid-turn must
+    demonstrably compete for the workspace -- not just log the event and
+    update background affect for whatever turn comes next."""
+    agent = _brain_stub()
+    agent._active_response_turn_id = "turn-123"
+
+    asyncio.run(
+        agent._on_facial_reflex(
+            {"name": "startle", "arousal_delta": 0.2, "evidence": "startle=0.9"}
+        )
+    )
+
+    agent.publish.assert_awaited_once()
+    (subject, payload), _ = agent.publish.call_args
+    from app.contracts import Topics
+
+    assert subject == Topics.AUDIO_STOP
+    assert payload["reason"] == "facial_reflex_startle"
+    assert payload["intent_type"] == "VISION_INTERRUPTION"
+    assert payload["turn_id"] == "turn-123"
+    assert payload["speculative"] is False
+
+
+def test_a_smile_during_an_active_turn_does_not_interrupt():
+    """Arbitration must actually gate, not fire on every reflex -- affect is
+    still updated, but the workspace is not contested over a smile."""
+    agent = _brain_stub()
+    agent._active_response_turn_id = "turn-123"
+    agent.cognitive_core.state.current_state.valence = 0.1
+
+    asyncio.run(
+        agent._on_facial_reflex({"name": "smile", "valence_delta": 0.04})
+    )
+
+    agent.publish.assert_not_awaited()
+    assert agent.cognitive_core.state.current_state.valence == pytest.approx(0.14)
+
+
+def test_a_startle_with_no_active_turn_does_not_publish():
+    """Nothing to interrupt -- a startle between turns is still a real affect
+    event (handled above), just not a workspace contest."""
+    agent = _brain_stub()
+    assert agent._active_response_turn_id is None
+
+    asyncio.run(
+        agent._on_facial_reflex({"name": "startle", "arousal_delta": 0.2})
+    )
+
+    agent.publish.assert_not_awaited()

--- a/backend/tests/test_vision.py
+++ b/backend/tests/test_vision.py
@@ -860,12 +860,11 @@ class TestVisionAgentFacialReflex:
         never fail agent construction entirely."""
         from app.config import Config
 
+        missing_path = tmp_path / "does_not_exist.task"
         monkeypatch.setattr(Config, "FACIAL_REFLEX_ENABLED", True)
-        monkeypatch.setattr(
-            Config, "FACIAL_REFLEX_MODEL_PATH", str(tmp_path / "does_not_exist.task")
-        )
+        monkeypatch.setattr(Config, "FACIAL_REFLEX_MODEL_PATH", str(missing_path))
 
-        agent = VisionAgent()
+        agent = VisionAgent(facial_reflex_model_path=missing_path)
 
         assert agent._face_landmarker is None
 
@@ -881,7 +880,7 @@ class TestVisionAgentFacialReflex:
         monkeypatch.setattr(Config, "FACIAL_REFLEX_MODEL_PATH", str(model_path))
         monkeypatch.setattr(Config, "FACIAL_REFLEX_ENABLED", False)
 
-        agent = VisionAgent()
+        agent = VisionAgent(facial_reflex_model_path=model_path)
 
         assert agent._face_landmarker is None
 
@@ -898,7 +897,7 @@ class TestVisionAgentFacialReflex:
         monkeypatch.setattr(Config, "FACIAL_REFLEX_ENABLED", True)
         monkeypatch.setattr(Config, "FACIAL_REFLEX_MODEL_PATH", str(model_path))
 
-        agent = VisionAgent()
+        agent = VisionAgent(facial_reflex_model_path=model_path)
 
         assert agent._face_landmarker is None
 


### PR DESCRIPTION
## Summary
- Implements Bucket 17 ("Name the workspace — Bucket 8's full implementation") items 1 and 2 from `VOICE_REMEDIATION_PLAN.md`: a `startle` facial-reflex event arriving mid-turn now competes for the workspace instead of only nudging background affect for whatever turn comes next.
- `DecisionService.is_facial_reflex_interruption_worthy` (pure, sibling to `is_speculative_stop_confirmed`) gates on `startle` only — `smile`/`brow_furrow` stay background-only.
- `brain_agent._on_facial_reflex` now publishes a confirmed `AudioStop(intent_type="VISION_INTERRUPTION", reason="facial_reflex_startle")` when a startle fires during an active turn, reusing `_on_audio_stop`'s existing, tested cancellation/truncation/adrenaline path — zero duplicated logic, and a genuine audible interruption since voice-agent/transport_agent already subscribe to `audio.stop`.
- Adds a reflex-tier JetStream consumer budget (`MESH_REFLEX_ACK_WAIT_S`/`MESH_REFLEX_MAX_DELIVER`) applied to `vision.facial_reflex` and `audio.stop`, making Bucket 8's "dual-loop split" concrete as a per-subject latency property rather than a new process (confirmed via exploration that every agent already runs as its own process — no new architecture needed).
- Bucket 17 items 3 (live camera capture) and 4 (S2S rejection) needed no further work — already shipped / already documented. This closes out Bucket 8/17.

**Also included:** `fix(test): add vision agent teardown fixture and harden model path overrides` — a real fix (made directly on this branch while this work was in progress) for the previously-documented, unresolved full-suite MediaPipe/LiveKit thread-leak stall near `test_vision.py`. Confirmed effective: the full suite now completes cleanly (1610/1610) where it previously stalled.

## Test plan
- [x] New tests in `test_facial_reflex.py`: arbitration truth table (startle→True, others→False), startle-during-active-turn publishes the correct `AudioStop` payload, smile-during-active-turn does not publish, startle-with-no-active-turn does not publish
- [x] Mutation-tested both the arbitration gate and the active-turn guard (each breaks exactly the tests that should catch it)
- [x] Full backend suite: 1610/1610 passing, 0 failures, 0 errors (JUnit XML)
- [x] `ruff check .` clean
- [x] `cargo check --workspace` clean