### PR TITLE
feat(cognitive): Phase 1 contract separation (1A-1E)

### DIFF
--- a/.agents/CONTEXT.md
+++ b/.agents/CONTEXT.md
@@ -15925,3 +15925,11 @@ distillation data. The single-turn reports also have no `state_fixture_hash`. Th
 and provenance gates are complete, but the research document's literal Phase 0 status remains
 **PARTIAL**. Phase 1's typed-realization experiment is the next valid step; do not redesign it based
 on these results, and do not claim stateful-runtime or subjective character-fidelity closure.
+
+## 2026-09-03 -- Codex Phase 1C (unmerged)
+
+Codex owns only the typed realization envelope experiment on clean base `a238fdd` (Claude's
+canonical Phase 1B). Added the opt-in `LLM_TYPED_REALIZATION_ENABLED` flag, bounded envelope
+parser, deterministic raw-text fallback, and focused stream tests. Claude owns 1A/1B/1D/1E;
+the earlier `cf83c9b` full-slice commit is overlap history and is not this branch's merge unit.
+No home-GPU run was performed.

--- a/backend/app/agents/base.py
+++ b/backend/app/agents/base.py
@@ -11,13 +11,14 @@ from typing import Any
 import nats
 import orjson
 
+from ..errors import AgentError
 from ..metrics import SubjectMetrics
 from ..utils.background_tasks import spawn_background
 
 logger = logging.getLogger(__name__)
 
 
-class JetStreamPublishFailed(RuntimeError):
+class JetStreamPublishFailed(RuntimeError, AgentError):
     """Raised by `BaseAgent.publish(..., allow_core_fallback=False)` when the
     JetStream publish itself failed. Distinguished from a generic publish
     failure so it can be let through the outer `except Exception` in

--- a/backend/app/agents/brain_agent.py
+++ b/backend/app/agents/brain_agent.py
@@ -9,6 +9,7 @@ from typing import Any
 from pydantic import ValidationError
 
 from ..cognitive import CognitiveService
+from ..cognitive.evidence import Evidence
 from ..cognitive.somatic import SomaticAppraiser
 from ..config import Config
 from ..contracts import (
@@ -113,6 +114,11 @@ class BrainAgent(BaseAgent):
 
         self.last_interaction_time = datetime.now()
         self.last_visual_context = "No visual data available."
+        # 1A: typed sibling of last_visual_context, built from the same
+        # VisionDescription payload. Additive -- last_visual_context stays
+        # the source every existing reader uses; this carries the
+        # confidence/timestamp/provenance those readers don't have access to.
+        self.last_visual_evidence: Evidence | None = None
         self.last_user_distance = 1.0
         self.last_user_voice_properties: UserVoiceProperties | None = None
 
@@ -263,6 +269,18 @@ class BrainAgent(BaseAgent):
             self.last_visual_context = f"I am seeing the user's {source}."
         distance = data.get("user_distance")
         self.last_user_distance = float(distance) if distance is not None else 1.0
+
+        # is_novel mirrors VisionDescription's own field: a frame that cleared
+        # habituation is a fresh observation (confidence 1.0); a cached
+        # repeat is worth less (0.5) without discarding it entirely.
+        self.last_visual_evidence = Evidence(
+            content=description or f"I am seeing the user's {source}.",
+            source=source,
+            modality="vision",
+            timestamp=float(data.get("timestamp", time.time())),
+            confidence=1.0 if data.get("is_novel", True) else 0.5,
+            provenance="vision_agent",
+        )
 
         await self._appraise_somatic(description)
 
@@ -658,6 +676,7 @@ class BrainAgent(BaseAgent):
             "metadata": {
                 **metadata,
                 "visuals": self.last_visual_context,
+                "visual_evidence": self.last_visual_evidence,
                 "turn_id": turn_id,
                 "utterance_id": utterance_id,
             },

--- a/backend/app/cognitive/action.py
+++ b/backend/app/cognitive/action.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncGenerator
 from typing import Any
 
 from ..config import Config
+from ..errors import AgentError
 from ..persona.biography import BIOGRAPHY_SOURCE
 from .decision import ActionPlan
 from .identity import _HOSTILE_TO_USER, _match_views
@@ -348,7 +349,7 @@ def reorder_for_long_context(memories):
     return reordered
 
 
-class MetacognitiveException(Exception):
+class MetacognitiveException(AgentError, Exception):
     def __init__(self, reason: str):
         super().__init__(reason)
         self.reason = reason

--- a/backend/app/cognitive/action.py
+++ b/backend/app/cognitive/action.py
@@ -9,8 +9,40 @@ from ..config import Config
 from ..persona.biography import BIOGRAPHY_SOURCE
 from .decision import ActionPlan
 from .identity import _HOSTILE_TO_USER, _match_views
+from .json_extract import extract_first_json_value
 
 logger = logging.getLogger(__name__)
+
+_TYPED_REALIZATION_GUIDANCE = (
+    "Return a JSON object with spoken_text (string), "
+    "realization_confidence (number from 0 to 1), "
+    "unanswered_questions (array), and claim_ids_used (array)."
+)
+
+
+def _parse_typed_realization(raw: str) -> dict[str, Any] | None:
+    """Validate the optional realization envelope; ``None`` means fallback."""
+    value = extract_first_json_value(raw or "", brackets="{")
+    if not isinstance(value, dict):
+        return None
+    spoken_text = value.get("spoken_text")
+    confidence = value.get("realization_confidence")
+    if not isinstance(spoken_text, str) or not spoken_text.strip():
+        return None
+    if isinstance(confidence, bool) or not isinstance(confidence, (int, float)):
+        return None
+    if not 0.0 <= float(confidence) <= 1.0:
+        return None
+    if not isinstance(value.get("unanswered_questions", []), list):
+        return None
+    if not isinstance(value.get("claim_ids_used", []), list):
+        return None
+    return {
+        "spoken_text": spoken_text,
+        "realization_confidence": float(confidence),
+        "unanswered_questions": value.get("unanswered_questions", []),
+        "claim_ids_used": value.get("claim_ids_used", []),
+    }
 
 # Phrases where the assistant attributes a fact to the shared past or the user's
 # prior statements ("you told me…", "remember when we…"). Such a phrase asserts a
@@ -974,6 +1006,8 @@ class ActionService:
             options_override=endocrine_options,
         ).__aiter__()
         deadline = time.monotonic() + stream_budget
+        typed_mode = bool(getattr(Config, "LLM_TYPED_REALIZATION_ENABLED", False))
+        typed_parts: list[str] = []
 
         while True:
             remaining = deadline - time.monotonic()
@@ -993,15 +1027,31 @@ class ActionService:
 
             # CoT strip check
             for segment in self._visible_segments(clean_chunk, state):
-                async for out in self._emit_validated(segment, state, plan.goal):
-                    yield out
+                if typed_mode:
+                    typed_parts.append(segment)
+                else:
+                    async for out in self._emit_validated(segment, state, plan.goal):
+                        yield out
 
         # Flush whatever the markup sanitizer was still holding back.
         for segment in self._visible_trailing(sanitizer.flush(), state):
-            async for out in self._emit_validated(
-                segment, state, plan.goal, allow_hesitation=False
-            ):
-                yield out
+            if typed_mode:
+                typed_parts.append(segment)
+            else:
+                async for out in self._emit_validated(
+                    segment, state, plan.goal, allow_hesitation=False
+                ):
+                    yield out
+
+        if typed_mode:
+            raw_typed = "".join(typed_parts)
+            envelope = _parse_typed_realization(raw_typed)
+            realization = envelope["spoken_text"] if envelope else raw_typed
+            if realization:
+                async for out in self._emit_validated(
+                    realization, state, plan.goal, allow_hesitation=False
+                ):
+                    yield out
 
         # Post-generation grounding gate: the whole utterance is now known, so
         # check it for fabricated shared-memory claims and route any hit
@@ -1265,6 +1315,8 @@ class ActionService:
 
         # Static System Prompt (cached by inference engines like Ollama/vLLM)
         system_instruction = f"{identity_prompt}\n\n{_CHAT_GUIDELINE}"
+        if getattr(Config, "LLM_TYPED_REALIZATION_ENABLED", False):
+            system_instruction += f"\n\n{_TYPED_REALIZATION_GUIDANCE}"
 
         # Dynamic User Prompt. Ordering fights "lost in the middle": the factual
         # grounding (SHARED HISTORY) is placed LAST before the user's query so it

--- a/backend/app/cognitive/action.py
+++ b/backend/app/cognitive/action.py
@@ -676,7 +676,14 @@ class ActionService:
         visual = payload.get("visual_context")
         if not visual or visual == "No visual data available.":
             return ""
-        return f"\nWHAT YOU CURRENTLY SEE:\n{_wrap_retrieved(visual)}"
+        evidence = payload.get("visual_evidence")
+        if evidence is not None:
+            age_s = max(0.0, time.time() - evidence.timestamp)
+            recency = "novel observation" if evidence.confidence >= 1.0 else "previously seen"
+            heading = f"WHAT YOU CURRENTLY SEE (as of {age_s:.0f}s ago, {recency})"
+        else:
+            heading = "WHAT YOU CURRENTLY SEE"
+        return f"\n{heading}:\n{_wrap_retrieved(visual)}"
 
     @staticmethod
     def _build_tom_context(user_tom) -> str:

--- a/backend/app/cognitive/action.py
+++ b/backend/app/cognitive/action.py
@@ -686,6 +686,33 @@ class ActionService:
         return f"\n{heading}:\n{_wrap_retrieved(visual)}"
 
     @staticmethod
+    def _build_realization_contract(plan: ActionPlan, emotion: str) -> str:
+        """Consolidate goal/emotion plus, when stage 6 attached one,
+        `plan.behavior_decision`'s relational stance/urgency/claim boundaries
+        into the single "Current Context" block -- one assembled place
+        instead of the goal line and any future addition each being bolted
+        on independently. Falls back to exactly today's two-line block when
+        no `behavior_decision` is present (the eval harness's action-path
+        plans, and any other plan built outside decision.py's BT, don't set
+        one)."""
+        lines = [f"- Goal: {plan.goal}", f"- Current Emotion: {emotion}"]
+        decision = plan.behavior_decision
+        if decision is not None:
+            intent = decision.intent
+            lines.append(f"- Relational stance: {intent.relational_stance}")
+            lines.append(f"- Urgency: {intent.urgency:.2f}")
+            if decision.allowed_claims:
+                lines.append(
+                    f"- You may claim: {', '.join(decision.allowed_claims)}"
+                )
+            if decision.forbidden_claims:
+                lines.append(
+                    "- You must NOT claim or imply: "
+                    + ", ".join(decision.forbidden_claims)
+                )
+        return "\n".join(lines)
+
+    @staticmethod
     def _build_tom_context(user_tom) -> str:
         """Render the Theory-of-Mind block describing the inferred user state."""
         if not user_tom:
@@ -1245,7 +1272,8 @@ class ActionService:
         # answer. The more abstract, lower-cost-to-lose context (goal, emotion,
         # Theory-of-Mind) goes earlier. Within the history block itself, memories
         # are already edge-loaded by reorder_for_long_context().
-        user_prompt = f"Current Context:\n- Goal: {plan.goal}\n- Current Emotion: {emotion}\n{tom_context}{wondering}{visual_context}{shared_history}\n\nUser: {msg}\nAssistant:"
+        realization_contract = self._build_realization_contract(plan, emotion)
+        user_prompt = f"Current Context:\n{realization_contract}\n{tom_context}{wondering}{visual_context}{shared_history}\n\nUser: {msg}\nAssistant:"
 
         valence = plan.payload.get("valence", 0.0)
         arousal = plan.payload.get("arousal", 0.5)

--- a/backend/app/cognitive/behavior_contracts.py
+++ b/backend/app/cognitive/behavior_contracts.py
@@ -1,0 +1,70 @@
+"""CommunicativeIntent / BehaviorDecision (Phase 1B, §15 item 4): what stage
+6 (the Behavior Tree) decides to say, separated from how stage 8
+(realization) says it.
+
+Today's `ActionPlan.payload` is `dict[str, Any]` -- assembled once by
+`decision.py` and consumed once by `action.py`, with the connection between
+"why this goal" and "what the model may/may not claim" implicit in whichever
+prompt lines `_execute_respond_chat` happens to build. `BehaviorDecision`
+makes that connection an explicit, typed object instead: one place that says
+what the turn is for, how urgent it is, and what's off-limits, so
+`persona/policy.py` can validate it before generation and `action.py` can
+render it as one consolidated block instead of several independently
+assembled ones.
+
+In-process only, not a NATS `Topics` member -- promoting a type to the wire
+is Phase 3's job for `SpeechExpression`, once validated here first.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+RelationalStance = Literal["distant", "guarded", "neutral", "warm", "close"]
+InterruptionPolicy = Literal["deliberative", "reflex"]
+
+
+class InternalState(BaseModel):
+    """Thin typed view over `StateService.get_context_snapshot()`'s dict.
+    Constructed on demand from the snapshot, never persisted itself -- it
+    exists so a caller that wants mood/trust/attachment doesn't re-read the
+    raw dict with its own copy of the default values."""
+
+    mood: float = 0.0
+    energy: float = 0.5
+    dominance: float = 0.5
+    trust: float = 0.5
+    attachment: float = 0.1
+
+    @classmethod
+    def from_snapshot(cls, snapshot: dict[str, Any] | None) -> InternalState:
+        snapshot = snapshot or {}
+        return cls(
+            mood=float(snapshot.get("mood", 0.0)),
+            energy=float(snapshot.get("energy", 0.5)),
+            dominance=float(snapshot.get("dominance", 0.5)),
+            trust=float(snapshot.get("trust", 0.5)),
+            attachment=float(snapshot.get("attachment", 0.1)),
+        )
+
+
+class CommunicativeIntent(BaseModel):
+    """What this turn is trying to do, in typed form."""
+
+    act: str  # event.intent, e.g. "CHAT", "RECALL"
+    goal: str  # MAUT-selected goal, e.g. "ENGAGE", "COMFORT"
+    urgency: float = Field(default=0.5, ge=0.0, le=1.0)
+    relational_stance: RelationalStance = "neutral"
+    interruption_policy: InterruptionPolicy = "deliberative"
+
+
+class BehaviorDecision(BaseModel):
+    """The typed decision stage 6 hands to stage 8's realization: an intent
+    plus the claim boundaries `persona/policy.py` enforces before
+    generation."""
+
+    intent: CommunicativeIntent
+    allowed_claims: list[str] = Field(default_factory=list)
+    forbidden_claims: list[str] = Field(default_factory=list)

--- a/backend/app/cognitive/decision.py
+++ b/backend/app/cognitive/decision.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from ..config import Config
 from ..state.adaptive_weights_store import AdaptiveWeightsStore
+from .behavior_contracts import BehaviorDecision, CommunicativeIntent
 from .bt import Action, Condition, NodeStatus, Selector, Sequence
 from .json_extract import extract_first_json_value
 from .perception import CognitiveEvent
@@ -33,6 +34,61 @@ class ActionPlan:
     payload: dict[str, Any]
     goal: str
     priority: int = 1
+    # 1B: typed sibling of goal/payload -- what this turn is trying to do and
+    # what it may/may not claim, before persona/policy.py's precheck
+    # (pipeline.py stage 7) and action.py's realization see it. Defaulted so
+    # every existing keyword/short-positional ActionPlan(...) call keeps
+    # working unchanged.
+    behavior_decision: BehaviorDecision | None = None
+
+
+# Ordered coarsest -> warmest; _bucket_relational_stance clamps into this.
+_RELATIONAL_STANCES: tuple[str, ...] = ("distant", "guarded", "neutral", "warm", "close")
+
+# Urgency at/above this maps a turn's interruption_policy to "reflex" --
+# naming, for conversational turns, the same class of "high-arousal signal
+# competes for the workspace immediately" judgment
+# `is_facial_reflex_interruption_worthy` already makes for vision's `startle`
+# reflex, rather than reintroducing a second threshold with different logic.
+_REFLEX_URGENCY_THRESHOLD = 0.75
+
+
+def _bucket_relational_stance(trust: float, attachment: float, mood: float) -> str:
+    """Clamp+bucket trust/attachment/mood into a named stance -- the same
+    clamp-then-map shape `persona/compiler.py::_infer_temperament` uses for
+    turning continuous dimension scores into bounded fields, applied here to
+    pick one of `_RELATIONAL_STANCES` instead of a numeric field."""
+    trust = max(0.0, min(1.0, trust))
+    attachment = max(0.0, min(1.0, attachment))
+    mood_unit = max(0.0, min(1.0, (mood + 1.0) / 2.0))
+    score = (trust + attachment + mood_unit) / 3.0
+    index = min(int(score * len(_RELATIONAL_STANCES)), len(_RELATIONAL_STANCES) - 1)
+    return _RELATIONAL_STANCES[index]
+
+
+def _build_communicative_intent(
+    event: CognitiveEvent, blackboard: dict[str, Any]
+) -> CommunicativeIntent:
+    """Stage 6: derive what this turn is trying to do from the event and the
+    state snapshot already on the blackboard -- no new state reads."""
+    state = blackboard.get("state") or {}
+    metadata = event.metadata or {}
+    tom = metadata.get("tom_inferences") or {}
+    urgency = max(0.0, min(1.0, float(tom.get("inferred_arousal", 0.5))))
+    stance = _bucket_relational_stance(
+        trust=float(state.get("trust", 0.5)),
+        attachment=float(state.get("attachment", 0.1)),
+        mood=float(state.get("mood", 0.0)),
+    )
+    return CommunicativeIntent(
+        act=event.intent or "CHAT",
+        goal=metadata.get("suggested_goal", "ENGAGE"),
+        urgency=urgency,
+        relational_stance=stance,
+        interruption_policy=(
+            "reflex" if urgency >= _REFLEX_URGENCY_THRESHOLD else "deliberative"
+        ),
+    )
 
 
 class DecisionService:
@@ -537,6 +593,7 @@ class DecisionService:
     async def _plan_social_response(self, blackboard: dict[str, Any]) -> bool:
         event = blackboard["event"]
         goal = event.metadata.get("suggested_goal", "ENGAGE")
+        intent = _build_communicative_intent(event, blackboard)
 
         blackboard["plan"] = ActionPlan(
             action_type="RESPOND_CHAT",
@@ -548,15 +605,30 @@ class DecisionService:
                 "surfaced_memories": event.metadata.get("surfaced_memories", []),
             },
             priority=1,
+            behavior_decision=BehaviorDecision(intent=intent),
         )
         return True
 
     async def _plan_reflection(self, blackboard: dict[str, Any]) -> bool:
-        blackboard["plan"] = ActionPlan("BACKGROUND_CONSOLIDATION", {}, "REFLECT", 0)
+        event = blackboard["event"]
+        intent = _build_communicative_intent(event, blackboard)
+        blackboard["plan"] = ActionPlan(
+            "BACKGROUND_CONSOLIDATION",
+            {},
+            "REFLECT",
+            0,
+            behavior_decision=BehaviorDecision(intent=intent),
+        )
         return True
 
     async def _plan_storage(self, blackboard: dict[str, Any]) -> bool:
+        event = blackboard["event"]
+        intent = _build_communicative_intent(event, blackboard)
         blackboard["plan"] = ActionPlan(
-            "STORE_MEMORY", {"content": blackboard["event"].raw_content}, "RECALL", 2
+            "STORE_MEMORY",
+            {"content": event.raw_content},
+            "RECALL",
+            2,
+            behavior_decision=BehaviorDecision(intent=intent),
         )
         return True

--- a/backend/app/cognitive/evidence.py
+++ b/backend/app/cognitive/evidence.py
@@ -1,0 +1,70 @@
+"""Evidence (§15 item 1): a typed unit of "what the agent currently knows
+this from," carrying modality, confidence, and provenance alongside content.
+
+Today's `brain_agent.last_visual_context` is a plain string overwritten on
+every vision event -- once a VLM description arrives, there is no way to
+distinguish "just observed, high confidence" from "last seen a while ago,
+maybe stale," and `action.py::_build_visual_context` has no basis to render
+that distinction even if it wanted to. `Evidence` is additive: it exists
+alongside the string context, not instead of it, so nothing that already
+reads `last_visual_context` breaks.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+Modality = Literal["vision", "audio", "text", "memory"]
+
+
+class Evidence(BaseModel):
+    """One piece of grounding for a cognitive turn: what was perceived or
+    recalled, where it came from, and how much to trust it."""
+
+    evidence_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    content: str
+    source: str
+    modality: Modality
+    timestamp: float = Field(default_factory=time.time)
+    confidence: float = 1.0
+    provenance: str = ""
+    # Wall-clock time after which this evidence should no longer be treated
+    # as current (e.g. a visual observation going stale). None means it
+    # doesn't expire on its own -- the caller decides staleness some other
+    # way (e.g. comparing against `timestamp` directly, as the visual
+    # context renderer does).
+    expiry: float | None = None
+
+    def is_expired(self, now: float | None = None) -> bool:
+        if self.expiry is None:
+            return False
+        return (now if now is not None else time.time()) >= self.expiry
+
+    @classmethod
+    def from_surfaced_memory(cls, mem: Any) -> Evidence:
+        """Adapt a `contracts.SurfacedMemory` into `Evidence`. Takes `Any`
+        rather than importing `SurfacedMemory` to avoid a
+        `cognitive` -> `contracts` -> ... import cycle risk; the attributes
+        read here (`content`, `score`, `created_at`, `metadata`) are exactly
+        `SurfacedMemory`'s own fields."""
+        created_at = getattr(mem, "created_at", None)
+        timestamp = time.time()
+        if created_at:
+            try:
+                timestamp = time.mktime(time.strptime(created_at[:19], "%Y-%m-%dT%H:%M:%S"))
+            except (ValueError, TypeError):
+                pass
+        score = getattr(mem, "score", 1.0) or 0.0
+        metadata = getattr(mem, "metadata", None) or {}
+        return cls(
+            content=getattr(mem, "content", ""),
+            source=str(metadata.get("provenance", "memory_store")),
+            modality="memory",
+            timestamp=timestamp,
+            confidence=max(0.0, min(1.0, score)),
+            provenance="memory_store",
+        )

--- a/backend/app/cognitive/pipeline.py
+++ b/backend/app/cognitive/pipeline.py
@@ -5,6 +5,7 @@ from collections.abc import AsyncGenerator
 from typing import Any
 
 from ..contracts import StateUpdate
+from ..persona.policy import PersonaPolicy
 
 logger = logging.getLogger(__name__)
 
@@ -306,6 +307,10 @@ class CognitivePipeline:
         plan.payload["visual_evidence"] = (
             event.metadata.get("visual_evidence") if event.metadata else None
         )
+        if plan.behavior_decision is not None:
+            plan.behavior_decision = PersonaPolicy.precheck(
+                plan.behavior_decision, self.identity.immutable_core
+            )
 
     @staticmethod
     def _compute_pre_llm_telemetry(stage_times: dict[str, Any], event) -> None:

--- a/backend/app/cognitive/pipeline.py
+++ b/backend/app/cognitive/pipeline.py
@@ -303,6 +303,9 @@ class CognitivePipeline:
         plan.payload["visual_context"] = (
             event.metadata.get("visuals") if event.metadata else None
         )
+        plan.payload["visual_evidence"] = (
+            event.metadata.get("visual_evidence") if event.metadata else None
+        )
 
     @staticmethod
     def _compute_pre_llm_telemetry(stage_times: dict[str, Any], event) -> None:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -215,6 +215,9 @@ class AppSettings(BaseSettings):
 
     LLM_STREAM_MAX_SECONDS: int = 120
     LLM_INTENT_CLASSIFICATION_ENABLED: bool = True
+    # Phase 1 experiment: ask the realization model for a bounded envelope.
+    # False preserves the existing streaming text contract.
+    LLM_TYPED_REALIZATION_ENABLED: bool = False
 
     # P1-1: the control tier's JetStream consumer settings (system.tick).
     # Both were previously implicit -- a 30s server-default ack_wait and

--- a/backend/app/contracts.py
+++ b/backend/app/contracts.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import time
 from enum import Enum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Literal
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -54,6 +54,63 @@ class Topics(str, Enum):
     # no such justification, and "who is connected" is state as much as
     # state.broadcast's affect snapshot is.
     SESSION_PRESENCE = "state.presence"
+
+
+# 1E (§14 MODIFY / §2 Infrastructure): explicit delivery semantics per
+# subject, so "audio is lossy, cognition is durable" is a declared fact
+# rather than something inferred from which stream tier a subject's pattern
+# happens to fall into, or which client library a process uses to consume
+# it -- HUMANOID_ARCHITECTURE_RESEARCH.md §2 names both of those as exactly
+# the wrong place to infer this from.
+#
+# Default derivation: every subject under the AI_AUDIO stream's `audio.>`
+# pattern (nats_streams.CORE_STREAMS) is memory-backed with a minutes-scale
+# retention (nats_streams.STREAM_POLICIES) -- an intentional, documented
+# trade-off -- so it defaults to "best_effort". Every other declared subject
+# sits on the file-backed, week-scale AI_MESSAGES stream, so it defaults to
+# "durable". Two subjects override that default, both for reasons already
+# established in check_subject_wiring.py's ALLOWLIST:
+#
+#   - AGENT_VOICE_MODULATION technically matches AI_MESSAGES' `agent.>`
+#     pattern, but its only real consumer is the frontend voice UI over a
+#     lossy WebRTC data channel, not durable cognition -- expressive
+#     control data, not something a restart should replay.
+#   - AMBIENT_NOISE_TELEMETRY matches no declared stream pattern at all (a
+#     known gap tracked there); its only consumer (voice-agent) reads it
+#     over core NATS as live telemetry, so it is classified by that actual
+#     behavior rather than left unclassified.
+#
+# `scripts/diagnostics/check_delivery_semantics.py` re-derives the
+# stream-tier default from `nats_streams.py` and fails if a subject here
+# disagrees with it without being one of the two named overrides above --
+# catching drift (a subject moved between streams, or a new one added here
+# without its tier being reasoned about) going forward.
+TOPIC_DELIVERY: dict[Topics, Literal["durable", "best_effort"]] = {
+    Topics.CHAT_INPUT: "durable",
+    Topics.CHAT_OUTPUT: "durable",
+    Topics.VISION_CONTROL: "durable",
+    Topics.VISION_FRAMES: "durable",
+    Topics.VISION_DESCRIPTION: "durable",
+    Topics.VISION_FACIAL_REFLEX: "durable",
+    Topics.AUDIO_PERCEPTION: "best_effort",
+    Topics.AUDIO_STOP: "best_effort",
+    Topics.AUDIO_RESUME: "best_effort",
+    Topics.AUDIO_INBOUND: "best_effort",
+    Topics.AUDIO_STREAM: "best_effort",
+    Topics.VOICE_WARM: "durable",
+    Topics.VOICE_SEGMENTATION_FEEDBACK: "durable",
+    Topics.SYSTEM_TICK: "durable",
+    Topics.MEMORY_SURFACED: "durable",
+    Topics.STATE_UPDATE: "durable",
+    Topics.STATE_SUBCONSCIOUS: "durable",
+    Topics.USER_VOICE_PROPERTIES: "durable",
+    Topics.AGENT_VOICE_MODULATION: "best_effort",  # override: frontend-consumed, see above
+    Topics.AUDIO_PLAYBACK_VISEMES: "best_effort",
+    Topics.AUDIO_PLAYBACK_PROGRESS: "best_effort",
+    Topics.AUDIO_PLAYBACK_BACKLOG: "best_effort",
+    Topics.AMBIENT_NOISE_TELEMETRY: "best_effort",  # override: no declared stream, see above
+    Topics.SESSION_PRESENCE: "durable",
+}
 
 
 # ─── chat.input ──────────────────────────────────────────────

--- a/backend/app/errors.py
+++ b/backend/app/errors.py
@@ -1,0 +1,53 @@
+"""Failure taxonomy (Phase 1D, §15 item 12).
+
+Today, a caller that wants to catch "something this agent raised, as opposed
+to a stray `ValueError` from a library" has no such type to catch -- each
+subsystem invented its own bespoke exception (`MetacognitiveException`,
+`StreamReconciliationError`, `JetStreamPublishFailed`,
+`PersonaCompilationError`, ...) with no common ancestor narrower than
+`Exception` itself. `AgentError` is that ancestor.
+
+Existing exceptions gain `AgentError` as an *additional* base via multiple
+inheritance rather than being redefined under it -- every existing
+``except StreamReconciliationError`` or ``except RuntimeError`` call site
+keeps working unchanged, while new code gets the option of
+``except AgentError`` to catch any of them uniformly.
+"""
+
+from __future__ import annotations
+
+
+class AgentError(Exception):
+    """Base for every error the agent mesh itself raises deliberately, as
+    opposed to an unexpected exception from a library or the runtime."""
+
+
+class PerceptionError(AgentError):
+    """Turning a raw event into a `CognitiveEvent` failed."""
+
+
+class RetrievalError(AgentError):
+    """Memory/graph/vector retrieval failed in a way the caller must react
+    to, distinct from "found nothing" (which is a normal, empty result)."""
+
+
+class StateConflictError(AgentError):
+    """A state mutation was rejected because it conflicted with a newer or
+    concurrent write -- see `AgentState`'s revision guard (Phase 2A)."""
+
+
+class PolicyError(AgentError):
+    """A persona/identity boundary check rejected a plan or a response."""
+
+
+class RealizationError(AgentError):
+    """Stage 8 (turning an approved decision into spoken/written text)
+    failed in a way distinct from a raw LLM transport/network error."""
+
+
+class TransportError(AgentError):
+    """Delivering a turn's output to the user-facing transport (chat/audio
+    session) failed. TTS-specific synthesis failures are a Rust concern
+    (voice-agent's own error types) -- this covers the Python-side
+    publish/session boundary only.
+    """

--- a/backend/app/nats_streams.py
+++ b/backend/app/nats_streams.py
@@ -8,10 +8,12 @@ import nats
 from nats.errors import NoRespondersError
 from nats.js.errors import BadRequestError, ServiceUnavailableError
 
+from .errors import AgentError
+
 logger = logging.getLogger("nats_streams")
 
 
-class StreamReconciliationError(RuntimeError):
+class StreamReconciliationError(RuntimeError, AgentError):
     """Raised when concurrent stream writers prevent convergence."""
 
 

--- a/backend/app/persona/compiler.py
+++ b/backend/app/persona/compiler.py
@@ -45,6 +45,7 @@ import re
 from typing import Any
 
 from ..config import Config
+from ..errors import AgentError
 from ..llm import LLMClient, build_llm_client
 from .profile import PersonaProfile
 
@@ -73,7 +74,7 @@ _PRONOUNS_NOT_NAMES = {
 }
 
 
-class PersonaCompilationError(Exception):
+class PersonaCompilationError(AgentError, Exception):
     """The LLM's output could not be turned into a persona.
 
     Raised rather than silently falling back to defaults: unlike booting an

--- a/backend/app/persona/policy.py
+++ b/backend/app/persona/policy.py
@@ -1,0 +1,63 @@
+"""PersonaPolicy (Phase 1B, §15 item 5): a proactive check on a
+`BehaviorDecision` before generation, sitting next to -- not replacing --
+`IdentityManager.validate_response`'s existing reactive regex check on the
+model's actual output.
+
+Today, the only thing standing between a plan and a boundary violation is
+catching it after the model has already generated the violating text
+(`validate_response`), which forces a self-correction retry pass. This adds
+a cheap check *before* generation: populate `forbidden_claims` from the
+immutable core so a consolidated realization prompt (Phase 1B's other half,
+in `action.py::_execute_respond_chat`) can tell the model what's off-limits
+up front, and clamp an over-warm `relational_stance` the same way. Neither
+of these replaces `validate_response` -- a determined model can still ignore
+a prompt instruction, which is exactly what the reactive check exists to
+catch.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..cognitive.behavior_contracts import BehaviorDecision
+
+# Boundaries mentioning any of these keywords cap relational_stance at
+# "warm" -- the friend can be warm without romantic/sexual framing, but nothing
+# in today's default IMMUTABLE_CORE (privacy, non-toxicity) triggers this;
+# it's here for personas that author such a boundary explicitly.
+_STANCE_RESTRICTING_KEYWORDS = ("romantic", "intimate", "sexual")
+_STANCE_CAP_WHEN_RESTRICTED = "warm"
+
+_RELATIONAL_STANCES: tuple[str, ...] = ("distant", "guarded", "neutral", "warm", "close")
+
+
+class PersonaPolicy:
+    """Stateless -- every method takes what it needs and returns a new
+    `BehaviorDecision` rather than mutating in place, so a caller holding a
+    reference to the pre-precheck decision isn't surprised by it changing
+    underfoot."""
+
+    @staticmethod
+    def precheck(
+        behavior_decision: BehaviorDecision, immutable_core: dict[str, Any]
+    ) -> BehaviorDecision:
+        boundaries = list(immutable_core.get("boundaries", []))
+        intent = behavior_decision.intent
+
+        stance = intent.relational_stance
+        if any(
+            keyword in boundary.lower()
+            for boundary in boundaries
+            for keyword in _STANCE_RESTRICTING_KEYWORDS
+        ):
+            cap_index = _RELATIONAL_STANCES.index(_STANCE_CAP_WHEN_RESTRICTED)
+            if _RELATIONAL_STANCES.index(stance) > cap_index:
+                stance = _STANCE_CAP_WHEN_RESTRICTED
+
+        clamped_intent = intent.model_copy(update={"relational_stance": stance})
+        return behavior_decision.model_copy(
+            update={
+                "intent": clamped_intent,
+                "forbidden_claims": boundaries,
+            }
+        )

--- a/backend/scripts/diagnostics/check_delivery_semantics.py
+++ b/backend/scripts/diagnostics/check_delivery_semantics.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+Phase 1E: assert `contracts.TOPIC_DELIVERY` agrees with `nats_streams.py`'s
+actual stream tiers, statically, in CI.
+
+`TOPIC_DELIVERY` declares whether each subject is "durable" (replayable
+cognition) or "best_effort" (lossy, low-latency audio/expression) -- a fact
+that used to be implicit in which stream tier a subject's pattern happened
+to fall into (`nats_streams.CORE_STREAMS`), or which client library a
+process used to consume it. This script re-derives the stream-tier default
+from `nats_streams.py` directly and fails if `TOPIC_DELIVERY` disagrees with
+it, unless the subject is one of the two documented overrides in
+`contracts.py` (each already justified there and in
+`check_subject_wiring.py`'s ALLOWLIST) -- catching drift (a subject moved
+between streams, a new subject added to `Topics` without a
+`TOPIC_DELIVERY` entry, or an override that no longer matches reality) going
+forward, matching `check_subject_wiring.py`'s own enforcing-not-warning
+convention.
+
+Usage: python scripts/diagnostics/check_delivery_semantics.py
+Exit 0 = TOPIC_DELIVERY fully agrees with nats_streams.py's stream tiers.
+Exit 1 = a subject's declared delivery semantics disagrees with its actual
+         stream tier, or Topics/TOPIC_DELIVERY have drifted apart.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.contracts import TOPIC_DELIVERY, Topics
+from app.nats_streams import CORE_STREAMS
+
+# Subjects whose declared delivery semantics deliberately disagrees with
+# their raw stream-tier match. Each entry documents why -- see the matching
+# comment block above `TOPIC_DELIVERY` in contracts.py.
+DOCUMENTED_OVERRIDES: dict[Topics, str] = {
+    Topics.AGENT_VOICE_MODULATION: (
+        "matches AI_MESSAGES' agent.> pattern, but consumed only by the "
+        "frontend voice UI over a lossy WebRTC data channel -- not durable "
+        "cognition"
+    ),
+    Topics.AMBIENT_NOISE_TELEMETRY: (
+        "matches no declared stream pattern (known gap, see "
+        "check_subject_wiring.py's ALLOWLIST); consumed live over core NATS"
+    ),
+}
+
+
+def subject_matches_pattern(subject: str, pattern: str) -> bool:
+    """NATS wildcard match: `>` matches one or more trailing tokens, `*`
+    matches exactly one token. Mirrors check_subject_wiring.py's helper of
+    the same name -- duplicated rather than imported, since that script is
+    a standalone CLI, not a module meant to be imported from."""
+    subj_tokens = subject.split(".")
+    pat_tokens = pattern.split(".")
+
+    for i, pat_tok in enumerate(pat_tokens):
+        if pat_tok == ">":
+            return len(subj_tokens) > i
+        if i >= len(subj_tokens):
+            return False
+        if pat_tok == "*":
+            continue
+        if pat_tok != subj_tokens[i]:
+            return False
+    return len(subj_tokens) == len(pat_tokens)
+
+
+def derive_default(subject: str) -> str | None:
+    """The stream-tier-derived default: best_effort for AI_AUDIO (`audio.>`,
+    memory-backed, minutes-scale retention), durable for AI_MESSAGES
+    (file-backed, week-scale). None if the subject matches no declared
+    stream at all -- that subject has no principled default and MUST be a
+    documented override."""
+    for stream_name, patterns in CORE_STREAMS.items():
+        if any(subject_matches_pattern(subject, pattern) for pattern in patterns):
+            return "best_effort" if stream_name == "AI_AUDIO" else "durable"
+    return None
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    declared_topics = set(TOPIC_DELIVERY.keys())
+    all_topics = set(Topics)
+
+    missing = all_topics - declared_topics
+    for topic in sorted(missing, key=lambda t: t.value):
+        failures.append(
+            f"{topic.value}: declared in Topics but missing from TOPIC_DELIVERY"
+        )
+
+    orphaned = declared_topics - all_topics
+    for topic in sorted(orphaned, key=lambda t: t.value):
+        failures.append(
+            f"{topic.value}: in TOPIC_DELIVERY but no longer a Topics member"
+        )
+
+    for topic in sorted(declared_topics & all_topics, key=lambda t: t.value):
+        declared = TOPIC_DELIVERY[topic]
+        default = derive_default(topic.value)
+
+        if topic in DOCUMENTED_OVERRIDES:
+            if default is not None and default == declared:
+                failures.append(
+                    f"{topic.value}: listed as a documented override "
+                    f"({DOCUMENTED_OVERRIDES[topic]}) but its declared "
+                    f"'{declared}' already matches the stream-tier default "
+                    "-- the override is stale, remove it"
+                )
+            continue
+
+        if default is None:
+            failures.append(
+                f"{topic.value}: matches no declared stream pattern, so it "
+                f"has no principled default for its declared '{declared}' -- "
+                "add it to DOCUMENTED_OVERRIDES with a reason, or wire it "
+                "into a CORE_STREAMS pattern"
+            )
+        elif default != declared:
+            failures.append(
+                f"{topic.value}: declared '{declared}' but its stream tier "
+                f"implies '{default}' -- fix TOPIC_DELIVERY, or add a "
+                "documented override with a reason if this is deliberate"
+            )
+
+    print(f"Topics declared: {len(all_topics)}")
+    print(f"TOPIC_DELIVERY entries: {len(declared_topics)}")
+    print(f"Documented overrides: {len(DOCUMENTED_OVERRIDES)}")
+    print()
+
+    if failures:
+        print(f"=== {len(failures)} delivery-semantics issue(s) ===")
+        for item in failures:
+            print(item)
+        return 1
+
+    print("OK: TOPIC_DELIVERY fully agrees with nats_streams.py's stream tiers.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_behavior_contracts.py
+++ b/backend/tests/test_behavior_contracts.py
@@ -1,0 +1,60 @@
+"""CommunicativeIntent / BehaviorDecision / InternalState (Phase 1B, §15
+item 4) -- the typed decision stage 6 hands stage 8, separate from the
+`decision.py` glue that builds one (covered in test_decision.py)."""
+
+import pytest
+from pydantic import ValidationError
+
+from app.cognitive.behavior_contracts import (
+    BehaviorDecision,
+    CommunicativeIntent,
+    InternalState,
+)
+
+
+def test_internal_state_from_snapshot_reads_known_keys():
+    snapshot = {
+        "mood": 0.4,
+        "energy": 0.6,
+        "dominance": 0.55,
+        "trust": 0.7,
+        "attachment": 0.3,
+        "unrelated_key": "ignored",
+    }
+    state = InternalState.from_snapshot(snapshot)
+    assert state.mood == 0.4
+    assert state.trust == 0.7
+    assert state.attachment == 0.3
+
+
+def test_internal_state_from_snapshot_defaults_on_missing_keys():
+    """A snapshot from a stub or an older caller may not carry every key --
+    from_snapshot must not raise, and must fall back to the schema's own
+    defaults rather than None."""
+    state = InternalState.from_snapshot({})
+    assert state.mood == 0.0
+    assert state.trust == 0.5
+    assert state.attachment == 0.1
+
+
+def test_internal_state_from_snapshot_handles_none():
+    state = InternalState.from_snapshot(None)
+    assert state.mood == 0.0
+
+
+def test_communicative_intent_rejects_urgency_out_of_bounds():
+    with pytest.raises(ValidationError):
+        CommunicativeIntent(act="CHAT", goal="ENGAGE", urgency=1.5)
+    with pytest.raises(ValidationError):
+        CommunicativeIntent(act="CHAT", goal="ENGAGE", urgency=-0.1)
+
+
+def test_communicative_intent_rejects_unknown_relational_stance():
+    with pytest.raises(ValidationError):
+        CommunicativeIntent(act="CHAT", goal="ENGAGE", relational_stance="obsessed")
+
+
+def test_behavior_decision_defaults_to_empty_claim_lists():
+    decision = BehaviorDecision(intent=CommunicativeIntent(act="CHAT", goal="ENGAGE"))
+    assert decision.allowed_claims == []
+    assert decision.forbidden_claims == []

--- a/backend/tests/test_context_assembly.py
+++ b/backend/tests/test_context_assembly.py
@@ -551,6 +551,66 @@ class TestRetrievedContentIsDelimited:
             "[RETRIEVED-CONTENT]The user is smiling.[/RETRIEVED-CONTENT]"
         )
 
+    def test_realization_contract_falls_back_to_two_lines_without_a_decision(self):
+        """No behavior_decision (eval-harness action-path plans, or any
+        other plan built outside decision.py's BT) -> exactly today's
+        pre-1B two-line block, unchanged."""
+        from app.cognitive.decision import ActionPlan
+
+        plan = ActionPlan(action_type="RESPOND_CHAT", goal="ENGAGE", payload={})
+        block = ActionService._build_realization_contract(plan, "happy")
+        assert block == "- Goal: ENGAGE\n- Current Emotion: happy"
+
+    def test_realization_contract_folds_in_behavior_decision_fields(self):
+        from app.cognitive.behavior_contracts import (
+            BehaviorDecision,
+            CommunicativeIntent,
+        )
+        from app.cognitive.decision import ActionPlan
+
+        decision = BehaviorDecision(
+            intent=CommunicativeIntent(
+                act="CHAT",
+                goal="COMFORT",
+                urgency=0.8,
+                relational_stance="warm",
+            ),
+            allowed_claims=["I remember you mentioned a hard day"],
+            forbidden_claims=["Will never share user data"],
+        )
+        plan = ActionPlan(
+            action_type="RESPOND_CHAT",
+            goal="COMFORT",
+            payload={},
+            behavior_decision=decision,
+        )
+        block = ActionService._build_realization_contract(plan, "concerned")
+        assert "- Goal: COMFORT" in block
+        assert "- Relational stance: warm" in block
+        assert "- Urgency: 0.80" in block
+        assert "You may claim: I remember you mentioned a hard day" in block
+        assert "You must NOT claim or imply: Will never share user data" in block
+
+    def test_realization_contract_omits_empty_claim_lists(self):
+        from app.cognitive.behavior_contracts import (
+            BehaviorDecision,
+            CommunicativeIntent,
+        )
+        from app.cognitive.decision import ActionPlan
+
+        decision = BehaviorDecision(
+            intent=CommunicativeIntent(act="CHAT", goal="ENGAGE")
+        )
+        plan = ActionPlan(
+            action_type="RESPOND_CHAT",
+            goal="ENGAGE",
+            payload={},
+            behavior_decision=decision,
+        )
+        block = ActionService._build_realization_contract(plan, "neutral")
+        assert "may claim" not in block
+        assert "must NOT claim" not in block
+
     def test_the_guideline_tells_the_model_the_markers_are_data(self):
         from app.cognitive.action import _CHAT_GUIDELINE
 

--- a/backend/tests/test_context_assembly.py
+++ b/backend/tests/test_context_assembly.py
@@ -507,6 +507,50 @@ class TestRetrievedContentIsDelimited:
             == ""
         )
 
+    def test_visual_context_renders_evidence_recency_when_present(self):
+        from app.cognitive.evidence import Evidence
+
+        evidence = Evidence(
+            content="ignored",
+            source="camera",
+            modality="vision",
+            confidence=1.0,
+        )
+        block = ActionService._build_visual_context(
+            {
+                "visual_context": "The user is smiling.",
+                "visual_evidence": evidence,
+            }
+        )
+        assert "novel observation" in block
+        assert "ago" in block
+
+    def test_visual_context_marks_stale_evidence_as_previously_seen(self):
+        from app.cognitive.evidence import Evidence
+
+        evidence = Evidence(
+            content="ignored", source="camera", modality="vision", confidence=0.5
+        )
+        block = ActionService._build_visual_context(
+            {
+                "visual_context": "The user is smiling.",
+                "visual_evidence": evidence,
+            }
+        )
+        assert "previously seen" in block
+
+    def test_visual_context_falls_back_when_evidence_absent(self):
+        """A producer that predates 1A (or the proactive-turn path, which
+        this phase deliberately doesn't touch) has no visual_evidence key --
+        rendering must not break, and must match the pre-1A heading exactly."""
+        block = ActionService._build_visual_context(
+            {"visual_context": "The user is smiling."}
+        )
+        assert block == (
+            "\nWHAT YOU CURRENTLY SEE:\n"
+            "[RETRIEVED-CONTENT]The user is smiling.[/RETRIEVED-CONTENT]"
+        )
+
     def test_the_guideline_tells_the_model_the_markers_are_data(self):
         from app.cognitive.action import _CHAT_GUIDELINE
 

--- a/backend/tests/test_decision.py
+++ b/backend/tests/test_decision.py
@@ -121,3 +121,108 @@ async def test_intent_classification_ignores_a_second_json_block_in_the_response
 
     assert event.intent == "COMMAND"
     assert event.metadata["suggested_goal"] == "TASK"
+
+
+# --------------------------------------------------------------------------
+# Phase 1B: CommunicativeIntent / BehaviorDecision attached to every plan
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chat_plan_carries_a_behavior_decision(decision_service, mock_llm_service):
+    mock_llm_service.generate.return_value = '{"intent": "CHAT", "goal": "TEASE"}'
+
+    event = CognitiveEvent(
+        event_id="6",
+        event_type="USER_MESSAGE",
+        raw_content="You are funny",
+        metadata={},
+    )
+    state = {"emotion": "happy", "mood": 0.5, "trust": 0.5, "attachment": 0.1}
+
+    plan = await decision_service.decide(event, state)
+
+    assert plan.behavior_decision is not None
+    assert plan.behavior_decision.intent.goal == "TEASE"
+    assert plan.behavior_decision.intent.act == "CHAT"
+
+
+@pytest.mark.asyncio
+async def test_reflect_plan_carries_a_behavior_decision(
+    decision_service, mock_llm_service
+):
+    event = CognitiveEvent(
+        event_id="7", event_type="SYSTEM_TICK", raw_content="Tick", metadata={}
+    )
+    event.intent = "REFLECT"
+    state = {"emotion": "neutral", "mood": 0.0}
+
+    plan = await decision_service.decide(event, state)
+
+    assert plan.behavior_decision is not None
+    assert plan.behavior_decision.intent.act == "REFLECT"
+
+
+def test_relational_stance_rises_with_trust_attachment_and_mood():
+    from app.cognitive.decision import _bucket_relational_stance
+
+    cold = _bucket_relational_stance(trust=0.0, attachment=0.0, mood=-1.0)
+    warm = _bucket_relational_stance(trust=1.0, attachment=1.0, mood=1.0)
+    assert cold == "distant"
+    assert warm == "close"
+
+
+def test_relational_stance_bucketing_is_monotonic_in_trust():
+    """A regression guard against a future edit that makes the bucket
+    function non-monotonic (e.g. an off-by-one in the index clamp) --
+    higher trust must never produce a colder-or-equal bucket ranked lower."""
+    from app.cognitive.decision import _RELATIONAL_STANCES, _bucket_relational_stance
+
+    stances = [
+        _bucket_relational_stance(trust=t / 10, attachment=0.5, mood=0.0)
+        for t in range(11)
+    ]
+    indices = [_RELATIONAL_STANCES.index(s) for s in stances]
+    assert indices == sorted(indices)
+
+
+def test_build_communicative_intent_reads_tom_urgency_and_state():
+    from app.cognitive.decision import _build_communicative_intent
+
+    event = CognitiveEvent(
+        event_id="8",
+        event_type="USER_MESSAGE",
+        raw_content="help now",
+        metadata={
+            "suggested_goal": "PROTECT",
+            "tom_inferences": {"inferred_arousal": 0.9},
+        },
+    )
+    event.intent = "CHAT"
+    blackboard = {
+        "event": event,
+        "state": {"trust": 0.5, "attachment": 0.1, "mood": 0.0},
+    }
+
+    intent = _build_communicative_intent(event, blackboard)
+
+    assert intent.goal == "PROTECT"
+    assert intent.urgency == pytest.approx(0.9)
+    assert intent.interruption_policy == "reflex"
+
+
+def test_build_communicative_intent_defaults_to_deliberative_below_threshold():
+    from app.cognitive.decision import _build_communicative_intent
+
+    event = CognitiveEvent(
+        event_id="9",
+        event_type="USER_MESSAGE",
+        raw_content="hey",
+        metadata={"tom_inferences": {"inferred_arousal": 0.3}},
+    )
+    event.intent = "CHAT"
+    blackboard = {"event": event, "state": {}}
+
+    intent = _build_communicative_intent(event, blackboard)
+
+    assert intent.interruption_policy == "deliberative"

--- a/backend/tests/test_delivery_semantics.py
+++ b/backend/tests/test_delivery_semantics.py
@@ -1,0 +1,72 @@
+"""Phase 1E: the delivery-semantics checker
+(scripts/diagnostics/check_delivery_semantics.py) is CI enforcement, so it
+needs to prove it actually catches the defect classes it exists for -- a
+mislabeled, missing, orphaned, or stale-override subject must each fail it,
+matching check_subject_wiring.py's own "the check tests itself" convention.
+"""
+
+import sys
+from pathlib import Path
+
+DIAGNOSTICS_DIR = Path(__file__).resolve().parents[1] / "scripts" / "diagnostics"
+if str(DIAGNOSTICS_DIR) not in sys.path:
+    sys.path.insert(0, str(DIAGNOSTICS_DIR))
+
+import check_delivery_semantics as checker
+
+from app.contracts import TOPIC_DELIVERY, Topics
+
+
+def test_the_real_repository_passes_clean():
+    """Regression guard: if this starts failing, either TOPIC_DELIVERY has
+    genuinely drifted from nats_streams.py's stream tiers, or a new
+    deliberate override needs to be added to DOCUMENTED_OVERRIDES -- not the
+    check silently going warn-only."""
+    assert checker.main() == 0
+
+
+def test_every_topics_member_has_a_delivery_entry():
+    assert set(TOPIC_DELIVERY.keys()) == set(Topics)
+
+
+def test_audio_subjects_default_to_best_effort():
+    assert checker.derive_default("audio.stream") == "best_effort"
+    assert checker.derive_default("audio.stop") == "best_effort"
+
+
+def test_non_audio_ai_messages_subjects_default_to_durable():
+    assert checker.derive_default("chat.output") == "durable"
+    assert checker.derive_default("state.update") == "durable"
+
+
+def test_a_subject_matching_no_stream_has_no_default():
+    assert checker.derive_default("nonexistent.subject") is None
+
+
+def test_a_mislabeled_subject_is_caught(monkeypatch):
+    """A subject on the durable AI_MESSAGES tier mislabeled as best_effort
+    (not one of the two documented overrides) must fail the check."""
+    mutated = dict(checker.TOPIC_DELIVERY)
+    mutated[Topics.CHAT_OUTPUT] = "best_effort"
+    monkeypatch.setattr(checker, "TOPIC_DELIVERY", mutated)
+    assert checker.main() == 1
+
+
+def test_a_missing_topics_entry_is_caught(monkeypatch):
+    mutated = dict(checker.TOPIC_DELIVERY)
+    del mutated[Topics.CHAT_OUTPUT]
+    monkeypatch.setattr(checker, "TOPIC_DELIVERY", mutated)
+    assert checker.main() == 1
+
+
+def test_a_stale_override_is_caught(monkeypatch):
+    """AGENT_VOICE_MODULATION is a documented override precisely because its
+    declared value disagrees with its stream-tier default. If the declared
+    value is changed to match the default, the override is now
+    unjustified -- the check must say so rather than silently accept it."""
+    mutated = dict(checker.TOPIC_DELIVERY)
+    mutated[Topics.AGENT_VOICE_MODULATION] = checker.derive_default(
+        Topics.AGENT_VOICE_MODULATION.value
+    )
+    monkeypatch.setattr(checker, "TOPIC_DELIVERY", mutated)
+    assert checker.main() == 1

--- a/backend/tests/test_errors_taxonomy.py
+++ b/backend/tests/test_errors_taxonomy.py
@@ -1,0 +1,88 @@
+"""AgentError taxonomy (Phase 1D, §15 item 12). Covers the new base/leaf
+classes in errors.py and the regression guard that every pre-existing
+bespoke exception still satisfies its OLD `except <Base>` call sites after
+gaining AgentError as an additional base."""
+
+import pytest
+
+from app.errors import (
+    AgentError,
+    PerceptionError,
+    PolicyError,
+    RealizationError,
+    RetrievalError,
+    StateConflictError,
+    TransportError,
+)
+
+_LEAVES = [
+    PerceptionError,
+    RetrievalError,
+    StateConflictError,
+    PolicyError,
+    RealizationError,
+    TransportError,
+]
+
+
+@pytest.mark.parametrize("leaf", _LEAVES)
+def test_every_leaf_is_an_agent_error(leaf):
+    assert issubclass(leaf, AgentError)
+
+
+@pytest.mark.parametrize("leaf", _LEAVES)
+def test_a_leaf_instance_is_catchable_as_agent_error(leaf):
+    with pytest.raises(AgentError):
+        raise leaf("boom")
+
+
+def test_agent_error_itself_is_a_plain_exception():
+    """A caller with only `except Exception` (no taxonomy awareness) must
+    keep working unchanged."""
+    assert issubclass(AgentError, Exception)
+
+
+# --------------------------------------------------------------------------
+# Existing bespoke exceptions: gained AgentError, must not lose their old base
+# --------------------------------------------------------------------------
+
+
+def test_metacognitive_exception_is_now_also_an_agent_error():
+    from app.cognitive.action import MetacognitiveException
+
+    exc = MetacognitiveException("leaked scaffolding")
+    assert isinstance(exc, AgentError)
+    assert isinstance(exc, Exception)
+    assert exc.reason == "leaked scaffolding"
+
+
+def test_stream_reconciliation_error_keeps_its_runtime_error_base():
+    """A pre-1D `except RuntimeError` call site around stream reconciliation
+    must keep catching this -- losing RuntimeError as a base would silently
+    stop it."""
+    from app.nats_streams import StreamReconciliationError
+
+    assert issubclass(StreamReconciliationError, RuntimeError)
+    assert issubclass(StreamReconciliationError, AgentError)
+    with pytest.raises(RuntimeError):
+        raise StreamReconciliationError("no convergence")
+    with pytest.raises(AgentError):
+        raise StreamReconciliationError("no convergence")
+
+
+def test_jetstream_publish_failed_keeps_its_runtime_error_base():
+    from app.agents.base import JetStreamPublishFailed
+
+    assert issubclass(JetStreamPublishFailed, RuntimeError)
+    assert issubclass(JetStreamPublishFailed, AgentError)
+    with pytest.raises(RuntimeError):
+        raise JetStreamPublishFailed("publish failed")
+
+
+def test_persona_compilation_error_is_now_also_an_agent_error():
+    from app.persona.compiler import PersonaCompilationError
+
+    assert issubclass(PersonaCompilationError, AgentError)
+    assert issubclass(PersonaCompilationError, Exception)
+    with pytest.raises(AgentError):
+        raise PersonaCompilationError("could not compile")

--- a/backend/tests/test_evidence_contract.py
+++ b/backend/tests/test_evidence_contract.py
@@ -1,0 +1,65 @@
+"""Evidence (Phase 1A, §15 item 1): a typed unit of grounding with modality,
+confidence, and provenance -- the thing last_visual_context as a plain
+string can't carry."""
+
+import time
+
+from app.cognitive.evidence import Evidence
+from app.contracts import SurfacedMemory
+
+
+def test_two_evidence_instances_get_distinct_ids():
+    """The default_factory must actually be called per-instance -- a bug
+    here (e.g. a bare default instead of default_factory) would silently
+    give every Evidence the same evidence_id."""
+    a = Evidence(content="x", source="vision_agent", modality="vision")
+    b = Evidence(content="x", source="vision_agent", modality="vision")
+    assert a.evidence_id != b.evidence_id
+
+
+def test_no_expiry_means_never_expired():
+    e = Evidence(content="x", source="s", modality="text", expiry=None)
+    assert e.is_expired() is False
+    assert e.is_expired(now=time.time() + 10_000) is False
+
+
+def test_expiry_in_the_past_is_expired():
+    e = Evidence(content="x", source="s", modality="vision", expiry=time.time() - 1)
+    assert e.is_expired() is True
+
+
+def test_expiry_in_the_future_is_not_yet_expired():
+    e = Evidence(content="x", source="s", modality="vision", expiry=time.time() + 100)
+    assert e.is_expired() is False
+
+
+def test_from_surfaced_memory_carries_content_and_score():
+    mem = SurfacedMemory(
+        content="the user's birthday is in March",
+        raw_content="the user's birthday is in March",
+        score=0.87,
+    )
+    evidence = Evidence.from_surfaced_memory(mem)
+    assert evidence.content == "the user's birthday is in March"
+    assert evidence.modality == "memory"
+    assert evidence.confidence == 0.87
+    assert evidence.provenance == "memory_store"
+
+
+def test_from_surfaced_memory_clamps_out_of_range_score():
+    """score isn't documented as bounded to [0,1] on SurfacedMemory itself --
+    a caller could hand Evidence a raw ranking value larger than 1.0 (or
+    negative). confidence must stay a valid probability regardless."""
+    mem = SurfacedMemory(content="x", raw_content="x", score=5.0)
+    assert Evidence.from_surfaced_memory(mem).confidence == 1.0
+
+    mem_negative = SurfacedMemory(content="x", raw_content="x", score=-2.0)
+    assert Evidence.from_surfaced_memory(mem_negative).confidence == 0.0
+
+
+def test_from_surfaced_memory_survives_missing_created_at():
+    """created_at is Optional on SurfacedMemory; a None must not raise
+    inside the timestamp parse."""
+    mem = SurfacedMemory(content="x", raw_content="x", created_at=None)
+    evidence = Evidence.from_surfaced_memory(mem)
+    assert evidence.timestamp > 0

--- a/backend/tests/test_persona_policy.py
+++ b/backend/tests/test_persona_policy.py
@@ -1,0 +1,70 @@
+"""PersonaPolicy.precheck (Phase 1B, §15 item 5) -- the proactive check on a
+BehaviorDecision before generation, sitting next to (not replacing)
+IdentityManager.validate_response's reactive regex check."""
+
+from app.cognitive.behavior_contracts import BehaviorDecision, CommunicativeIntent
+from app.persona.policy import PersonaPolicy
+
+_DEFAULT_CORE = {
+    "values": ["Honesty", "Privacy"],
+    "boundaries": [
+        "Will never share user data",
+        "Will not adopt toxic behavior",
+    ],
+}
+
+
+def test_precheck_populates_forbidden_claims_from_boundaries():
+    decision = BehaviorDecision(
+        intent=CommunicativeIntent(act="CHAT", goal="ENGAGE")
+    )
+    result = PersonaPolicy.precheck(decision, _DEFAULT_CORE)
+    assert result.forbidden_claims == _DEFAULT_CORE["boundaries"]
+
+
+def test_precheck_does_not_clamp_stance_under_default_boundaries():
+    """Today's default IMMUTABLE_CORE (privacy, non-toxicity) says nothing
+    about relational closeness -- "close" must pass through unclamped."""
+    decision = BehaviorDecision(
+        intent=CommunicativeIntent(act="CHAT", goal="ENGAGE", relational_stance="close")
+    )
+    result = PersonaPolicy.precheck(decision, _DEFAULT_CORE)
+    assert result.intent.relational_stance == "close"
+
+
+def test_precheck_clamps_stance_when_a_boundary_restricts_it():
+    core = {
+        "values": ["Honesty"],
+        "boundaries": ["Will not engage in romantic or sexual roleplay"],
+    }
+    decision = BehaviorDecision(
+        intent=CommunicativeIntent(act="CHAT", goal="ENGAGE", relational_stance="close")
+    )
+    result = PersonaPolicy.precheck(decision, core)
+    assert result.intent.relational_stance == "warm"
+
+
+def test_precheck_leaves_an_already_capped_stance_alone():
+    core = {
+        "values": [],
+        "boundaries": ["Will not engage in romantic or sexual roleplay"],
+    }
+    decision = BehaviorDecision(
+        intent=CommunicativeIntent(
+            act="CHAT", goal="ENGAGE", relational_stance="guarded"
+        )
+    )
+    result = PersonaPolicy.precheck(decision, core)
+    assert result.intent.relational_stance == "guarded"
+
+
+def test_precheck_does_not_mutate_the_input_decision():
+    """A caller holding a reference to the pre-precheck decision (e.g. for
+    logging) must not see it change underfoot."""
+    decision = BehaviorDecision(
+        intent=CommunicativeIntent(act="CHAT", goal="ENGAGE", relational_stance="close")
+    )
+    core = {"boundaries": ["Will not engage in romantic or sexual roleplay"]}
+    PersonaPolicy.precheck(decision, core)
+    assert decision.intent.relational_stance == "close"
+    assert decision.forbidden_claims == []

--- a/backend/tests/test_pipeline.py
+++ b/backend/tests/test_pipeline.py
@@ -144,6 +144,62 @@ async def test_pipeline_carries_visual_context_into_the_plan_payload(
 
 
 @pytest.mark.asyncio
+async def test_pipeline_carries_visual_evidence_into_the_plan_payload(
+    pipeline, mock_components
+):
+    """1A's typed sibling of visual_context must survive the same
+    perception -> decision -> action-prep handoff, or _build_visual_context
+    has no evidence to render epistemic framing from."""
+    from app.cognitive.evidence import Evidence
+
+    evidence = Evidence(content="a mug", source="camera", modality="vision")
+
+    mock_components["state"].last_speculative_intent = None
+    mock_components["perception"].perceive.return_value = MagicMock(
+        event_type="USER_MESSAGE",
+        raw_content="what am I holding?",
+        intent="CHAT",
+        event_id="evt-3",
+        metadata={
+            "visuals": "I am seeing the user's camera.",
+            "visual_evidence": evidence,
+        },
+    )
+    mock_components["appraisal"].appraise.return_value = AppraisalVector(
+        relevance=1.0,
+        novelty=0.5,
+        goal_congruence=0.2,
+        agency=0.8,
+        norm_alignment=1.0,
+        relationship_impact=0.1,
+    )
+    mock_components["state"].get_context_snapshot.return_value = {"mood": 0.0}
+    mock_components["state"].get_behavioral_directive.return_value = "be friendly"
+    mock_components["decision"].decide.return_value = ActionPlan(
+        action_type="RESPOND_CHAT", goal="ANSWER", payload={"message": "hi"}
+    )
+    mock_components["identity"].validate_response.return_value = (True, "")
+    mock_components["identity"].get_persona_prompt.return_value = "System prompt"
+
+    seen_payloads = []
+
+    async def mock_execute(plan):
+        seen_payloads.append(plan.payload)
+        yield {"type": "content", "data": "You're holding a mug."}
+        yield {"type": "done", "data": ""}
+
+    mock_components["action"].execute.side_effect = mock_execute
+
+    async for _ in pipeline.execute(
+        {"type": "USER_MESSAGE", "content": "what am I holding?"}
+    ):
+        pass
+
+    assert seen_payloads, "action.execute was never called"
+    assert seen_payloads[0]["visual_evidence"] is evidence
+
+
+@pytest.mark.asyncio
 async def test_pipeline_sources_appraisal_boundaries_from_immutable_core(
     pipeline, mock_components
 ):

--- a/backend/tests/test_pipeline.py
+++ b/backend/tests/test_pipeline.py
@@ -200,6 +200,111 @@ async def test_pipeline_carries_visual_evidence_into_the_plan_payload(
 
 
 @pytest.mark.asyncio
+async def test_stage_7_calls_persona_policy_precheck_exactly_once(
+    pipeline, mock_components
+):
+    """1B: PersonaPolicy.precheck must run exactly once per turn on a plan
+    carrying a behavior_decision -- a future duplicate call (e.g. one added
+    alongside a new stage) would silently double-apply the stance clamp."""
+    from unittest.mock import patch
+
+    from app.cognitive.behavior_contracts import BehaviorDecision, CommunicativeIntent
+    from app.persona.policy import PersonaPolicy
+
+    mock_components["state"].last_speculative_intent = None
+    mock_components["identity"].immutable_core = {"boundaries": []}
+    mock_components["perception"].perceive.return_value = MagicMock(
+        event_type="USER_MESSAGE",
+        raw_content="hello",
+        intent="CHAT",
+        event_id="evt-precheck",
+        metadata={},
+    )
+    mock_components["appraisal"].appraise.return_value = AppraisalVector(
+        relevance=1.0,
+        novelty=0.5,
+        goal_congruence=0.2,
+        agency=0.8,
+        norm_alignment=1.0,
+        relationship_impact=0.1,
+    )
+    mock_components["state"].get_context_snapshot.return_value = {"mood": 0.0}
+    mock_components["state"].get_behavioral_directive.return_value = "be friendly"
+    behavior_decision = BehaviorDecision(
+        intent=CommunicativeIntent(act="CHAT", goal="ENGAGE")
+    )
+    mock_components["decision"].decide.return_value = ActionPlan(
+        action_type="RESPOND_CHAT",
+        goal="ENGAGE",
+        payload={"message": "hi"},
+        behavior_decision=behavior_decision,
+    )
+    mock_components["identity"].validate_response.return_value = (True, "")
+    mock_components["identity"].get_persona_prompt.return_value = "System prompt"
+
+    async def mock_execute(plan):
+        yield {"type": "content", "data": "hi"}
+        yield {"type": "done", "data": ""}
+
+    mock_components["action"].execute.side_effect = mock_execute
+
+    with patch(
+        "app.cognitive.pipeline.PersonaPolicy.precheck",
+        wraps=PersonaPolicy.precheck,
+    ) as spy:
+        async for _ in pipeline.execute({"type": "USER_MESSAGE", "content": "hello"}):
+            pass
+
+    spy.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_stage_7_skips_precheck_when_no_behavior_decision(
+    pipeline, mock_components
+):
+    """A plan built outside decision.py's BT (or an older call site) has no
+    behavior_decision -- precheck must not be called, and must not raise
+    reaching into a None."""
+    from unittest.mock import patch
+
+    mock_components["state"].last_speculative_intent = None
+    mock_components["perception"].perceive.return_value = MagicMock(
+        event_type="USER_MESSAGE",
+        raw_content="hello",
+        intent="CHAT",
+        event_id="evt-no-precheck",
+        metadata={},
+    )
+    mock_components["appraisal"].appraise.return_value = AppraisalVector(
+        relevance=1.0,
+        novelty=0.5,
+        goal_congruence=0.2,
+        agency=0.8,
+        norm_alignment=1.0,
+        relationship_impact=0.1,
+    )
+    mock_components["state"].get_context_snapshot.return_value = {"mood": 0.0}
+    mock_components["state"].get_behavioral_directive.return_value = "be friendly"
+    mock_components["decision"].decide.return_value = ActionPlan(
+        action_type="RESPOND_CHAT", goal="ENGAGE", payload={"message": "hi"}
+    )
+    mock_components["identity"].validate_response.return_value = (True, "")
+    mock_components["identity"].get_persona_prompt.return_value = "System prompt"
+
+    async def mock_execute(plan):
+        yield {"type": "content", "data": "hi"}
+        yield {"type": "done", "data": ""}
+
+    mock_components["action"].execute.side_effect = mock_execute
+
+    with patch("app.cognitive.pipeline.PersonaPolicy.precheck") as spy:
+        async for _ in pipeline.execute({"type": "USER_MESSAGE", "content": "hello"}):
+            pass
+
+    spy.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_pipeline_sources_appraisal_boundaries_from_immutable_core(
     pipeline, mock_components
 ):

--- a/backend/tests/test_somatic_vision.py
+++ b/backend/tests/test_somatic_vision.py
@@ -375,6 +375,44 @@ def test_somatic_failure_does_not_lose_the_visual_context():
     assert "chai" in agent.last_visual_context
 
 
+def test_novel_observation_gets_full_confidence_evidence():
+    agent = _brain_stub([{"name": "chai", "confidence": 1.0}])
+
+    asyncio.run(
+        agent._on_vision_description(
+            {
+                "description": "A cup of chai.",
+                "source": "camera",
+                "is_novel": True,
+            }
+        )
+    )
+
+    assert agent.last_visual_evidence.modality == "vision"
+    assert agent.last_visual_evidence.confidence == 1.0
+    assert agent.last_visual_evidence.source == "camera"
+
+
+def test_cached_repeat_gets_lower_confidence_evidence():
+    """is_novel=False (a repeat frame under habituation) must not be
+    reported with the same confidence as a fresh observation -- that's
+    exactly the distinction _build_visual_context's recency framing
+    depends on."""
+    agent = _brain_stub([{"name": "chai", "confidence": 1.0}])
+
+    asyncio.run(
+        agent._on_vision_description(
+            {
+                "description": "A cup of chai.",
+                "source": "camera",
+                "is_novel": False,
+            }
+        )
+    )
+
+    assert agent.last_visual_evidence.confidence < 1.0
+
+
 # --------------------------------------------------------------------------
 # capture capability probe
 # --------------------------------------------------------------------------

--- a/backend/tests/test_typed_realization_parsing.py
+++ b/backend/tests/test_typed_realization_parsing.py
@@ -1,0 +1,132 @@
+import pytest
+
+from app.cognitive.action import (
+    ActionService,
+    ControlMarkupSanitizer,
+    _ChatStreamState,
+    _parse_typed_realization,
+)
+from app.cognitive.decision import ActionPlan
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (
+            (
+                '{"spoken_text":"hello","realization_confidence":0.8,'
+                '"unanswered_questions":[],"claim_ids_used":[]}'
+            ),
+            "hello",
+        ),
+        ("not json", None),
+        ('{"spoken_text":"","realization_confidence":0.8}', None),
+        ('{"spoken_text":"hello","realization_confidence":2}', None),
+        ('{"spoken_text":"hello","realization_confidence":true}', None),
+        ('{"spoken_text":"hello","realization_confidence":0.8,"claim_ids_used":"x"}', None),
+    ],
+)
+def test_typed_realization_parser_fails_closed(raw, expected):
+    parsed = _parse_typed_realization(raw)
+    assert parsed is None if expected is None else parsed["spoken_text"] == expected
+
+
+class _StreamingLLM:
+    def __init__(self, chunks):
+        self.chunks = chunks
+        self.system_instruction = None
+
+    async def generate_stream(self, **kwargs):
+        self.system_instruction = kwargs.get("system")
+        for chunk in self.chunks:
+            yield chunk
+
+
+async def _stream(service, plan, monkeypatch, enabled):
+    import app.config as config_module
+
+    monkeypatch.setattr(
+        config_module.config_instance, "LLM_TYPED_REALIZATION_ENABLED", enabled
+    )
+    return [
+        item
+        async for item in service._stream_primary_response(
+            plan=plan,
+            user_prompt="hello",
+            system_instruction="system",
+            model=None,
+            endocrine_options={},
+            sanitizer=ControlMarkupSanitizer(),
+            stream_budget=15,
+            state=_ChatStreamState(),
+            surfaced=[],
+            msg="hello",
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_typed_realization_stream_emits_only_spoken_text(monkeypatch):
+    service = ActionService(
+        llm_service=_StreamingLLM(
+            [
+                '{"spoken_text":"bounded ',
+                'reply","realization_confidence":0.9,"unanswered_questions":[],',
+                '"claim_ids_used":[]}',
+            ]
+        )
+    )
+    plan = ActionPlan(action_type="RESPOND_CHAT", payload={}, goal="ENGAGE")
+
+    outputs = await _stream(service, plan, monkeypatch, enabled=True)
+
+    assert [item["data"] for item in outputs if item["type"] == "content"] == [
+        "bounded reply"
+    ]
+    assert outputs[-1] == {"type": "done", "data": "finished"}
+
+
+@pytest.mark.asyncio
+async def test_invalid_typed_realization_falls_back_to_raw_text(monkeypatch):
+    service = ActionService(_StreamingLLM(["not a JSON envelope"]))
+    plan = ActionPlan(action_type="RESPOND_CHAT", payload={}, goal="ENGAGE")
+
+    outputs = await _stream(service, plan, monkeypatch, enabled=True)
+
+    assert [item["data"] for item in outputs if item["type"] == "content"] == [
+        "not a JSON envelope"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_typed_realization_is_opt_in_and_legacy_streaming_is_preserved(monkeypatch):
+    service = ActionService(_StreamingLLM(["hello", " world"]))
+    plan = ActionPlan(action_type="RESPOND_CHAT", payload={}, goal="ENGAGE")
+
+    outputs = await _stream(service, plan, monkeypatch, enabled=False)
+
+    assert [item["data"] for item in outputs if item["type"] == "content"] == [
+        "hello",
+        " world",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_typed_realization_guidance_is_appended_only_when_enabled(monkeypatch):
+    import app.config as config_module
+
+    service = ActionService(_StreamingLLM(["hello"]))
+    plan = ActionPlan(
+        action_type="RESPOND_CHAT",
+        payload={"message": "hello"},
+        goal="ENGAGE",
+    )
+
+    monkeypatch.setattr(
+        config_module.config_instance, "LLM_TYPED_REALIZATION_ENABLED", True
+    )
+    outputs = [item async for item in service._execute_respond_chat(plan)]
+
+    assert "spoken_text" in service.llm.system_instruction
+    assert "claim_ids_used" in service.llm.system_instruction
+    assert outputs[-1] == {"type": "done", "data": "finished"}


### PR DESCRIPTION
## Summary
Phase 1 of the sequenced implementation plan (contract separation, §16 Phase 1): typed in-process contracts that make the decision layer's output explicit instead of implicit in prompt-assembly strings, plus supporting infrastructure. Built jointly with Codex per the split logged in `personal/HANDOFF.md` (gitignored, not in this diff) — 1A/1B/1D/1E from this branch, 1C merged in from `codex/phase1c`.

- **1A** — `Evidence` contract: typed sibling of `brain_agent.last_visual_context` (modality/confidence/provenance/timestamp), rendered as recency framing ("novel observation" vs "previously seen") in `action.py`.
- **1B** — `CommunicativeIntent`/`BehaviorDecision`: what a turn is trying to do (goal, urgency, relational stance, interruption policy), attached to every `ActionPlan`. `PersonaPolicy.precheck` runs in pipeline stage 7 as a proactive backstop alongside (not replacing) `IdentityManager.validate_response`'s reactive check.
- **1C** (Codex) — opt-in typed realization envelope (`Config.LLM_TYPED_REALIZATION_ENABLED`, off by default) with deterministic fallback on parse failure.
- **1D** — `AgentError` failure taxonomy; four pre-existing bespoke exceptions gained it as an additional base via multiple inheritance, keeping their original bases intact.
- **1E** — `TOPIC_DELIVERY` explicit durable-vs-best-effort metadata per NATS subject, plus a CI diagnostic (`check_delivery_semantics.py`) that derives the expected value from `nats_streams.py`'s real stream tiers and fails on drift.

All additive: existing callers/tests were not changed in shape, only extended (defaulted fields, optional parameters, new files).

## Test plan
- [x] Full backend suite: 1755/1755 passing
- [x] `ruff check .`: clean
- [x] New tests for each sub-phase, each mutation-tested (the specific logic broken and confirmed to fail, then reverted)
- [x] Clean automatic merge of 1C onto 1A/1B/1D/1E (only real file overlap was `action.py`, resolved by git with no manual intervention needed)
- [ ] Home-gpu verification (typed-realization A/B against `phi4-mini`, latency check) — not run yet, per the plan's Mac-tonight/home-gpu-tomorrow split

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional structured response generation, with automatic fallback to standard text when structured output is invalid.
  * Improved visual-awareness context by indicating whether observations are new, repeated, recent, or stale.
  * Added richer conversational behavior controls, including goals, urgency, relational tone, and claim boundaries.
  * Added proactive safeguards to keep responses aligned with persona boundaries.
  * Classified message delivery behavior for improved reliability across audio and live updates.

* **Bug Fixes**
  * Standardized agent error handling while preserving existing exception behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->